### PR TITLE
add primitive type helpers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.2.1
+
+- add type helpers `Branded` and `Flavored` for nominal-ish typing
+  ([#23](https://github.com/feltcoop/gro/pull/23))
+
 ## 0.2.0
 
 - **breaking:** upgrade `kleur` dep and remove color wrappers

--- a/src/globalTypes.ts
+++ b/src/globalTypes.ts
@@ -23,3 +23,36 @@ declare type PartialOnly<T, K extends keyof T> = {[P in K]?: T[P]} &
 declare type PartialValues<T> = {
 	[P in keyof T]: Partial<T[P]>;
 };
+
+/*
+
+The `Flavored` and `Branded` type helpers add varying degrees of nominal typing to other types.
+This is especially useful with primitives like strings and numbers.
+
+```ts
+type PhoneNumber = Branded<string, 'PhoneNumber'>;
+const phone1: PhoneNumber = 'foo'; // error!
+const phone2: PhoneNumber = 'foo' as PhoneNumber; // ok
+```
+
+`Flavored` is a looser form of `Branded` that trades safety for ergonomics.
+With `Flavored` you don't need to cast unflavored types:
+
+```ts
+type Email = Flavored<string, 'Email'>;
+const email1: Email = 'foo'; // ok
+type Address = Flavored<string, 'Address'>;
+const email2: Email = 'foo' as Address; // error!
+```
+
+*/
+declare type Branded<TValue, TName> = TValue & Brand<TName>;
+declare type Flavored<TValue, TName> = TValue & Flavor<TName>;
+declare interface Brand<T> {
+	readonly [BrandedSymbol]: T;
+}
+declare interface Flavor<T> {
+	readonly [FlavoredSymbol]?: T;
+}
+declare const BrandedSymbol: unique symbol;
+declare const FlavoredSymbol: unique symbol;


### PR DESCRIPTION
This adds a couple of primitive type helpers that we'll try to use in Felt. This pattern is often called "branding" among TypeScript developers. I want to think about the names a bit more. `Primitive` might be the wrong way to think about them, since you could technically brand any type. Maybe `Nominal` and `StrictNominal`? Or `Brand` and `StrictBrand`? Or reverse them and use "Loose"? I've also seen the optional kind named `Flavor`, so `Brand` would be strict.