### PR TITLE
make the clean task remove directories instead of emptying them

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ gro format --check # checks that all source files are formatted
 ```
 
 ```bash
+gro clean # deletes all build artifacts from the filesystem
+```
+
+```bash
 gro serve # staticly serves the current directory (or a configured one)
 ```
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Gro changelog
 
+## unreleased
+
+- change `gro clean` to delete directories instead of emptying them
+
 ## 0.1.5
 
 - add `gro format` and `gro format --check` and format generated code

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Gro changelog
 
-## unreleased
+## 0.1.6
 
 - change `gro clean` to delete directories instead of emptying them
 

--- a/src/project/clean.ts
+++ b/src/project/clean.ts
@@ -1,4 +1,4 @@
-import {pathExists, emptyDir} from '../fs/nodeFs.js';
+import {pathExists, remove} from '../fs/nodeFs.js';
 import {paths} from '../paths.js';
 import {SystemLogger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
@@ -11,14 +11,14 @@ export const clean = async (log: SystemLogger) => {
 // Checking `pathExists` avoids creating the directory if it doesn't exist.
 export const cleanBuild = async (log: SystemLogger) => {
 	if (await pathExists(paths.build)) {
-		log.info('emptying', printPath(paths.build));
-		await emptyDir(paths.build);
+		log.info('removing', printPath(paths.build));
+		await remove(paths.build);
 	}
 };
 
 export const cleanDist = async (log: SystemLogger) => {
 	if (await pathExists(paths.dist)) {
-		log.info('emptying', printPath(paths.dist));
-		await emptyDir(paths.dist);
+		log.info('removing', printPath(paths.dist));
+		await remove(paths.dist);
 	}
 };


### PR DESCRIPTION
This changes the `gro clean` task to remove directories entirely instead of just emptying them. Gro's current heuristic for performing a compilation when running a task currently just looks for the presence of a build directory.

Previously, running `gro clean && gro <task>` as a user would not trigger compilation, but with this change it does.

Although the heuristic leads to problems in some circumstances, it's a fine solution for now. The fix is to just run `gro clean`.