### PR TITLE
fix .js module resolution in the Rollup TypeScript plugin

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - change assertions `t.is` and `t.equal` to use a shared generic type for extra safety
   ([#22](https://github.com/feltcoop/gro/pull/22))
+- fix .js module resolution in the Rollup TypeScript plugin
+  ([#24](https://github.com/feltcoop/gro/pull/24))
 
 ## 0.1.12
 


### PR DESCRIPTION
This fixes JS module resolution in the TypeScript plugin. Previously we were importing `.ts` files directly [which will hopefully be supported by TypeScript soonish](https://github.com/microsoft/TypeScript/issues/38149), but isn't right now.