### PR TITLE
add async rejects assertion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.1.10
 
+- add async `rejects` assertion
+  ([#19](https://github.com/feltcoop/gro/pull/19))
 - change the check task to run tests only if some exist
   ([#18](https://github.com/feltcoop/gro/pull/18))
 

--- a/src/oki/README.md
+++ b/src/oki/README.md
@@ -84,8 +84,16 @@ interface Assertions {
 	isNot(actual: any, expected: any); // `!Object.is`
 	equal(actual: any, expected: any); // deeply equal
 	notEqual(actual: any, expected: any); // !deeply equal
-	// expects `cb` to throw an error that matches optional `matcher`
-	throws(cb: () => void, matcher?: ErrorClass | RegExp | string);
+	throws(
+		// expects `cb` to throw an error that matches optional `matcher`
+		cb: () => void,
+		matcher?: ErrorClass | RegExp | string,
+	);
+	rejects(
+		// expects `cbOrPromise` to throw an error that matches optional `matcher`
+		cbOrPromise: Promise<any> | (() => Promise<void>),
+		matcher?: ErrorClass | RegExp | string,
+	);
 	fail(message: string); // throws a `TestAssertionError` (t.Error)
 	Error(message: string); // the `TestAssertionError` class for deliberate fails
 }

--- a/src/oki/assertions.test.ts
+++ b/src/oki/assertions.test.ts
@@ -85,6 +85,81 @@ test('assertions', () => {
 		});
 	});
 
+	const failToReject = async (cb: () => Promise<void>): Promise<AssertionError> => {
+		try {
+			await cb();
+		} catch (err) {
+			if (err instanceof AssertionError) {
+				if (err.assertion.operator !== AssertionOperator.rejects) {
+					t.fail(`Expected error operator to be "${AssertionOperator.rejects}"`);
+				}
+				return err; // success
+			} else {
+				t.fail('Expected error to be a AssertionError');
+			}
+		}
+		t.fail(`Expected an error`);
+	};
+	test('rejects() ✓', async () => {
+		await t.rejects(async () => {
+			throw Error();
+		});
+	});
+	test('rejects() 🞩', async () => {
+		await failToReject(async () => {
+			await t.rejects(async () => {});
+		});
+	});
+	test('rejects() a promise ✓', async () => {
+		await t.rejects(new Promise((_, reject) => reject()));
+	});
+	test('rejects() a promise 🞩', async () => {
+		await failToReject(async () => {
+			await t.rejects(new Promise((resolve) => resolve()));
+		});
+	});
+	test('rejects() with a string matcher ✓', async () => {
+		const thrownError = new Error('~~~match this error message~~~');
+		await t.rejects(async () => {
+			throw thrownError;
+		}, 'match this error message');
+	});
+	test('rejects() with a string matcher 🞩', async () => {
+		await failToReject(async () => {
+			await t.rejects(async () => {
+				throw Error('foo');
+			}, 'food');
+		});
+	});
+	test('rejects() with a RegExp matcher ✓', async () => {
+		const thrownError = new Error('match me with a regexp');
+		await t.rejects(async () => {
+			throw thrownError;
+		}, /witH.+ReGeX/i);
+	});
+	test('rejects() with a RegExp matcher 🞩', async () => {
+		await failToReject(async () => {
+			await t.rejects(async () => {
+				throw Error('foo');
+			}, /food/);
+		});
+	});
+	test('rejects() with an ErrorClass matcher ✓', async () => {
+		class SomeError extends Error {}
+		const thrownError = new SomeError();
+		await t.rejects(async () => {
+			throw thrownError;
+		}, SomeError);
+	});
+	test('rejects() with an ErrorClass matcher 🞩', async () => {
+		class SomeError extends Error {}
+		await failToReject(async () => {
+			await t.rejects(async () => {
+				throw Error();
+			}, SomeError);
+		});
+	});
+
 	test('ok() ✓', () => {
 		t.ok(true);
 		t.ok(1);
@@ -185,102 +260,5 @@ test('assertions', () => {
 		t.throws(() => t.notEqual([1, 'a', [1, 'a']], [1, 'a', [1, 'a']]));
 		t.throws(() => t.notEqual(NaN, NaN));
 		t.throws(() => t.notEqual(-Infinity, -Infinity));
-	});
-});
-
-const skip: typeof test = Function.prototype as any;
-
-skip('failed assertions', () => {
-	test('fail()', () => {
-		t.fail('this test failed because errror');
-	});
-
-	const failToThrow = (cb: () => void): AssertionError => {
-		try {
-			cb();
-		} catch (err) {
-			if (err instanceof AssertionError) {
-				if (err.assertion.operator !== AssertionOperator.throws) {
-					t.fail(`Expected error operator to be "${AssertionOperator.throws}"`);
-				}
-				return err; // success
-			} else {
-				t.fail('Expected error to be a AssertionError');
-			}
-		}
-		t.fail(`Expected an error`);
-	};
-	test('throws() ✓', async () => {
-		failToThrow(() => {
-			t.throws(() => {
-				throw Error();
-			});
-		});
-	});
-	test('throws() 🞩', () => {
-		t.throws(() => {});
-	});
-	test('throws() an error unmatched by Error class', () => {
-		class SomeError extends Error {}
-		t.throws(() => {
-			throw Error();
-		}, SomeError);
-	});
-	test('throws() an error unmatched by regexp', () => {
-		t.throws(() => {
-			throw Error('foo');
-		}, /food/);
-	});
-	test('throws() an error unmatched by message substring', () => {
-		t.throws(() => {
-			throw Error('foo');
-		}, 'food');
-	});
-
-	test('ok()', () => {
-		t.ok(0);
-	});
-
-	test('is()', () => {
-		t.is(0, 1);
-	});
-
-	test('isNot()', () => {
-		t.isNot(0, 0);
-	});
-
-	test('equal() with numbers', () => {
-		t.equal(0, 1);
-	});
-	test('equal() with bigints', () => {
-		t.equal(BigInt(40000000000), BigInt(40000000001));
-	});
-	test('equal() with strings', () => {
-		t.equal('hello', 'hell');
-	});
-	test('equal() with booleans', () => {
-		t.equal(true, false);
-	});
-	test('equal() with null and undefined', () => {
-		t.equal(null, undefined);
-	});
-	test('equal() with symbols', () => {
-		t.equal(Symbol(), Symbol());
-	});
-	test('equal() with objects', () => {
-		t.equal({a: 1, b: {c: {d: 2}}}, {a: 1, b: {c: {d: 3}}});
-	});
-	test('equal() with functions', () => {
-		function fn() {
-			return 'hello world';
-		}
-		t.equal(fn, () => 'hello world');
-	});
-
-	test('notEqual() with numbers', () => {
-		t.notEqual(0, 0);
-	});
-	test('notEqual() with objects', () => {
-		t.notEqual({a: 1, b: {c: {d: 3}}}, {a: 1, b: {c: {d: 3}}});
 	});
 });

--- a/src/oki/report.ts
+++ b/src/oki/report.ts
@@ -107,12 +107,13 @@ export const reportAssertionError = (
 			log.plain(printValue(assertion.expected));
 			break;
 		case AssertionOperator.throws:
+		case AssertionOperator.rejects:
 			const logArgs: any[] = [];
-			if (assertion.thrown) {
+			if (assertion.error) {
 				if (assertion.matcher) {
-					logArgs.push(printUnmatchedErrorMessage(assertion.matcher, assertion.thrown));
+					logArgs.push(printUnmatchedErrorMessage(assertion.matcher, assertion.error));
 				}
-				logArgs.push('\n' + printThrownError(assertion.thrown, reportFullStackTraces));
+				logArgs.push('\n' + printThrownError(assertion.error, reportFullStackTraces));
 			}
 			log.plain(...logArgs);
 			break;
@@ -194,7 +195,7 @@ const printUnmatchedErrorMessage = (
 	} else if (matcher instanceof RegExp) {
 		strs.push(printMatcher(matcher), 'does not match error message', printStr(error.message));
 	} else {
-		strs.push(printMatcher(matcher), 'is not a superclass of thrown', cyan(error.name));
+		strs.push(printMatcher(matcher), 'is not a superclass of error', cyan(error.name));
 	}
 	return strs.join(' ');
 };


### PR DESCRIPTION
This adds the async test assertion `rejects` to complement the synchronous `throws`. I needed it for Felt. The tests for `rejects` might make your eyes glaze over (they did to me), but they're pretty simple - just copy/pasted from the `throws` tests with `async` sprinkled in, with two cases added to test promise arguments.

It also cleans up some things and removes some ancient test code that was being ignored.