### PR TITLE
add install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You'll also want to install Gro globally to add its CLI to your system PATH:
 
 ```bash
 npm i -g @feltcoop/gro
-gro # should work - defers to the project's locally installed version of Gro
+gro # should print some stuff - defers to the project's locally installed version of Gro
 ```
 
 ## usage

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ It includes:
 - more to come, exploring what deeply integrated tools enable
   in the realms of developer power and ergonomics and end user experience
 
+## install
+
+Normally you'll want to install Gro as a dev dependency:
+
+```bash
+npm i -D @feltcoop/gro
+```
+
+You'll also want to install Gro globally to add its CLI to your system PATH:
+
+```bash
+npm i -g @feltcoop/gro
+gro # should work - defers to the project's locally installed version of Gro
+```
+
 ## usage
 
 ```bash


### PR DESCRIPTION
Most projects have a separate CLI but I didn't want the complication. Long term that's probably the better thing to do.

Peer dependencies are currently a wart, printing out a bunch of warnings on installation, but [npm 7](https://blog.npmjs.org/post/618653678433435649/npm-v7-series-arborist-deep-dive) should eliminate that issue.