### PR TITLE
check full task path to see if compilation is needed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,14 @@
 # Gro changelog
 
+## 0.1.7
+
+- compile TypeScript if an invoked task cannot be found in `build/`
+  ([#12](https://github.com/feltcoop/gro/pull/12))
+
 ## 0.1.6
 
 - change `gro clean` to delete directories instead of emptying them
+  ([#11](https://github.com/feltcoop/gro/pull/11))
 
 ## 0.1.5
 

--- a/src/cli/invoke.ts
+++ b/src/cli/invoke.ts
@@ -93,9 +93,9 @@ const main = async () => {
 			// First ensure that the project has been built.
 			// This is useful for initial project setup and CI.
 			if (!(await pathExists(toImportId(pathData.id)))) {
-				log.info('Building the project for initial setup.');
+				log.info('Task file not found in build directory. Compiling TypeScript...');
 				subTimings.start('build project');
-				await spawnProcess('node_modules/.bin/tsc');
+				await spawnProcess('node_modules/.bin/tsc'); // ignore compiler errors
 				subTimings.stop('build project');
 			}
 

--- a/src/cli/invoke.ts
+++ b/src/cli/invoke.ts
@@ -21,7 +21,15 @@ import {Timings} from '../utils/time.js';
 import {printMs, printPath, printPathOrGroPath, printSubTiming} from '../utils/print.js';
 import {resolveRawInputPath, getPossibleSourceIds} from '../fs/inputPath.js';
 import {TASK_FILE_SUFFIX, isTaskPath, toTaskName, TaskError} from '../task/task.js';
-import {paths, groPaths, toBasePath, replaceRootDir, pathsFromId, isId} from '../paths.js';
+import {
+	paths,
+	groPaths,
+	toBasePath,
+	replaceRootDir,
+	pathsFromId,
+	isId,
+	toImportId,
+} from '../paths.js';
 import {findModules, loadModules} from '../fs/modules.js';
 import {findFiles, pathExists} from '../fs/nodeFs.js';
 import {plural} from '../utils/string.js';
@@ -84,7 +92,9 @@ const main = async () => {
 
 			// First ensure that the project has been built.
 			// This is useful for initial project setup and CI.
-			if (!(await pathExists(paths.build))) {
+			if (
+				!(await pathExists(toImportId(findModulesResult.sourceIdsByInputPath.get(inputPath)![0])))
+			) {
 				log.info('Building the project for initial setup.');
 				subTimings.start('build project');
 				await spawnProcess('node_modules/.bin/tsc');

--- a/src/cli/invoke.ts
+++ b/src/cli/invoke.ts
@@ -92,9 +92,7 @@ const main = async () => {
 
 			// First ensure that the project has been built.
 			// This is useful for initial project setup and CI.
-			if (
-				!(await pathExists(toImportId(findModulesResult.sourceIdsByInputPath.get(inputPath)![0])))
-			) {
+			if (!(await pathExists(toImportId(pathData.id)))) {
 				log.info('Building the project for initial setup.');
 				subTimings.start('build project');
 				await spawnProcess('node_modules/.bin/tsc');


### PR DESCRIPTION
This improves a heuristic to detect if we want Gro to compile TypeScript when it tries to run a task. Previously it looked for the presence of the `build/` directory, and now it looks for the actual target task file in `build/`. Typically `gro dev` takes care of all of this for the developer, but this helps cover usage outside of that normal happy path.

PR #11 changed `gro clean` to remove directories completely to accommodate the old heuristic, rather than simply emptying the directories like it did before. Although that's no longer needed, because it now looks for the specific task file, I think it's still good behavior to fully remove the `build/` and `dist/` directories. Feels cleaner for sure. 🧹🧹 