### PR TITLE
add the invokeTask helper for task composition

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.1.12
+
+- add the `invokeTask` helper for task composition
+  ([#20](https://github.com/feltcoop/gro/pull/20))
+
 ## 0.1.11
 
 - fix `terser` import

--- a/src/assets.task.ts
+++ b/src/assets.task.ts
@@ -1,12 +1,9 @@
 import {Task} from './task/task.js';
 import {assets} from './project/assets.js';
-import {printPath} from './utils/print.js';
-import {paths} from './paths.js';
 
 export const task: Task = {
 	description: 'copy assets to dist',
-	run: async ({log}): Promise<void> => {
-		log.info(`copying assets to ${printPath(paths.dist)}`);
+	run: async (): Promise<void> => {
 		await assets();
 	},
 };

--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -1,24 +1,16 @@
 import {Task, TaskError} from './task/task.js';
-import {task as typecheckTask} from './typecheck.task.js';
-import {task as testTask} from './test.task.js';
-import {task as genTask} from './gen.task.js';
-import {task as formatTask} from './format.task.js';
 import {findGenModules} from './gen/genModule.js';
 import {findTestModules} from './oki/testModule.js';
 
 export const task: Task = {
 	description: 'check that everything is ready to commit',
-	run: async (ctx) => {
-		const {log} = ctx;
-
-		log.info('typechecking');
-		await typecheckTask.run(ctx);
+	run: async ({log, args, invokeTask}) => {
+		await invokeTask('typecheck');
 
 		// Run tests only if the the project has some.
 		const findTestModulesResult = await findTestModules();
 		if (findTestModulesResult.ok) {
-			log.info('testing');
-			await testTask.run(ctx);
+			await invokeTask('test');
 		} else if (findTestModulesResult.type !== 'inputDirectoriesWithNoFiles') {
 			for (const reason of findTestModulesResult.reasons) {
 				log.error(reason);
@@ -30,7 +22,7 @@ export const task: Task = {
 		const findGenModulesResult = await findGenModules();
 		if (findGenModulesResult.ok) {
 			log.info('checking that generated files have not changed');
-			await genTask.run({...ctx, args: {...ctx.args, check: true}});
+			await invokeTask('gen', {...args, check: true});
 		} else if (findGenModulesResult.type !== 'inputDirectoriesWithNoFiles') {
 			for (const reason of findGenModulesResult.reasons) {
 				log.error(reason);
@@ -38,7 +30,6 @@ export const task: Task = {
 			throw new TaskError('Failed to find gen modules.');
 		}
 
-		log.info('checking that all files are formatted correctly');
-		await formatTask.run({...ctx, args: {...ctx.args, check: true}});
+		await invokeTask('format', {...args, check: true});
 	},
 };

--- a/src/cli/invoke.ts
+++ b/src/cli/invoke.ts
@@ -1,5 +1,5 @@
 // handle uncaught errors
-import {attachProcessErrorHandlers, spawnProcess} from '../utils/process.js';
+import {attachProcessErrorHandlers} from '../utils/process.js';
 attachProcessErrorHandlers();
 
 // install source maps
@@ -14,54 +14,19 @@ if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development';
 import mri from 'mri';
 
 import {Args} from './types.js';
-import {SystemLogger, Logger} from '../utils/log.js';
-import {green, blue, cyan, red, gray} from '../colors/terminal.js';
-import {runTask} from '../task/runTask.js';
-import {Timings} from '../utils/time.js';
-import {printMs, printPath, printPathOrGroPath, printSubTiming} from '../utils/print.js';
-import {resolveRawInputPath, getPossibleSourceIds} from '../fs/inputPath.js';
-import {TASK_FILE_SUFFIX, isTaskPath, toTaskName, TaskError} from '../task/task.js';
-import {
-	paths,
-	groPaths,
-	toBasePath,
-	replaceRootDir,
-	pathsFromId,
-	isGroId,
-	toImportId,
-} from '../paths.js';
-import {findModules, loadModules} from '../fs/modules.js';
-import {findFiles, pathExists} from '../fs/nodeFs.js';
-import {plural} from '../utils/string.js';
-import {loadTaskModule} from '../task/taskModule.js';
-import {PathData} from '../fs/pathData.js';
+import {invokeTask} from '../task/invokeTask.js';
 
 /*
 
-This module invokes the Gro CLI.
-
+This module invokes the Gro CLI which in turn invokes tasks.
 Tasks are the CLI's primary concept.
 To learn more about them, see the docs at `src/task/README.md`.
 
-When the CLI is invoked,
-it first searches for tasks in the current working directory
-using the first CLI arg a.k.a. "taskName",
-and falls back to searching Gro's directory, if the two are different.
-See `src/fs/inputPath.ts` for info about what "taskName" can refer to.
-If it matches a directory, all of the tasks within it are logged,
-both in the current working directory and Gro.
-
-This code is particularly hairy because
-we're accepting a wide range of user input
-and trying to do the right thing.
-Precise error messages are especially difficult and
-there are some subtle differences in the complex logical branches.
-The comments describe each condition.
+When the CLI is invoked it passes the first CLI arg as "taskName" to `invokeTask`.
 
 */
 const main = async () => {
 	const argv: Args = mri(process.argv.slice(2));
-	const log = new SystemLogger([blue(`[${green('gro')}]`)]);
 
 	const {
 		_: [taskName, ..._],
@@ -69,184 +34,7 @@ const main = async () => {
 	} = argv;
 	const args = {_, ...namedArgs};
 
-	const timings = new Timings<'total'>();
-	timings.start('total');
-	const subTimings = new Timings();
-
-	// Resolve the input path for the provided task name.
-	const inputPath = resolveRawInputPath(taskName || paths.source);
-
-	// Find the task or directory specified by the `inputPath`.
-	// Fall back to searching the Gro directory as well.
-	const findModulesResult = await findModules(
-		[inputPath],
-		(id) => findFiles(id, (file) => isTaskPath(file.path)),
-		(inputPath) => getPossibleSourceIds(inputPath, [TASK_FILE_SUFFIX], [groPaths.root]),
-	);
-
-	if (findModulesResult.ok) {
-		subTimings.merge(findModulesResult.timings);
-		// Found a match either in the current working directory or Gro's directory.
-		const pathData = findModulesResult.sourceIdPathDataByInputPath.get(inputPath)!; // this is null safe because result is ok
-		if (!pathData.isDirectory) {
-			// The input path matches a file, so load and run it.
-
-			// First ensure that the project has been built.
-			// This is useful for initial project setup and CI.
-			if (await shouldBuildProject(pathData)) {
-				log.info('Task file not found in build directory. Compiling TypeScript...');
-				subTimings.start('build project');
-				await spawnProcess('node_modules/.bin/tsc'); // ignore compiler errors
-				subTimings.stop('build project');
-			}
-
-			// Load and run the task.
-			const loadModulesResult = await loadModules(
-				findModulesResult.sourceIdsByInputPath,
-				loadTaskModule,
-			);
-			if (loadModulesResult.ok) {
-				subTimings.merge(loadModulesResult.timings);
-				// Run the task!
-				// `pathData` is not a directory, so there's a single task module here.
-				const task = loadModulesResult.modules[0];
-				log.info(
-					`→ ${cyan(task.name)} ${
-						(task.mod.task.description && gray(task.mod.task.description)) || ''
-					}`,
-				);
-				subTimings.start('run task');
-				const result = await runTask(task, args, process.env);
-				subTimings.stop('run task');
-				if (result.ok) {
-					log.info(`✓ ${cyan(task.name)}`);
-				} else {
-					log.info(`${red('🞩')} ${cyan(task.name)}`);
-					logErrorReasons(log, [result.reason]);
-					if (result.error instanceof TaskError) {
-						process.exit(1);
-					} else {
-						throw result.error;
-					}
-				}
-			} else {
-				logErrorReasons(log, loadModulesResult.reasons);
-				process.exit(1);
-			}
-		} else {
-			// The input path matches a directory. Log the tasks but don't run them.
-			if (paths === groPaths) {
-				// Is the Gro directory the same as the cwd? Log the matching files.
-				logAvailableTasks(log, printPath(pathData.id), findModulesResult.sourceIdsByInputPath);
-			} else if (isGroId(pathData.id)) {
-				// Does the Gro directory contain the matching files? Log them.
-				logAvailableTasks(
-					log,
-					printPathOrGroPath(pathData.id),
-					findModulesResult.sourceIdsByInputPath,
-				);
-			} else {
-				// The Gro directory is not the same as the cwd
-				// and it doesn't contain the matching files.
-				// Find all of the possible matches in the Gro directory as well,
-				// and log everything out.
-				const groDirInputPath = replaceRootDir(inputPath, groPaths.root);
-				const groDirFindModulesResult = await findModules([groDirInputPath], (id) =>
-					findFiles(id, (file) => isTaskPath(file.path)),
-				);
-				// Ignore any errors - the directory may not exist or have any files!
-				if (groDirFindModulesResult.ok) {
-					subTimings.merge(groDirFindModulesResult.timings);
-					const groPathData = groDirFindModulesResult.sourceIdPathDataByInputPath.get(
-						groDirInputPath,
-					)!;
-					// First log the Gro matches.
-					logAvailableTasks(
-						log,
-						printPathOrGroPath(groPathData.id),
-						groDirFindModulesResult.sourceIdsByInputPath,
-					);
-				}
-				// Then log the current working directory matches.
-				logAvailableTasks(log, printPath(pathData.id), findModulesResult.sourceIdsByInputPath);
-			}
-		}
-	} else if (findModulesResult.type === 'inputDirectoriesWithNoFiles') {
-		// The input path matched a directory, but it contains no matching files.
-		if (
-			paths === groPaths ||
-			// this is null safe because of the failure type
-			isGroId(findModulesResult.sourceIdPathDataByInputPath.get(inputPath)!.id)
-		) {
-			// If the directory is inside Gro, just log the errors.
-			logErrorReasons(log, findModulesResult.reasons);
-			process.exit(1);
-		} else {
-			// If there's a matching directory in the current working directory,
-			// but it has no matching files, we still want to search Gro's directory.
-			const groDirInputPath = replaceRootDir(inputPath, groPaths.root);
-			const groDirFindModulesResult = await findModules([groDirInputPath], (id) =>
-				findFiles(id, (file) => isTaskPath(file.path)),
-			);
-			if (groDirFindModulesResult.ok) {
-				subTimings.merge(groDirFindModulesResult.timings);
-				const groPathData = groDirFindModulesResult.sourceIdPathDataByInputPath.get(
-					groDirInputPath,
-				)!;
-				// Log the Gro matches.
-				logAvailableTasks(
-					log,
-					printPathOrGroPath(groPathData.id),
-					groDirFindModulesResult.sourceIdsByInputPath,
-				);
-			} else {
-				// Log the original errors, not the Gro-specific ones.
-				logErrorReasons(log, findModulesResult.reasons);
-				process.exit(1);
-			}
-		}
-	} else {
-		// Some other find modules result failure happened, so log it out.
-		// (currently, just "unmappedInputPaths")
-		logErrorReasons(log, findModulesResult.reasons);
-		process.exit(1);
-	}
-
-	for (const [key, timing] of subTimings.getAll()) {
-		log.trace(printSubTiming(key, timing));
-	}
-	log.info(`🕒 ${printMs(timings.stop('total'))}`);
+	await invokeTask(taskName, args);
 };
-
-const logAvailableTasks = (
-	log: Logger,
-	dirLabel: string,
-	sourceIdsByInputPath: Map<string, string[]>,
-): void => {
-	const sourceIds = Array.from(sourceIdsByInputPath.values()).flat();
-	if (sourceIds.length) {
-		log.info(`${sourceIds.length} task${plural(sourceIds.length)} in ${dirLabel}:`);
-		for (const sourceId of sourceIds) {
-			log.info('\t' + cyan(toTaskName(toBasePath(sourceId, pathsFromId(sourceId)))));
-		}
-	} else {
-		log.info(`No tasks found in ${dirLabel}.`);
-	}
-};
-
-const logErrorReasons = (log: Logger, reasons: string[]): void => {
-	for (const reason of reasons) {
-		log.error(reason);
-	}
-};
-
-// This is a best-effort heuristic that detects if
-// we should compile a project's TypeScript when invoking a task.
-// Properly detecting this is too expensive and would impact startup time significantly.
-// Generally speaking, the user is expected to be running `gro dev` or `gro build`.
-const shouldBuildProject = async (pathData: PathData): Promise<boolean> =>
-	paths !== groPaths && isGroId(pathData.id)
-		? !(await pathExists(paths.build))
-		: !(await pathExists(toImportId(pathData.id)));
 
 main(); // see `attachProcessErrorHandlers` above for why we don't catch here

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -1,15 +1,13 @@
 import {Task} from './task/task.js';
-import * as buildTask from './build.task.js';
-import * as serveTask from './serve.task.js';
 
 const DEFAULT_SERVE_DIR = 'dist/';
 
 export const task: Task = {
 	description: 'start development server',
-	run: async (ctx): Promise<void> => {
+	run: async ({args, invokeTask}): Promise<void> => {
 		// TODO fix these
-		ctx.args.watch = true; // TODO always?
-		ctx.args.dir = ctx.args.dir || DEFAULT_SERVE_DIR;
+		args.watch = true; // TODO always?
+		args.dir = args.dir || DEFAULT_SERVE_DIR;
 		// TODO also take HOST and PORT from env
 		// .option('-H, --host', 'Hostname for the server')
 		// .option('-p, --port', 'Port number for the server')
@@ -18,7 +16,7 @@ export const task: Task = {
 		// .option('-w, --watch', 'Watch for changes and rebuild')
 		// .option('-P, --production', 'Set NODE_ENV to production')
 
-		await Promise.all([buildTask.task.run(ctx), serveTask.task.run(ctx)]);
+		await Promise.all([invokeTask('build'), invokeTask('serve')]);
 
 		// ...
 	},

--- a/src/dist.task.ts
+++ b/src/dist.task.ts
@@ -4,16 +4,13 @@ import {paths} from './paths.js';
 import {isTestBuildFile, isTestBuildArtifact} from './oki/testModule.js';
 import {printPath} from './utils/print.js';
 import {cleanDist} from './project/clean.js';
-import {task as assetsTask} from './assets.task.js';
 
 export const isDistFile = (path: string): boolean =>
 	!isTestBuildFile(path) && !isTestBuildArtifact(path);
 
 export const task: Task = {
 	description: 'create the distribution',
-	run: async (ctx) => {
-		const {log} = ctx;
-
+	run: async ({log, invokeTask}) => {
 		await cleanDist(log);
 
 		log.info(`copying ${printPath(paths.build)} to ${printPath(paths.dist)}`);
@@ -21,6 +18,6 @@ export const task: Task = {
 			filter: (id) => isDistFile(id),
 		});
 
-		await assetsTask.run(ctx);
+		await invokeTask('assets');
 	},
 };

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -17,6 +17,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 - [project/build](../project/build.task.ts) - build, create, and link the distribution
 - [project/dev](../project/dev.task.ts) - build typescript in watch mode for development
 - [project/dist](../project/dist.task.ts) - create and link the distribution
+- [project/link](../project/link.task.ts) - link the distribution
 - [serve](../serve.task.ts) - start static file server
 - [test](../test.task.ts) - run tests
 - [typecheck](../typecheck.task.ts) - typecheck the project without emitting any files

--- a/src/gen/README.md
+++ b/src/gen/README.md
@@ -209,12 +209,11 @@ or in code:
 
 ```ts
 import {Task} from '@feltcoop/gro';
-import {task as genTask} from '@feltcoop/gro/dist/gen.task.js';
 
 export const task: Task = {
-	run: async (ctx) => {
+	run: async ({args, invokeTask}) => {
 		// this throws a `TaskError` if anything is new or different
-		await genTask.run({...ctx, args: {...ctx.args, check: true}});
+		await invokeTask('gen', {...args, check: true});
 	},
 };
 ```

--- a/src/project/build.task.ts
+++ b/src/project/build.task.ts
@@ -1,6 +1,5 @@
 import {Task} from '../task/task.js';
 import {spawnProcess} from '../utils/process.js';
-import {task as distTask} from './dist.task.js';
 import {cleanBuild} from './clean.js';
 
 // TODO `process.env.NODE_ENV = 'production'`?
@@ -8,14 +7,12 @@ import {cleanBuild} from './clean.js';
 
 export const task: Task = {
 	description: 'build, create, and link the distribution',
-	run: async (ctx) => {
-		const {log} = ctx;
-
+	run: async ({log, invokeTask}) => {
 		await cleanBuild(log);
 
 		log.info('compiling typescript');
 		await spawnProcess('node_modules/.bin/tsc');
 
-		await distTask.run(ctx);
+		await invokeTask('project/dist');
 	},
 };

--- a/src/project/dist.task.ts
+++ b/src/project/dist.task.ts
@@ -1,19 +1,9 @@
-import {Task, TaskError} from '../task/task.js';
-import {printKeyValue} from '../utils/print.js';
-import {spawnProcess} from '../utils/process.js';
-import {task as distTask} from '../dist.task.js';
+import {Task} from '../task/task.js';
 
 export const task: Task = {
 	description: 'create and link the distribution',
-	run: async (ctx) => {
-		const {log} = ctx;
-
-		await distTask.run(ctx);
-
-		log.info('linking');
-		const linkResult = await spawnProcess('npm', ['link']);
-		if (!linkResult.ok) {
-			throw new TaskError(`Failed to link. ${printKeyValue('code', linkResult.code)}`);
-		}
+	run: async ({invokeTask}) => {
+		await invokeTask('dist');
+		await invokeTask('project/link');
 	},
 };

--- a/src/project/link.task.ts
+++ b/src/project/link.task.ts
@@ -1,0 +1,13 @@
+import {Task, TaskError} from '../task/task.js';
+import {printKeyValue} from '../utils/print.js';
+import {spawnProcess} from '../utils/process.js';
+
+export const task: Task = {
+	description: 'link the distribution',
+	run: async () => {
+		const linkResult = await spawnProcess('npm', ['link']);
+		if (!linkResult.ok) {
+			throw new TaskError(`Failed to link. ${printKeyValue('code', linkResult.code)}`);
+		}
+	},
+};

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -9,10 +9,10 @@ const DEFAULT_DIR = './';
 
 export const task: Task = {
 	description: 'start static file server',
-	run: async ({log, args, env}): Promise<void> => {
+	run: async ({log, args}): Promise<void> => {
 		// TODO also take these from args
-		const host: string = env.HOST || DEFAULT_HOST;
-		const port: number = Number(env.PORT) || DEFAULT_PORT;
+		const host: string = process.env.HOST || DEFAULT_HOST;
+		const port: number = Number(process.env.PORT) || DEFAULT_PORT;
 		const dir: string = resolve((args.dir as any) || DEFAULT_DIR);
 
 		const devServer = createDevServer({host, port, dir});

--- a/src/task/README.md
+++ b/src/task/README.md
@@ -87,17 +87,17 @@ because you don't need to rely on the task override rules to get desired behavio
 but the logging and diagnostics it provides are nice to have.
 
 ```bash
-gro some/task
+gro some/file
 ```
 
 ```ts
-// src/some/task.task.ts
+// src/some/file.task.ts
 import {Task} from '@feltcoop/gro';
 
 export const task: Task = {
 	run: async ({args, invokeTask}) => {
-		// runs `src/other/task.task.ts`
-		await invokeTask('other/task', {...args, optionally: 'extendTheArgs'});
+		// runs `src/other/file.task.ts`
+		await invokeTask('other/file', {...args, optionally: 'extendTheArgs'});
 	},
 };
 ```

--- a/src/task/README.md
+++ b/src/task/README.md
@@ -73,7 +73,7 @@ export const task: Task = {
 
 Because Gro tasks are just functions,
 you can directly import them from within other tasks and run them.
-Usually though you'll want to use the `invokeTask` helper
+However, we recommend using the `invokeTask` helper
 for its automatic logging and diagnostics.
 
 The `invokeTask` helper uses Gro's task resolution rules

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -1,0 +1,227 @@
+import {spawnProcess} from '../utils/process.js';
+
+import {Args} from '../cli/types';
+import {SystemLogger, Logger} from '../utils/log.js';
+import {magenta, cyan, red, gray} from '../colors/terminal.js';
+import {runTask} from './runTask.js';
+import {Timings} from '../utils/time.js';
+import {printMs, printPath, printPathOrGroPath, printSubTiming} from '../utils/print.js';
+import {resolveRawInputPath, getPossibleSourceIds} from '../fs/inputPath.js';
+import {TASK_FILE_SUFFIX, isTaskPath, toTaskName, TaskError} from './task.js';
+import {
+	paths,
+	groPaths,
+	toBasePath,
+	replaceRootDir,
+	pathsFromId,
+	isGroId,
+	toImportId,
+} from '../paths.js';
+import {findModules, loadModules} from '../fs/modules.js';
+import {findFiles, pathExists} from '../fs/nodeFs.js';
+import {plural} from '../utils/string.js';
+import {loadTaskModule} from './taskModule.js';
+import {PathData} from '../fs/pathData.js';
+
+/*
+
+This module invokes Gro tasks by name using the filesystem as the source.
+
+When a task is invoked,
+it first searches for tasks in the current working directory.
+and falls back to searching Gro's directory, if the two are different.
+See `src/fs/inputPath.ts` for info about what "taskName" can refer to.
+If it matches a directory, all of the tasks within it are logged,
+both in the current working directory and Gro.
+
+This code is particularly hairy because
+we're accepting a wide range of user input
+and trying to do the right thing.
+Precise error messages are especially difficult and
+there are some subtle differences in the complex logical branches.
+The comments describe each condition.
+
+*/
+
+export const invokeTask = async (taskName: string, args: Args): Promise<void> => {
+	const log = new SystemLogger([`${gray('[')}${magenta(taskName)}${gray(']')}`]);
+
+	const timings = new Timings<'total'>();
+	timings.start('total');
+	const subTimings = new Timings();
+
+	// Resolve the input path for the provided task name.
+	const inputPath = resolveRawInputPath(taskName || paths.source);
+
+	// Find the task or directory specified by the `inputPath`.
+	// Fall back to searching the Gro directory as well.
+	const findModulesResult = await findModules(
+		[inputPath],
+		(id) => findFiles(id, (file) => isTaskPath(file.path)),
+		(inputPath) => getPossibleSourceIds(inputPath, [TASK_FILE_SUFFIX], [groPaths.root]),
+	);
+
+	if (findModulesResult.ok) {
+		subTimings.merge(findModulesResult.timings);
+		// Found a match either in the current working directory or Gro's directory.
+		const pathData = findModulesResult.sourceIdPathDataByInputPath.get(inputPath)!; // this is null safe because result is ok
+		if (!pathData.isDirectory) {
+			// The input path matches a file, so load and run it.
+
+			// First ensure that the project has been built.
+			// This is useful for initial project setup and CI.
+			if (await shouldBuildProject(pathData)) {
+				log.info('Task file not found in build directory. Compiling TypeScript...');
+				subTimings.start('build project');
+				await spawnProcess('node_modules/.bin/tsc'); // ignore compiler errors
+				subTimings.stop('build project');
+			}
+
+			// Load and run the task.
+			const loadModulesResult = await loadModules(
+				findModulesResult.sourceIdsByInputPath,
+				loadTaskModule,
+			);
+			if (loadModulesResult.ok) {
+				subTimings.merge(loadModulesResult.timings);
+				// Run the task!
+				// `pathData` is not a directory, so there's a single task module here.
+				const task = loadModulesResult.modules[0];
+				log.info(
+					`→ ${cyan(task.name)} ${
+						(task.mod.task.description && gray(task.mod.task.description)) || ''
+					}`,
+				);
+				subTimings.start('run task');
+				const result = await runTask(task, args, invokeTask);
+				subTimings.stop('run task');
+				if (result.ok) {
+					log.info(`✓ ${cyan(task.name)}`);
+				} else {
+					log.info(`${red('🞩')} ${cyan(task.name)}`);
+					logErrorReasons(log, [result.reason]);
+					if (result.error instanceof TaskError) {
+						process.exit(1);
+					} else {
+						throw result.error;
+					}
+				}
+			} else {
+				logErrorReasons(log, loadModulesResult.reasons);
+				process.exit(1);
+			}
+		} else {
+			// The input path matches a directory. Log the tasks but don't run them.
+			if (paths === groPaths) {
+				// Is the Gro directory the same as the cwd? Log the matching files.
+				logAvailableTasks(log, printPath(pathData.id), findModulesResult.sourceIdsByInputPath);
+			} else if (isGroId(pathData.id)) {
+				// Does the Gro directory contain the matching files? Log them.
+				logAvailableTasks(
+					log,
+					printPathOrGroPath(pathData.id),
+					findModulesResult.sourceIdsByInputPath,
+				);
+			} else {
+				// The Gro directory is not the same as the cwd
+				// and it doesn't contain the matching files.
+				// Find all of the possible matches in the Gro directory as well,
+				// and log everything out.
+				const groDirInputPath = replaceRootDir(inputPath, groPaths.root);
+				const groDirFindModulesResult = await findModules([groDirInputPath], (id) =>
+					findFiles(id, (file) => isTaskPath(file.path)),
+				);
+				// Ignore any errors - the directory may not exist or have any files!
+				if (groDirFindModulesResult.ok) {
+					subTimings.merge(groDirFindModulesResult.timings);
+					const groPathData = groDirFindModulesResult.sourceIdPathDataByInputPath.get(
+						groDirInputPath,
+					)!;
+					// First log the Gro matches.
+					logAvailableTasks(
+						log,
+						printPathOrGroPath(groPathData.id),
+						groDirFindModulesResult.sourceIdsByInputPath,
+					);
+				}
+				// Then log the current working directory matches.
+				logAvailableTasks(log, printPath(pathData.id), findModulesResult.sourceIdsByInputPath);
+			}
+		}
+	} else if (findModulesResult.type === 'inputDirectoriesWithNoFiles') {
+		// The input path matched a directory, but it contains no matching files.
+		if (
+			paths === groPaths ||
+			// this is null safe because of the failure type
+			isGroId(findModulesResult.sourceIdPathDataByInputPath.get(inputPath)!.id)
+		) {
+			// If the directory is inside Gro, just log the errors.
+			logErrorReasons(log, findModulesResult.reasons);
+			process.exit(1);
+		} else {
+			// If there's a matching directory in the current working directory,
+			// but it has no matching files, we still want to search Gro's directory.
+			const groDirInputPath = replaceRootDir(inputPath, groPaths.root);
+			const groDirFindModulesResult = await findModules([groDirInputPath], (id) =>
+				findFiles(id, (file) => isTaskPath(file.path)),
+			);
+			if (groDirFindModulesResult.ok) {
+				subTimings.merge(groDirFindModulesResult.timings);
+				const groPathData = groDirFindModulesResult.sourceIdPathDataByInputPath.get(
+					groDirInputPath,
+				)!;
+				// Log the Gro matches.
+				logAvailableTasks(
+					log,
+					printPathOrGroPath(groPathData.id),
+					groDirFindModulesResult.sourceIdsByInputPath,
+				);
+			} else {
+				// Log the original errors, not the Gro-specific ones.
+				logErrorReasons(log, findModulesResult.reasons);
+				process.exit(1);
+			}
+		}
+	} else {
+		// Some other find modules result failure happened, so log it out.
+		// (currently, just "unmappedInputPaths")
+		logErrorReasons(log, findModulesResult.reasons);
+		process.exit(1);
+	}
+
+	for (const [key, timing] of subTimings.getAll()) {
+		log.trace(printSubTiming(key, timing));
+	}
+	log.info(`🕒 ${printMs(timings.stop('total'))}`);
+};
+
+const logAvailableTasks = (
+	log: Logger,
+	dirLabel: string,
+	sourceIdsByInputPath: Map<string, string[]>,
+): void => {
+	const sourceIds = Array.from(sourceIdsByInputPath.values()).flat();
+	if (sourceIds.length) {
+		log.info(`${sourceIds.length} task${plural(sourceIds.length)} in ${dirLabel}:`);
+		for (const sourceId of sourceIds) {
+			log.info('\t' + cyan(toTaskName(toBasePath(sourceId, pathsFromId(sourceId)))));
+		}
+	} else {
+		log.info(`No tasks found in ${dirLabel}.`);
+	}
+};
+
+const logErrorReasons = (log: Logger, reasons: string[]): void => {
+	for (const reason of reasons) {
+		log.error(reason);
+	}
+};
+
+// This is a best-effort heuristic that detects if
+// we should compile a project's TypeScript when invoking a task.
+// Properly detecting this is too expensive and would impact startup time significantly.
+// Generally speaking, the user is expected to be running `gro dev` or `gro build`.
+const shouldBuildProject = async (pathData: PathData): Promise<boolean> =>
+	paths !== groPaths && isGroId(pathData.id)
+		? !(await pathExists(paths.build))
+		: !(await pathExists(toImportId(pathData.id)));

--- a/src/task/runTask.test.ts
+++ b/src/task/runTask.test.ts
@@ -15,9 +15,38 @@ test('runTask()', () => {
 				},
 			},
 			args,
-			process.env,
+			async () => {},
 		);
 		t.ok(result.ok);
+		t.is(result.output, args);
+	});
+
+	test('invokes a sub task', async () => {
+		const args = {a: 1, _: []};
+		let invokedTaskName;
+		let invokedArgs;
+		const result = await runTask(
+			{
+				name: 'testTask',
+				id: 'foo/testTask',
+				mod: {
+					task: {
+						run: async ({args, invokeTask}) => {
+							invokeTask('bar/testTask', args);
+							return args;
+						},
+					},
+				},
+			},
+			args,
+			async (invokingTaskName, invokingArgs) => {
+				invokedTaskName = invokingTaskName;
+				invokedArgs = invokingArgs;
+			},
+		);
+		t.ok(result.ok);
+		t.is(invokedTaskName, 'bar/testTask');
+		t.is(invokedArgs, args);
 		t.is(result.output, args);
 	});
 
@@ -37,7 +66,7 @@ test('runTask()', () => {
 				},
 			},
 			{_: []},
-			process.env,
+			async () => {},
 		);
 		t.ok(!result.ok);
 		t.ok(result.reason);

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -1,7 +1,7 @@
 import {SystemLogger} from '../utils/log.js';
-import {cyan, magenta, red} from '../colors/terminal.js';
+import {cyan, magenta, red, gray} from '../colors/terminal.js';
 import {TaskModuleMeta} from './taskModule.js';
-import {Args, Env} from '../cli/types.js';
+import {Args} from '../cli/types.js';
 import {TaskError} from './task.js';
 
 export type RunTaskResult =
@@ -18,14 +18,14 @@ export type RunTaskResult =
 export const runTask = async (
 	task: TaskModuleMeta,
 	args: Args,
-	env: Env,
+	invokeTask: (taskName: string, args: Args) => Promise<void>,
 ): Promise<RunTaskResult> => {
 	let output;
 	try {
 		output = await task.mod.task.run({
 			args,
-			env,
-			log: new SystemLogger([magenta(`[task:${cyan(task.name)}]`)]),
+			log: new SystemLogger([`${gray('[')}${magenta(task.name)}${gray(':log')}${gray(']')}`]),
+			invokeTask: (invokedTaskName, invokedArgs = args) => invokeTask(invokedTaskName, invokedArgs),
 		});
 	} catch (err) {
 		return {

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -1,15 +1,15 @@
 import {Logger} from '../utils/log.js';
-import {Args, Env} from '../cli/types.js';
+import {Args} from '../cli/types.js';
 
-export interface Task<T = unknown> {
-	run: (ctx: TaskContext) => Promise<T>;
+export interface Task {
+	run: (ctx: TaskContext) => Promise<unknown>;
 	description?: string;
 }
 
 export interface TaskContext {
 	log: Logger;
 	args: Args;
-	env: Env;
+	invokeTask: (taskName: string, args?: Args) => Promise<void>;
 }
 
 export const TASK_FILE_PATTERN = /\.task\.ts$/;


### PR DESCRIPTION
This adds the `invokeTask` helper to compose tasks. It's now the preferred way to run tasks within other tasks. See [`src/task/README.md`](https://github.com/feltcoop/gro/compare/invoke-task?expand=1#diff-ebdf9b0ad317ea3f4bc6180e382d4bc4) for the new documentation.

The motivating use case was that the builtin check task did not account for the user overriding any of its sub tasks. Directly importing and running tasks from within builtin tasks is usually not what we want. For end users, it matters less, but they probably want to prefer `invokeTask` over explicit task imports because it provides good logging and diagnostics. The docs linked above go into more detail.

It might look like there are a lot of changes but there's not much to it, helped by the fact that the code was already well-factored. Extracting [`src/task/invokeTask.ts`](https://github.com/feltcoop/gro/compare/invoke-task?expand=1#diff-3a70e6f1e41c66098ba1a5f75e573d8e) is the biggest piece and it's almost identical to the original.