### PR TITLE
clean up tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "include": ["src/**/*"],
-  "exclude": [],
+  // Commented-out options have their default values.
+  "include": ["src"],
+  // "exclude": [],
   // "files": [], // A list of relative or absolute file paths to include.
   // "extends": "", // A string containing a path to another configuration file to inherit from.
   // "references": [], // An array of objects `{"path": "./to/dirOrConfig"}` that specifies projects to reference.
@@ -8,15 +9,27 @@
 
   "compilerOptions": {
     // Main options
-    "target": "esnext", // Specify ECMAScript target version: 'es3' (default), 'es5', 'es2015', 'es2016', 'es2017','es2018' or 'esnext'.
+    "target": "es2018", // Specify ECMAScript target version: 'es3' (default), 'es5', 'es2015', 'es2016', 'es2017','es2018' or 'esnext'.
     "module": "esnext", // Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'.
     "lib": ["esnext", "dom"], // Specify library files to be included in the compilation.
     // "allowJs": false, // Allow javascript files to be compiled.
     // "checkJs": false, // Report errors in .js files.
     // "outFile": "./", // Concatenate and emit output to single file.
-    "outDir": "./build/", // Redirect output structure to the directory.
-    "rootDir": "./src/", // Specify the root directory of input files. Use to control the output directory structure with `--outDir`.
+    "outDir": "build", // Redirect output structure to the directory.
+    "rootDir": "src", // Specify the root directory of input files. Use to control the output directory structure with `--outDir`.
     // "project": "", // Compile a project given a valid configuration file.
+
+    // Compilation options
+    // "composite": true, // Enable project compilation: https://www.typescriptlang.org/docs/handbook/project-references.html
+    // "diagnostics": false, // Show diagnostic information.
+    // "incremental": true, // Enable incremental compilation by reading/writing information from prior compilations to a file on disk.
+    // "isolatedModules": false, // Transpile each file as a separate module (similar to 'ts.transpileModule').
+    // "listEmittedFiles": false, // Print names of generated files part of the compilation.
+    // "listFiles": true, // Print names of files part of the compilation.
+    // "noErrorTruncation": false, // Do not truncate error messages.
+    // "preserveWatchOutput": false, // Keep outdated console output in watch mode instead of clearing the screen.
+    // "traceResolution": false, // Enable tracing of the name resolution process.
+    // "tsBuildInfoFile": ".tsbuildinfo", // Specify file to store incremental compilation information.
 
     // Strict typechecking options
     "strict": true, // Enable all strict type-checking options.
@@ -47,7 +60,7 @@
     // "paths": {}, // A series of entries which re-map imports to lookup locations relative to the 'baseUrl'.
     // "rootDirs": [], // List of root folders whose combined content represents the structure of the project at runtime.
     // "typeRoots": [], // List of folders to include type definitions from.
-    "types": ["node", "svelte"], // Type declaration files to be included in compilation.
+    // "types": [], // Type declaration files to be included in compilation.
     "allowSyntheticDefaultImports": true, // Allow default imports from modules with no default export. This does not affect code emit, just typechecking.
     // "esModuleInterop": false, // Emit '__importStar' and '__importDefault' helpers for runtime babel ecosystem compatibility and enable '--allowSyntheticDefaultImports' for typesystem compatibility.
     // "maxNodeModuleJsDepth": 0, // The maximum dependency depth to search under node_modules and load JavaScript files. Only applicable with --allowJs.
@@ -76,18 +89,6 @@
     // "mapRoot": "", // Specify the location where debugger should locate map files instead of generated locations.
     // "inlineSourceMap": true, // Emit a single file with source maps instead of having a separate file.
     // "inlineSources": true, // Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set.
-
-    // Compilation options
-    // "composite": true, // Enable project compilation: https://www.typescriptlang.org/docs/handbook/project-references.html
-    // "diagnostics": false, // Show diagnostic information.
-    // "incremental": true, // Enable incremental compilation by reading/writing information from prior compilations to a file on disk.
-    // "isolatedModules": false, // Transpile each file as a separate module (similar to 'ts.transpileModule').
-    // "listEmittedFiles": false, // Print names of generated files part of the compilation.
-    // "listFiles": true, // Print names of files part of the compilation.
-    // "noErrorTruncation": false, // Do not truncate error messages.
-    // "preserveWatchOutput": false, // Keep outdated console output in watch mode instead of clearing the screen.
-    // "traceResolution": false, // Enable tracing of the name resolution process.
-    // "tsBuildInfoFile": ".tsbuildinfo", // Specify file to store incremental compilation information.
 
     // JSX options
     // "jsx": "preserve", // Specify JSX code generation: 'preserve', 'react-native', or 'react'.


### PR DESCRIPTION
This cleans up some of the TypeScript config and makes it match Felt's. Behavior should be the same except it's now down-compiled to ES2018.