### PR TITLE
ensure the project has been built when invoking tasks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.1.4
+
+- ensure the project has been built when invoking tasks
+  ([#5](https://github.com/feltcoop/gro/pull/5))
+
 ## 0.1.3
 
 - upgrade TypeScript minor version


### PR DESCRIPTION
This change allows any projects using Gro to bootstrap without first building TypeScript. This simplifies CI and first-time setup. CI for Felt can be simplified from `npm run build`, which does `tsc && gro build`, to simply `gro build` without any additional changes.