### PR TITLE
check generated files only when some exist

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 - compile TypeScript if an invoked task cannot be found in `build/`
   ([#12](https://github.com/feltcoop/gro/pull/12))
+- add optional `okIfNone` arg to `gro gen` to suppress errors when no gen files are found
 
 ## 0.1.6
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - compile TypeScript if an invoked task cannot be found in `build/`
   ([#12](https://github.com/feltcoop/gro/pull/12))
 - add optional `okIfNone` arg to `gro gen` to suppress errors when no gen files are found
+  ([#13](https://github.com/feltcoop/gro/pull/13))
 
 ## 0.1.6
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 - compile TypeScript if an invoked task cannot be found in `build/`
   ([#12](https://github.com/feltcoop/gro/pull/12))
-- add optional `okIfNone` arg to `gro gen` to suppress errors when no gen files are found
+- change the check task to look for stale generated files only if the project contains gen files
   ([#13](https://github.com/feltcoop/gro/pull/13))
 
 ## 0.1.6

--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -16,7 +16,7 @@ export const task: Task = {
 		await testTask.run(ctx);
 
 		log.info('checking that generated files have not changed');
-		await genTask.run({...ctx, args: {...ctx.args, check: true}});
+		await genTask.run({...ctx, args: {...ctx.args, check: true, okIfNone: true}});
 
 		log.info('checking that all files are formatted correctly');
 		await formatTask.run({...ctx, args: {...ctx.args, check: true}});

--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -1,8 +1,9 @@
-import {Task} from './task/task.js';
+import {Task, TaskError} from './task/task.js';
 import {task as typecheckTask} from './typecheck.task.js';
 import {task as testTask} from './test.task.js';
 import {task as genTask} from './gen.task.js';
 import {task as formatTask} from './format.task.js';
+import {findGenModules} from './gen/genModule.js';
 
 export const task: Task = {
 	description: 'check that everything is ready to commit',
@@ -15,8 +16,17 @@ export const task: Task = {
 		log.info('testing');
 		await testTask.run(ctx);
 
-		log.info('checking that generated files have not changed');
-		await genTask.run({...ctx, args: {...ctx.args, check: true, okIfNone: true}});
+		// Check for stale code generation if the project has any gen files.
+		const findGenModulesResult = await findGenModules();
+		if (findGenModulesResult.ok) {
+			log.info('checking that generated files have not changed');
+			await genTask.run({...ctx, args: {...ctx.args, check: true}});
+		} else if (findGenModulesResult.type !== 'inputDirectoriesWithNoFiles') {
+			for (const reason of findGenModulesResult.reasons) {
+				log.error(reason);
+			}
+			throw new TaskError('Failed to find gen modules.');
+		}
 
 		log.info('checking that all files are formatted correctly');
 		await formatTask.run({...ctx, args: {...ctx.args, check: true}});

--- a/src/gen/genModule.test.ts
+++ b/src/gen/genModule.test.ts
@@ -1,5 +1,8 @@
+import {join} from 'path';
+
 import {test, t} from '../oki/oki.js';
-import {validateGenModule} from './genModule.js';
+import {validateGenModule, findGenModules} from './genModule.js';
+import {paths} from '../paths.js';
 
 test('validateGenModule()', () => {
 	t.ok(validateGenModule({gen: () => {}}));
@@ -8,4 +11,9 @@ test('validateGenModule()', () => {
 		t.ok(!validateGenModule({gen: {}}));
 		t.ok(!validateGenModule({task: {run: {}}}));
 	});
+});
+
+test('findGenModules()', async () => {
+	const findGenModulesResult = await findGenModules([join(paths.source, 'docs/')]);
+	t.ok(findGenModulesResult.ok);
 });

--- a/src/gen/genModule.ts
+++ b/src/gen/genModule.ts
@@ -1,6 +1,8 @@
-import {ModuleMeta, loadModule, LoadModuleResult} from '../fs/modules.js';
-import {Gen, GenResults, GenFile} from './gen.js';
-import {pathExists, readFile} from '../fs/nodeFs.js';
+import {ModuleMeta, loadModule, LoadModuleResult, findModules} from '../fs/modules.js';
+import {Gen, GenResults, GenFile, isGenPath, GEN_FILE_PATTERN} from './gen.js';
+import {pathExists, readFile, findFiles} from '../fs/nodeFs.js';
+import {getPossibleSourceIds} from '../fs/inputPath.js';
+import {paths} from '../paths.js';
 
 export interface GenModule {
 	gen: Gen;
@@ -50,3 +52,14 @@ export const checkGenModule = async (file: GenFile): Promise<CheckGenModuleResul
 		hasChanged: file.contents !== existingContents,
 	};
 };
+
+export const findGenModules = (
+	inputPaths: string[] = [paths.source],
+	extensions: string[] = [GEN_FILE_PATTERN],
+	rootDirs: string[] = [],
+) =>
+	findModules(
+		inputPaths,
+		(id) => findFiles(id, (file) => isGenPath(file.path)),
+		(inputPath) => getPossibleSourceIds(inputPath, extensions, rootDirs),
+	);


### PR DESCRIPTION
We have a widely useful task in `gro check` that wraps up the following:

- typechecks
- runs tests
- checks formatting
- checks generated files are not stale

The last one is a bit tricky because some projects might not use Gro's file generation, but we still want `gro check` to be convenient. We usually want `gro gen` to fail loudly if there's nothing to generate. This adds the optional flag `okIfNone` to the gen task to suppress errors specifically when no files are found, instead printing a helpful diagnostic and exiting quietly. It's then used in the `gro check` task.

I considered not using a flag and instead using the heuristic that if you do `gro gen` it'll not error, but `gro gen dirWithNoGenFiles` would error, but opted for the more explicit, less surprising flag route.

I tried to think of a good name and this was the best I could come up with. 🤷 