### PR TITLE
fix js module resolution for external paths in typescript plugin

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,16 @@
 # Gro changelog
 
+## 0.1.14
+
+- correctly fix `.js` module resolution where
+  [#24](https://github.com/feltcoop/gro/pull/24) failed
+  ([#25](https://github.com/feltcoop/gro/pull/25))
+
 ## 0.1.13
 
 - change assertions `t.is` and `t.equal` to use a shared generic type for extra safety
   ([#22](https://github.com/feltcoop/gro/pull/22))
-- fix .js module resolution in the Rollup TypeScript plugin
+- fix `.js` module resolution in the Rollup TypeScript plugin
   ([#24](https://github.com/feltcoop/gro/pull/24))
 
 ## 0.1.12

--- a/src/project/rollup-plugin-gro-typescript.ts
+++ b/src/project/rollup-plugin-gro-typescript.ts
@@ -70,7 +70,9 @@ export const groTypescriptPlugin = (opts: InitialOptions = {}): Plugin => {
 			// TypeScript doesn't allow importing `.ts` files right now.
 			// See https://github.com/microsoft/TypeScript/issues/38149
 			// This ensures that `.js` files are imported correctly from TypeScript.
-			if (importer && importee.endsWith('.js')) {
+			// Note that detection of the relative `importee` does not strictly follow conventions
+			// by allowing dot-free relative paths - this is an acceptable limitation for now.
+			if (importer && importee.endsWith('.js') && importee.startsWith('.')) {
 				const resolvedPath = resolve(importer, '../', importee);
 				if (isSourceId(resolvedPath)) {
 					return toSourceExt(resolvedPath);


### PR DESCRIPTION
This fixes Node module resolution that #24 missed. See the added comments for more.