### PR TITLE
 upgrade kleur and remove color wrappers 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.1.15
+
+- upgrade `kleur` dep and remove color wrappers
+  [#26](https://github.com/feltcoop/gro/pull/26)
+
 ## 0.1.14
 
 - correctly fix `.js` module resolution where

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,8 @@
 # Gro changelog
 
-## 0.1.15
+## 0.2.0
 
-- upgrade `kleur` dep and remove color wrappers
+- **breaking:** upgrade `kleur` dep and remove color wrappers
   [#26](https://github.com/feltcoop/gro/pull/26)
 
 ## 0.1.14

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,9 +152,9 @@
       }
     },
     "kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.0.0.tgz",
+      "integrity": "sha512-D8qk4wvB8ofBeLAsRNwnCkjbwdrcKYsMC/56pFQMOSfmmYJkG1O9/oBgXzD05K7biYAwnHjMI2abZ3YiuMY0Pg=="
     },
     "magic-string": {
       "version": "0.25.7",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/source-map-support": "^0.5.1",
     "cheap-watch": "^1.0.2",
     "fs-extra": "^9.0.0",
-    "kleur": "^3.0.3",
+    "kleur": "^4.0.0",
     "mri": "^1.1.5",
     "rollup-plugin-commonjs": "^10.1.0",
     "source-map-support": "^0.5.16",

--- a/src/colors/terminal.ts
+++ b/src/colors/terminal.ts
@@ -1,46 +1,8 @@
-import kleur from 'kleur';
+import {red, yellow, green, cyan, blue, magenta} from 'kleur/colors';
 
-// TODO esm
-// we're re-exporting `kleur` only because node ES modules don't support named exports yet - change when they're ready!
-// see https://nodejs.org/api/esm.html
-
-// colors
-export const red = kleur.red;
-export const yellow = kleur.yellow;
-export const green = kleur.green;
-export const cyan = kleur.cyan;
-export const blue = kleur.blue;
-export const magenta = kleur.magenta;
-export const white = kleur.white;
-export const gray = kleur.gray;
-export const black = kleur.black;
-
-// backgrounds
-export const bgRed = kleur.bgRed;
-export const bgYellow = kleur.bgYellow;
-export const bgGreen = kleur.bgGreen;
-export const bgCyan = kleur.bgCyan;
-export const bgBlue = kleur.bgBlue;
-export const bgMagenta = kleur.bgMagenta;
-export const bgWhite = kleur.bgWhite;
-export const bgBlack = kleur.bgBlack;
-
-// modifiers
-export const reset = kleur.reset;
-export const bold = kleur.bold;
-export const dim = kleur.dim;
-export const italic = kleur.italic;
-export const underline = kleur.underline;
-export const inverse = kleur.inverse;
-export const hidden = kleur.hidden;
-export const strikethrough = kleur.strikethrough;
-
-// custom stuff
-
-export const colors = [red, yellow, green, cyan, blue, magenta];
+const rainbowColors = [red, yellow, green, cyan, blue, magenta];
 
 export const rainbow = (str: string): string =>
-	str
-		.split('')
-		.map((char, i) => colors[i % colors.length](char))
+	Array.from(str)
+		.map((char, i) => rainbowColors[i % rainbowColors.length](char))
 		.join('');

--- a/src/devServer/devServer.ts
+++ b/src/devServer/devServer.ts
@@ -9,8 +9,8 @@ import {
 } from 'http';
 import {ListenOptions} from 'net';
 import {resolve} from 'path';
+import {cyan, yellow, gray} from 'kleur/colors';
 
-import {cyan, yellow, gray} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {stripAfter} from '../utils/string.js';
 import {loadFile, getMimeType, File} from '../fs/nodeFile.js';

--- a/src/fs/modules.ts
+++ b/src/fs/modules.ts
@@ -1,5 +1,6 @@
+import {red} from 'kleur/colors';
+
 import {pathExists, stat} from './nodeFs.js';
-import {red} from '../colors/terminal.js';
 import {printPath, printError, printPathOrGroPath} from '../utils/print.js';
 import {loadSourcePathDataByInputPath, loadSourceIdsByInputPath} from '../fs/inputPath.js';
 import {Timings} from '../utils/time.js';

--- a/src/gen.task.ts
+++ b/src/gen.task.ts
@@ -1,6 +1,7 @@
+import {red, green, gray} from 'kleur/colors';
+
 import {outputFile} from './fs/nodeFs.js';
 import {Task, TaskError} from './task/task.js';
-import {red, green, gray} from './colors/terminal.js';
 import {runGen} from './gen/runGen.js';
 import {loadGenModule, checkGenModules, findGenModules} from './gen/genModule.js';
 import {printPath, printMs, printError, printSubTiming} from './utils/print.js';

--- a/src/gen/runGen.ts
+++ b/src/gen/runGen.ts
@@ -1,3 +1,5 @@
+import {red} from 'kleur/colors';
+
 import {GenModuleMeta} from './genModule.js';
 import {
 	GenResults,
@@ -9,7 +11,6 @@ import {
 } from './gen.js';
 import {printPath} from '../utils/print.js';
 import {Timings} from '../utils/time.js';
-import {red} from '../colors/terminal.js';
 
 export const runGen = async (
 	genModules: GenModuleMeta[],

--- a/src/oki/TestContext.ts
+++ b/src/oki/TestContext.ts
@@ -1,4 +1,5 @@
-import {cyan} from '../colors/terminal.js';
+import {cyan} from 'kleur/colors';
+
 import {Logger, LogLevel, SystemLogger} from '../utils/log.js';
 import {AsyncState} from '../utils/async.js';
 import {omitUndefined} from '../utils/object.js';

--- a/src/oki/report.ts
+++ b/src/oki/report.ts
@@ -1,4 +1,5 @@
-import {green, red, bgGreen, black, yellow, gray, cyan} from '../colors/terminal.js';
+import {green, red, bgGreen, black, yellow, gray, cyan} from 'kleur/colors';
+
 import {TestContext, TOTAL_TIMING, TestInstance} from './TestContext.js';
 import {printMs, printValue, printStr, printError} from '../utils/print.js';
 import {toSourcePath} from '../paths.js';

--- a/src/project/assets.ts
+++ b/src/project/assets.ts
@@ -1,8 +1,8 @@
 import {join} from 'path';
+import {magenta} from 'kleur/colors';
 
 import {copy} from '../fs/nodeFs.js';
 import {SystemLogger, Logger} from '../utils/log.js';
-import {magenta} from '../colors/terminal.js';
 import {omitUndefined} from '../utils/object.js';
 import {findFiles} from '../fs/nodeFs.js';
 import {paths, toDistId, SOURCE_DIR_NAME, BUILD_DIR_NAME, SOURCE_DIR, BUILD_DIR} from '../paths.js';

--- a/src/project/build.ts
+++ b/src/project/build.ts
@@ -10,8 +10,9 @@ import {
 import resolvePlugin from '@rollup/plugin-node-resolve';
 import commonjsPlugin from 'rollup-plugin-commonjs';
 import {resolve} from 'path';
+import {magenta} from 'kleur/colors';
 
-import {magenta, rainbow} from '../colors/terminal.js';
+import {rainbow} from '../colors/terminal.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {diagnosticsPlugin} from './rollup-plugin-diagnostics.js';
 import {deindent} from '../utils/string.js';

--- a/src/project/cssCache.ts
+++ b/src/project/cssCache.ts
@@ -1,4 +1,5 @@
-import {green} from '../colors/terminal.js';
+import {green} from 'kleur/colors';
+
 import {SystemLogger} from '../utils/log.js';
 import {printKeyValue, printPath} from '../utils/print.js';
 

--- a/src/project/fileCache.ts
+++ b/src/project/fileCache.ts
@@ -1,4 +1,5 @@
-import {green} from '../colors/terminal.js';
+import {green} from 'kleur/colors';
+
 import {SystemLogger} from '../utils/log.js';
 import {omitUndefined} from '../utils/object.js';
 import {PathData} from '../fs/pathData.js';

--- a/src/project/globalTypes.d.ts
+++ b/src/project/globalTypes.d.ts
@@ -1,1 +1,41 @@
 declare module 'mri';
+
+declare module 'kleur/colors' {
+	type Colorize = (s: unknown) => string;
+
+	export const $: {
+		enabled: boolean;
+	};
+
+	// modifiers
+	export const reset: Colorize;
+	export const bold: Colorize;
+	export const dim: Colorize;
+	export const italic: Colorize;
+	export const underline: Colorize;
+	export const inverse: Colorize;
+	export const hidden: Colorize;
+	export const strikethrough: Colorize;
+
+	// colors
+	export const black: Colorize;
+	export const red: Colorize;
+	export const green: Colorize;
+	export const yellow: Colorize;
+	export const blue: Colorize;
+	export const magenta: Colorize;
+	export const cyan: Colorize;
+	export const white: Colorize;
+	export const gray: Colorize;
+	export const grey: Colorize;
+
+	// background colors
+	export const bgBlack: Colorize;
+	export const bgRed: Colorize;
+	export const bgGreen: Colorize;
+	export const bgYellow: Colorize;
+	export const bgBlue: Colorize;
+	export const bgMagenta: Colorize;
+	export const bgCyan: Colorize;
+	export const bgWhite: Colorize;
+}

--- a/src/project/rollup-plugin-diagnostics.ts
+++ b/src/project/rollup-plugin-diagnostics.ts
@@ -1,6 +1,6 @@
 import {Plugin} from 'rollup';
+import {gray} from 'kleur/colors';
 
-import {gray} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';
 import {createStopwatch} from '../utils/time.js';

--- a/src/project/rollup-plugin-gro-json.ts
+++ b/src/project/rollup-plugin-gro-json.ts
@@ -1,8 +1,8 @@
 import {Plugin} from 'rollup';
 import rollupPluginutils from '@rollup/pluginutils';
 const {createFilter, dataToEsm} = rollupPluginutils; // TODO esm
+import {magenta} from 'kleur/colors';
 
-import {magenta} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 import {omitUndefined} from '../utils/object.js';

--- a/src/project/rollup-plugin-gro-svelte.ts
+++ b/src/project/rollup-plugin-gro-svelte.ts
@@ -4,8 +4,8 @@ import {CompileOptions, Warning} from 'svelte/types/compiler/interfaces';
 import {Plugin, PluginContext, ExistingRawSourceMap} from 'rollup';
 import rollupPluginutils from '@rollup/pluginutils';
 const {createFilter} = rollupPluginutils; // TODO esm
+import {magenta, yellow, red} from 'kleur/colors';
 
-import {magenta, yellow, red} from '../colors/terminal.js';
 import {getPathStem, replaceExt} from '../utils/path.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';

--- a/src/project/rollup-plugin-gro-terser.ts
+++ b/src/project/rollup-plugin-gro-terser.ts
@@ -2,8 +2,8 @@ import terser from 'terser';
 import {Plugin} from 'rollup';
 import rollupPluginutils from '@rollup/pluginutils';
 const {createFilter} = rollupPluginutils; // TODO esm
+import {magenta} from 'kleur/colors';
 
-import {magenta} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 import {omitUndefined} from '../utils/object.js';

--- a/src/project/rollup-plugin-gro-typescript.ts
+++ b/src/project/rollup-plugin-gro-typescript.ts
@@ -3,8 +3,8 @@ import {Plugin, PluginContext} from 'rollup';
 import {resolve} from 'path';
 import rollupPluginutils from '@rollup/pluginutils';
 const {createFilter} = rollupPluginutils; // TODO esm
+import {magenta, red} from 'kleur/colors';
 
-import {magenta, red} from '../colors/terminal.js';
 import {createStopwatch} from '../utils/time.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';

--- a/src/project/rollup-plugin-output-css.ts
+++ b/src/project/rollup-plugin-output-css.ts
@@ -1,9 +1,9 @@
 import {Plugin} from 'rollup';
 import {dirname, join, relative} from 'path';
 import sourcemapCodec from 'sourcemap-codec';
+import {blue, gray} from 'kleur/colors';
 
 import {outputFile} from '../fs/nodeFs.js';
-import {blue, gray} from '../colors/terminal.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {GroCssBuild, GroCssBundle} from './types.js';
 import {omitUndefined} from '../utils/object.js';

--- a/src/project/rollup-plugin-plain-css.ts
+++ b/src/project/rollup-plugin-plain-css.ts
@@ -3,8 +3,8 @@ import {resolve, dirname} from 'path';
 import {existsSync} from 'fs';
 import rollupPluginutils from '@rollup/pluginutils';
 const {createFilter} = rollupPluginutils; // TODO esm
+import {green} from 'kleur/colors';
 
-import {green} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {GroCssBuild} from './types.js';
 import {hasExt} from '../utils/path.js';

--- a/src/project/svelte-preprocess-typescript.ts
+++ b/src/project/svelte-preprocess-typescript.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import {PreprocessorGroup} from 'svelte/types/compiler/preprocess';
+import {magenta, red} from 'kleur/colors';
 
-import {magenta, red} from '../colors/terminal.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {loadTsconfig} from './tsHelpers.js';
 import {printPath} from '../utils/print.js';

--- a/src/project/tsHelpers.ts
+++ b/src/project/tsHelpers.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import {dirname} from 'path';
+import {black, bgRed} from 'kleur/colors';
 
-import {black, bgRed} from '../colors/terminal.js';
 import {Logger} from '../utils/log.js';
 
 // confusingly, TypeScript doesn't seem to be a good type for this

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -1,8 +1,8 @@
-import {spawnProcess} from '../utils/process.js';
+import {magenta, cyan, red, gray} from 'kleur/colors';
 
+import {spawnProcess} from '../utils/process.js';
 import {Args} from '../cli/types';
 import {SystemLogger, Logger} from '../utils/log.js';
-import {magenta, cyan, red, gray} from '../colors/terminal.js';
 import {runTask} from './runTask.js';
 import {Timings} from '../utils/time.js';
 import {printMs, printPath, printPathOrGroPath, printSubTiming} from '../utils/print.js';

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -1,5 +1,6 @@
+import {cyan, magenta, red, gray} from 'kleur/colors';
+
 import {SystemLogger} from '../utils/log.js';
-import {cyan, magenta, red, gray} from '../colors/terminal.js';
 import {TaskModuleMeta} from './taskModule.js';
 import {Args} from '../cli/types.js';
 import {TaskError} from './task.js';

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,4 +1,5 @@
-import {red, yellow, gray, black, bgYellow, bgRed} from '../colors/terminal.js';
+import {red, yellow, gray, black, bgYellow, bgRed} from 'kleur/colors';
+
 import {EMPTY_ARRAY} from './array.js';
 
 // TODO track warnings/errors (or anything above a certain threshold)

--- a/src/utils/print.ts
+++ b/src/utils/print.ts
@@ -1,5 +1,6 @@
+import {gray, white, green, yellow} from 'kleur/colors';
+
 import {round} from '../utils/math.js';
-import {gray, white, green, yellow} from '../colors/terminal.js';
 import {paths, toRootPath, groDirBasename, pathsFromId, groPaths} from '../paths.js';
 import {truncate} from './string.js';
 

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,6 +1,6 @@
 import {spawn, SpawnOptions} from 'child_process';
+import {red} from 'kleur/colors';
 
-import {red} from '../colors/terminal.js';
 import {SystemLogger} from './log.js';
 import {printError} from './print.js';
 


### PR DESCRIPTION
This upgrades the `kleur` dependency to v4 which now provides ES modules. We can remove our wrapper code and import from `kleur/colors` directly now. It's a breaking change so it bumps Gro to v0.2.0. I was on the fence about supporting fancy RGBA colors later on, like via Chalk, but that's such a low priority and this keeps things simple and fast.