### PR TITLE
add --version and -v CLI flags to print the Gro version

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ gro serve # staticly serves the current directory (or a configured one)
 ```
 
 ```bash
+gro --version # or `-v` - print the Gro version
+```
+
+```bash
 gro check # typechecks, runs tests, and ensures generated files are current
 gro typecheck # just the typechecking
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ gro serve # staticly serves the current directory (or a configured one)
 ```
 
 ```bash
-gro --version # or `-v` - print the Gro version
+gro --version # or `-v` prints the Gro version
 ```
 
 ```bash

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - add the `invokeTask` helper for task composition
   ([#20](https://github.com/feltcoop/gro/pull/20))
+- add CLI flags to print the Gro version with `--version` or `-v`
+  ([#21](https://github.com/feltcoop/gro/pull/21))
 
 ## 0.1.11
 

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -22,6 +22,7 @@ import {findFiles, pathExists} from '../fs/nodeFs.js';
 import {plural} from '../utils/string.js';
 import {loadTaskModule} from './taskModule.js';
 import {PathData} from '../fs/pathData.js';
+import {getGroPackageJson} from '../project/pkg.js';
 
 /*
 
@@ -45,6 +46,13 @@ The comments describe each condition.
 
 export const invokeTask = async (taskName: string, args: Args): Promise<void> => {
 	const log = new SystemLogger([`${gray('[')}${magenta(taskName)}${gray(']')}`]);
+
+	// Check if the caller just wants to see the version.
+	if (!taskName && (args.version || args.v)) {
+		const groPackageJson = await getGroPackageJson();
+		log.info(`${gray('v')}${cyan(groPackageJson.version as string)}`);
+		return;
+	}
 
 	const timings = new Timings<'total'>();
 	timings.start('total');


### PR DESCRIPTION
This makes `gro --version` and `gro -v` just print the Gro version. We don't yet support sophisticated CLI flag processing so it's low tech. Currently we just leave everything to the individual tasks but that will probably change in the future.