### PR TITLE
add createObtainable for decoupled lifecycle management

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Gro changelog
 
+## 0.1.2
+
+- add `utils/createObtainable.ts` for decoupled lifecycle management
+
 ## 0.1.1
 
 - add `fs/watchNodeFs.ts` for low level filesystem watching

--- a/src/utils/createObtainable.test.ts
+++ b/src/utils/createObtainable.test.ts
@@ -3,7 +3,7 @@ import {test, t} from '../oki/oki.js';
 import {createObtainable} from './createObtainable.js';
 
 test('createObtainable()', () => {
-	test('release out of order', () => {
+	test('release out of order', async () => {
 		let thing: Symbol | undefined;
 		let isReleased = false;
 		const obtainThing = createObtainable(
@@ -31,14 +31,18 @@ test('createObtainable()', () => {
 		t.is(thing3, thing);
 		t.ok(!isReleased);
 
-		release2();
+		const releasePromise2 = release2();
 		t.ok(!isReleased);
+		t.ok(releasePromise2 instanceof Promise);
 
-		release3();
+		const releasePromise3 = release3();
 		t.ok(!isReleased);
+		t.is(releasePromise3, releasePromise2);
 
-		release1();
+		const releasePromise1 = release1();
 		t.ok(isReleased);
+		t.is(releasePromise1, releasePromise2);
+		await releasePromise1; // this will hang if never resolved
 
 		const originalThing = thing;
 		thing = undefined;
@@ -48,8 +52,11 @@ test('createObtainable()', () => {
 		t.is(thing4, thing);
 		t.isNot(thing4, originalThing);
 		t.ok(!isReleased);
-		release4();
+		const releasePromise4 = release4();
 		t.ok(isReleased);
+		t.ok(releasePromise4 instanceof Promise);
+		t.isNot(releasePromise4, releasePromise1);
+		await releasePromise4; // this will hang if never resolved
 	});
 
 	// This is a complicated corner case that probably should not happen

--- a/src/utils/createObtainable.test.ts
+++ b/src/utils/createObtainable.test.ts
@@ -40,11 +40,11 @@ test('createObtainable()', () => {
 		release3();
 		release3();
 		t.ok(!isReleased);
-		t.is(releasePromise3, releasePromise2);
+		t.ok(releasePromise3 instanceof Promise);
 
 		const releasePromise1 = release1();
 		t.ok(isReleased);
-		t.is(releasePromise1, releasePromise2);
+		t.ok(releasePromise1 instanceof Promise);
 		await releasePromise1; // this will hang if never resolved
 
 		const originalThing = thing;

--- a/src/utils/createObtainable.test.ts
+++ b/src/utils/createObtainable.test.ts
@@ -1,0 +1,107 @@
+import {test, t} from '../oki/oki.js';
+
+import {createObtainable} from './createObtainable.js';
+
+test('createObtainable()', () => {
+	test('release out of order', () => {
+		let thing: Symbol | undefined;
+		let isReleased = false;
+		const obtainThing = createObtainable(
+			() => {
+				t.is(thing, undefined);
+				thing = Symbol();
+				return thing;
+			},
+			thingReleased => {
+				isReleased = true;
+				t.is(thingReleased, thing);
+			},
+		);
+
+		const [thing1, release1] = obtainThing();
+		t.is(thing1, thing);
+		t.ok(!isReleased);
+
+		const [thing2, release2] = obtainThing();
+		t.is(thing2, thing);
+		t.ok(!isReleased);
+		t.is(release1, release2); // release function refs should be the same
+
+		const [thing3, release3] = obtainThing();
+		t.is(thing3, thing);
+		t.ok(!isReleased);
+
+		release2();
+		t.ok(!isReleased);
+
+		release3();
+		t.ok(!isReleased);
+
+		release1();
+		t.ok(isReleased);
+
+		const originalThing = thing;
+		thing = undefined;
+		isReleased = false;
+		const [thing4, release4] = obtainThing();
+		t.isNot(thing4, originalThing);
+		t.ok(!isReleased);
+		release4();
+		t.ok(isReleased);
+	});
+
+	// This is a complicated corner case that probably should not happen
+	// because it would normally cause a stack overflow in user code,
+	// but we're covering it just in case.
+	test('obtain is called during release', () => {
+		let shouldObtainDuringRelease = true;
+		let thing: Symbol | undefined;
+		let isReleased = false;
+		const obtainThing = createObtainable(
+			() => {
+				t.is(thing, undefined);
+				isReleased = false;
+				thing = Symbol();
+				return thing;
+			},
+			thingReleased => {
+				isReleased = true;
+				t.is(thingReleased, thing);
+				thing = undefined;
+
+				if (!shouldObtainDuringRelease) return; // prevent stack overflow
+				shouldObtainDuringRelease = false;
+				const [thing3, release3] = obtainThing();
+				t.ok(thing3);
+				t.is(thing3, thing);
+				t.isNot(thing3, thingReleased);
+				t.ok(!isReleased);
+				release3();
+				t.ok(isReleased);
+				t.is(thing, undefined);
+			},
+		);
+
+		const [thing1, release1] = obtainThing();
+		t.is(thing1, thing);
+		t.ok(!isReleased);
+
+		const [thing2, release2] = obtainThing();
+		t.is(thing2, thing);
+		t.ok(!isReleased);
+
+		release2();
+		t.ok(!isReleased);
+
+		release1();
+		t.ok(isReleased);
+	});
+
+	test('cannot obtain undefined', () => {
+		const obtainThing = createObtainable(
+			() => undefined,
+			() => {},
+		);
+		t.throws(() => obtainThing());
+	});
+});

--- a/src/utils/createObtainable.test.ts
+++ b/src/utils/createObtainable.test.ts
@@ -25,7 +25,7 @@ test('createObtainable()', () => {
 		const [thing2, release2] = obtainThing();
 		t.is(thing2, thing);
 		t.ok(!isReleased);
-		t.is(release1, release2); // release function refs should be the same
+		t.isNot(release1, release2); // release function refs should not be the same
 
 		const [thing3, release3] = obtainThing();
 		t.is(thing3, thing);
@@ -36,6 +36,9 @@ test('createObtainable()', () => {
 		t.ok(releasePromise2 instanceof Promise);
 
 		const releasePromise3 = release3();
+		release3(); // call release additional times to make sure it's idempotent
+		release3();
+		release3();
 		t.ok(!isReleased);
 		t.is(releasePromise3, releasePromise2);
 

--- a/src/utils/createObtainable.test.ts
+++ b/src/utils/createObtainable.test.ts
@@ -44,6 +44,8 @@ test('createObtainable()', () => {
 		thing = undefined;
 		isReleased = false;
 		const [thing4, release4] = obtainThing();
+		t.ok(thing4);
+		t.is(thing4, thing);
 		t.isNot(thing4, originalThing);
 		t.ok(!isReleased);
 		release4();

--- a/src/utils/createObtainable.ts
+++ b/src/utils/createObtainable.ts
@@ -13,19 +13,19 @@ See the tests for usage examples - ./createObtainable.test.ts
 */
 export const createObtainable = <T>(
 	createObtainableValue: () => T,
-	teardownObtainableValue?: (obtainable: T) => void,
+	teardownObtainableValue?: (obtainable: T) => unknown,
 ): (() => [T, () => Promise<void>]) => {
 	let obtainable: T | undefined;
 	const obtainedRefs = new Set<symbol>();
 	let resolve: () => void;
 	let promise: Promise<void>;
-	const releaseObtainable = (obtainedRef: symbol): Promise<void> => {
+	const releaseObtainable = async (obtainedRef: symbol): Promise<void> => {
 		if (!obtainedRefs.has(obtainedRef)) return promise; // makes releasing idempotent per obtainer
 		obtainedRefs.delete(obtainedRef);
 		if (obtainedRefs.size > 0) return promise; // there are other open obtainers
 		const finalValue = obtainable;
 		obtainable = undefined; // reset before releasing just in case release re-obtains
-		if (teardownObtainableValue) teardownObtainableValue(finalValue!);
+		if (teardownObtainableValue) await teardownObtainableValue(finalValue!);
 		resolve();
 		return promise;
 	};

--- a/src/utils/createObtainable.ts
+++ b/src/utils/createObtainable.ts
@@ -11,9 +11,6 @@ The motivating use case was reusing a database connection across multiple tasks.
 
 See the tests for usage examples - ./createObtainable.test.ts
 
-A future improvement could have `release` always return a promise
-that resolves when the obtainable is fully released.
-
 */
 export const createObtainable = <T>(
 	obtain: () => T,

--- a/src/utils/createObtainable.ts
+++ b/src/utils/createObtainable.ts
@@ -11,6 +11,9 @@ The motivating use case was reusing a database connection across multiple tasks.
 
 See the tests for usage examples - ./createObtainable.test.ts
 
+A future improvement could have `release` always return a promise
+that resolves when the obtainable is fully released.
+
 */
 export const createObtainable = <T>(
 	obtain: () => T,

--- a/src/utils/createObtainable.ts
+++ b/src/utils/createObtainable.ts
@@ -20,7 +20,7 @@ export const createObtainable = <T>(
 	let resolve: () => void;
 	let promise: Promise<void>;
 	const releaseObtainable = (obtainedRef: symbol): Promise<void> => {
-		if (!obtainedRefs.has(obtainedRef)) return promise; // makes releasing idempotent per obtained call
+		if (!obtainedRefs.has(obtainedRef)) return promise; // makes releasing idempotent per obtainer
 		obtainedRefs.delete(obtainedRef);
 		if (obtainedRefs.size > 0) return promise; // there are other open obtainers
 		const releasedResource = obtainable;

--- a/src/utils/createObtainable.ts
+++ b/src/utils/createObtainable.ts
@@ -1,0 +1,40 @@
+/*
+
+This is a higher order function that
+counts the number of obtained references to a thing
+and calls `release` when the count drops to zero.
+
+It allows decoupled consumers to use things with a lifecycle
+without disrupting each other when they're done with the thing.
+
+The motivating use case was reusing a database connection across multiple tasks.
+
+See the tests for usage examples - ./createObtainable.test.ts
+
+*/
+export const createObtainable = <T>(
+	obtain: () => T,
+	release: (obtainable: T) => void,
+): (() => [T, () => void]) => {
+	let count = 0;
+	let obtainable: T | undefined;
+	const releaseObtainable = () => {
+		count--;
+		if (count > 0) return;
+		const releasedResource = obtainable;
+		obtainable = undefined; // reset before releasing just in case release re-obtains
+		release(releasedResource!);
+	};
+	return () => {
+		count++;
+		if (obtainable === undefined) {
+			obtainable = obtain();
+			if (obtainable === undefined) {
+				// this prevents `obtain` from being called multiple times,
+				// which would cause bugs if it has side effects
+				throw Error('Obtainable value cannot be undefined - use null instead.');
+			}
+		}
+		return [obtainable, releaseObtainable];
+	};
+};

--- a/src/utils/createObtainable.ts
+++ b/src/utils/createObtainable.ts
@@ -23,9 +23,9 @@ export const createObtainable = <T>(
 		if (!obtainedRefs.has(obtainedRef)) return promise; // makes releasing idempotent per obtainer
 		obtainedRefs.delete(obtainedRef);
 		if (obtainedRefs.size > 0) return promise; // there are other open obtainers
-		const releasedResource = obtainable;
+		const finalValue = obtainable;
 		obtainable = undefined; // reset before releasing just in case release re-obtains
-		if (teardownObtainableValue) teardownObtainableValue(releasedResource!);
+		if (teardownObtainableValue) teardownObtainableValue(finalValue!);
 		resolve();
 		return promise;
 	};


### PR DESCRIPTION
This adds a utility function that was needed for Felt's database tasks. ([this impermanent link works for now to see its usage](https://github.com/feltcoop/felt/commit/202f8494d539cb528c84e5a31e16332e46f30a86#diff-ebc46f16dd98026100a75a4423088092R8)) The use case was the `db/create` task which composed `db/destroy`, `db/migrate`, and `db/seed`. Each of those tasks needs to separately obtain a database connection and tear it down when finished. However we only want to tear down the connection once, not between each sub-task.

As a higher order function, its type is fairly complex, but it's nicely reusable and well tested. 

~~A future improvement could have the `release` function always return a promise that's called when the obtained thing is fully released. I didn't need it now, so I kept things simple.~~ I decided that the semantics of this thing really do want `release` to always return a promise, even though we don't have an immediate use case for the the functionality. It wasn't hard to add and test.