### PR TITLE
change check task to run tests only if some exist

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## 0.1.9
 
+- change the check task to run tests only if some exist
+  ([#18](https://github.com/feltcoop/gro/pull/18))
+
+## 0.1.9
+
 - actually fix unbuilt project detection when invoking builtin Gro tasks
   ([#17](https://github.com/feltcoop/gro/pull/17))
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Gro changelog
 
-## 0.1.9
+## 0.1.10
 
 - change the check task to run tests only if some exist
   ([#18](https://github.com/feltcoop/gro/pull/18))

--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -4,6 +4,7 @@ import {task as testTask} from './test.task.js';
 import {task as genTask} from './gen.task.js';
 import {task as formatTask} from './format.task.js';
 import {findGenModules} from './gen/genModule.js';
+import {findTestModules} from './oki/testModule.js';
 
 export const task: Task = {
 	description: 'check that everything is ready to commit',
@@ -13,8 +14,17 @@ export const task: Task = {
 		log.info('typechecking');
 		await typecheckTask.run(ctx);
 
-		log.info('testing');
-		await testTask.run(ctx);
+		// Run tests only if the the project has some.
+		const findTestModulesResult = await findTestModules();
+		if (findTestModulesResult.ok) {
+			log.info('testing');
+			await testTask.run(ctx);
+		} else if (findTestModulesResult.type !== 'inputDirectoriesWithNoFiles') {
+			for (const reason of findTestModulesResult.reasons) {
+				log.error(reason);
+			}
+			throw new TaskError('Failed to find task modules.');
+		}
 
 		// Check for stale code generation if the project has any gen files.
 		const findGenModulesResult = await findGenModules();

--- a/src/oki/testModule.ts
+++ b/src/oki/testModule.ts
@@ -1,4 +1,7 @@
-import {ModuleMeta, loadModule, LoadModuleResult} from '../fs/modules.js';
+import {ModuleMeta, loadModule, LoadModuleResult, findModules} from '../fs/modules.js';
+import {paths} from '../paths.js';
+import {findFiles} from '../fs/nodeFs.js';
+import {getPossibleSourceIds} from '../fs/inputPath.js';
 
 export interface TestModuleMeta extends ModuleMeta<TestModule> {}
 
@@ -20,3 +23,14 @@ export const isTestBuildFile = (path: string): boolean => TEST_BUILD_FILE_MATCHE
 export const TEST_BUILD_ARTIFACT_MATCHER = /.+\.test\.(js\.map|d\.ts|d\.ts\.map)$/;
 export const isTestBuildArtifact = (path: string): boolean =>
 	TEST_BUILD_ARTIFACT_MATCHER.test(path);
+
+export const findTestModules = (
+	inputPaths: string[] = [paths.source],
+	extensions: string[] = [TEST_FILE_SUFFIX],
+	rootDirs: string[] = [],
+) =>
+	findModules(
+		inputPaths,
+		(id) => findFiles(id, (file) => isTestPath(file.path)),
+		(inputPath) => getPossibleSourceIds(inputPath, extensions, rootDirs),
+	);

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -1,9 +1,8 @@
 import {Task, TaskError} from './task/task.js';
 import {TestContext} from './oki/TestContext.js';
-import {resolveRawInputPaths, getPossibleSourceIds} from './fs/inputPath.js';
-import {findFiles} from './fs/nodeFs.js';
-import {findModules, loadModules} from './fs/modules.js';
-import {TEST_FILE_SUFFIX, isTestPath} from './oki/testModule.js';
+import {resolveRawInputPaths} from './fs/inputPath.js';
+import {loadModules} from './fs/modules.js';
+import {findTestModules} from './oki/testModule.js';
 import {printMs, printSubTiming} from './utils/print.js';
 import {Timings} from './utils/time.js';
 import * as report from './oki/report.js';
@@ -22,11 +21,7 @@ export const task: Task = {
 
 		const testContext = new TestContext({report});
 
-		const findModulesResult = await findModules(
-			inputPaths,
-			(id) => findFiles(id, (file) => isTestPath(file.path)),
-			(inputPath) => getPossibleSourceIds(inputPath, [TEST_FILE_SUFFIX]),
-		);
+		const findModulesResult = await findTestModules(inputPaths);
 		if (!findModulesResult.ok) {
 			for (const reason of findModulesResult.reasons) {
 				log.error(reason);


### PR DESCRIPTION
This mirrors what #13 did for gen files, but with tests. Previously the check task would error out if the project has no tests. I ran into this while dogfooding Gro on a fresh project today. (it revealed other rough edges, but overall I give all my thumbs up 👍👍👍)

Again this is not efficient, but we're only talking about a few milliseconds for most projects, and before Felt grows too large, we'll want to implement a virtual filesystem for lots of reasons, which will solve the performance issue.