### PR TITLE
fix unbuilt project detection when invoking builtin Gro tasks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.1.8
 
 - fix unbuilt project detection when invoking builtin Gro tasks
-  ([#12](https://github.com/feltcoop/gro/pull/16))
+  ([#16](https://github.com/feltcoop/gro/pull/16))
 
 ## 0.1.7
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.1.8
+
+- fix unbuilt project detection when invoking builtin Gro tasks
+  ([#12](https://github.com/feltcoop/gro/pull/16))
+
 ## 0.1.7
 
 - compile TypeScript if an invoked task cannot be found in `build/`

--- a/src/cli/invoke.ts
+++ b/src/cli/invoke.ts
@@ -92,7 +92,7 @@ const main = async () => {
 
 			// First ensure that the project has been built.
 			// This is useful for initial project setup and CI.
-			if (!(await pathExists(toImportId(pathData.id)))) {
+			if (!(await pathExists(paths.build)) || !(await pathExists(toImportId(pathData.id)))) {
 				log.info('Task file not found in build directory. Compiling TypeScript...');
 				subTimings.start('build project');
 				await spawnProcess('node_modules/.bin/tsc'); // ignore compiler errors


### PR DESCRIPTION
This fixes Gro's heuristic that detects if a project should have its TypeScript compiled during a task invocation. It worked in the intended cases except when a user project invoked a Gro builtin task - in that case the it detected that Gro's version of the task was built, but the current project may not be. Now it looks for the presence of a `build/` directory in the current project.

This is really just a best-effort detection heuristic. Properly detecting if a project needs to be built when invoking a task is too expensive to perform each time - it would significantly impact startup time. Generally speaking, the developer should be expected to call `gro dev` or `gro build` to ensure their tasks are correctly refreshed. The primary purpose of this detection is initial setup, CI, and convenience in some cases, like after calling a manual `gro clean`.