### PR TITLE
properly detect build status when invoking builtin Gro tasks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.1.9
+
+- actually fix unbuilt project detection when invoking builtin Gro tasks
+  ([#17](https://github.com/feltcoop/gro/pull/17))
+
 ## 0.1.8
 
 - fix unbuilt project detection when invoking builtin Gro tasks

--- a/src/cli/invoke.ts
+++ b/src/cli/invoke.ts
@@ -27,7 +27,7 @@ import {
 	toBasePath,
 	replaceRootDir,
 	pathsFromId,
-	isId,
+	isGroId,
 	toImportId,
 } from '../paths.js';
 import {findModules, loadModules} from '../fs/modules.js';
@@ -138,7 +138,7 @@ const main = async () => {
 			if (paths === groPaths) {
 				// Is the Gro directory the same as the cwd? Log the matching files.
 				logAvailableTasks(log, printPath(pathData.id), findModulesResult.sourceIdsByInputPath);
-			} else if (isId(pathData.id, groPaths)) {
+			} else if (isGroId(pathData.id)) {
 				// Does the Gro directory contain the matching files? Log them.
 				logAvailableTasks(
 					log,
@@ -175,11 +175,8 @@ const main = async () => {
 		// The input path matched a directory, but it contains no matching files.
 		if (
 			paths === groPaths ||
-			isId(
-				// this is null safe because of the failure type
-				findModulesResult.sourceIdPathDataByInputPath.get(inputPath)!.id,
-				groPaths,
-			)
+			// this is null safe because of the failure type
+			isGroId(findModulesResult.sourceIdPathDataByInputPath.get(inputPath)!.id)
 		) {
 			// If the directory is inside Gro, just log the errors.
 			logErrorReasons(log, findModulesResult.reasons);
@@ -248,8 +245,8 @@ const logErrorReasons = (log: Logger, reasons: string[]): void => {
 // Properly detecting this is too expensive and would impact startup time significantly.
 // Generally speaking, the user is expected to be running `gro dev` or `gro build`.
 const shouldBuildProject = async (pathData: PathData): Promise<boolean> =>
-	paths === groPaths || isId(pathData.id, paths)
-		? !(await pathExists(toImportId(pathData.id)))
-		: !(await pathExists(paths.build));
+	paths !== groPaths && isGroId(pathData.id)
+		? !(await pathExists(paths.build))
+		: !(await pathExists(toImportId(pathData.id)));
 
 main(); // see `attachProcessErrorHandlers` above for why we don't catch here

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -5,6 +5,7 @@ import {
 	createPaths,
 	paths,
 	groPaths,
+	isGroId,
 	toRootPath,
 	toBasePath,
 	basePathToSourceId,
@@ -31,7 +32,12 @@ test('createPaths()', () => {
 });
 
 test('paths object has the same identity as the groPaths object', () => {
-	t.is(paths, groPaths);
+	t.is(paths, groPaths); // because we're testing inside the Gro project
+});
+
+test('isGroId()', () => {
+	t.ok(isGroId(resolve(paths.source)));
+	t.ok(!isGroId(resolve('../fake/src')));
 });
 
 test('toRootPath()', () => {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -58,9 +58,9 @@ export const groDir = join(groImportDir, '../');
 export const groDirBasename = basename(groDir) + sep;
 export const groPaths = groDir === paths.root ? paths : createPaths(groDir);
 
-export const pathsFromId = (id: string): Paths => (isId(id, groPaths) ? groPaths : paths);
+export const pathsFromId = (id: string): Paths => (isGroId(id) ? groPaths : paths);
+export const isGroId = (id: string): boolean => id.startsWith(groPaths.root);
 
-export const isId = (id: string, p = paths): boolean => id.startsWith(p.root);
 export const isSourceId = (id: string, p = paths): boolean => id.startsWith(p.source);
 export const isBuildId = (id: string, p = paths): boolean => id.startsWith(p.build);
 export const isDistId = (id: string, p = paths): boolean => id.startsWith(p.dist);


### PR DESCRIPTION
This fixes what I thought I fixed in #16. There was a subtle bug in how the code differentiated between Gro and app file paths.