### PR TITLE
improve type safety for assertions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.1.13
+
+- change assertions `t.is` and `t.equal` to use a shared generic type for extra safety
+  ([#22](https://github.com/feltcoop/gro/pull/22))
+
 ## 0.1.12
 
 - add the `invokeTask` helper for task composition

--- a/src/oki/assertions.ts
+++ b/src/oki/assertions.ts
@@ -13,7 +13,7 @@ export const ok: (value: any) => asserts value = (value) => {
 	}
 };
 
-export const is = (actual: any, expected: any): void => {
+export const is = <T>(actual: T, expected: T): void => {
 	if (!Object.is(actual, expected)) {
 		throw new AssertionError({operator: AssertionOperator.is, actual, expected});
 	}
@@ -25,7 +25,7 @@ export const isNot = (actual: any, expected: any): void => {
 	}
 };
 
-export const equal = (actual: any, expected: any): void => {
+export const equal = <T>(actual: T, expected: T): void => {
 	if (!deepEqual(actual, expected)) {
 		throw new AssertionError({operator: AssertionOperator.equal, actual, expected});
 	}

--- a/src/utils/object.test.ts
+++ b/src/utils/object.test.ts
@@ -41,7 +41,7 @@ test('omitUndefined', () => {
 	t.equal(omitUndefined({a: 1, b: undefined, c: undefined}), {a: 1});
 	t.equal(omitUndefined({a: undefined, b: 2, c: undefined}), {b: 2});
 	t.equal(omitUndefined({a: 1, b: 2}), {a: 1, b: 2});
-	t.equal(omitUndefined({a: undefined, b: undefined}), {});
+	t.equal(omitUndefined({a: undefined, b: undefined}), {} as any);
 	t.equal(omitUndefined({}), {});
 });
 


### PR DESCRIPTION
This is a small change that adds a bit of type safety to Gro's assertions. It makes `t.is` and `t.equal` share a generic type so incompatible types will surface an error.

Occasionally it'll have a false positive that can be trivially fixed with a cast to `any`, [as is needed here](https://github.com/feltcoop/gro/compare/improve-assertions-types?expand=1#diff-670184333154c7b9a93145aba7ea382dR44).