### PR TITLE
format files in the root directory

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 - compile TypeScript if an invoked task cannot be found in `build/`
   ([#12](https://github.com/feltcoop/gro/pull/12))
-- format certain files in the root directory
+- format files in the root directory, not just `src/`
   ([#15](https://github.com/feltcoop/gro/pull/15))
 
 ## 0.1.6

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - compile TypeScript if an invoked task cannot be found in `build/`
   ([#12](https://github.com/feltcoop/gro/pull/12))
+- format certain files in the root directory
+  ([#15](https://github.com/feltcoop/gro/pull/15))
 
 ## 0.1.6
 

--- a/src/format.task.ts
+++ b/src/format.task.ts
@@ -3,6 +3,8 @@ import {spawnProcess} from './utils/process.js';
 import {printKeyValue} from './utils/print.js';
 import {paths} from './paths.js';
 
+const FORMATTED_EXTENSIONS = 'ts,js,json,svelte,html,css,md,yml';
+
 export const task: Task = {
 	description: 'format source files',
 	run: async ({args}) => {
@@ -10,8 +12,8 @@ export const task: Task = {
 
 		const formatResult = await spawnProcess('node_modules/.bin/prettier', [
 			check ? '--check' : '--write',
-			`${paths.source}**/*.{ts,js,json,svelte,html,css,md,yml}`,
-			`${paths.root}*.{ts,js,md}`,
+			`${paths.source}**/*.{${FORMATTED_EXTENSIONS}}`,
+			`${paths.root}*.{${FORMATTED_EXTENSIONS}}`,
 		]);
 
 		if (!formatResult.ok) {

--- a/src/format.task.ts
+++ b/src/format.task.ts
@@ -11,6 +11,7 @@ export const task: Task = {
 		const formatResult = await spawnProcess('node_modules/.bin/prettier', [
 			check ? '--check' : '--write',
 			`${paths.source}**/*.{ts,js,json,svelte,html,css,md,yml}`,
+			`${paths.root}*.{ts,js,md}`,
 		]);
 
 		if (!formatResult.ok) {


### PR DESCRIPTION
This adds an additional glob to the default formatter to include some files in the root directory. Which files to target is a bit tricky. Generally speaking, Gro expects everything to be in your `src/` directory, but it's common to have some files in the root directory for various tools, and we want a subset of those to be formatted. We don't want to format things like `package-lock.json` or `package.json` because those are modified directly by npm. Insead of adding a blacklist, I opted to just target TypeScript, JavaScript, and Markdown files. Seems ok?