### PR TITLE
export kleur colors for external usage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.2.2
+
+- export `kleur/colors` from `src/colors/terminal.js`
+  ([#27](https://github.com/feltcoop/gro/pull/27))
+
 ## 0.2.1
 
 - add type helpers `Branded` and `Flavored` for nominal-ish typing

--- a/src/colors/terminal.ts
+++ b/src/colors/terminal.ts
@@ -1,5 +1,7 @@
 import {red, yellow, green, cyan, blue, magenta} from 'kleur/colors';
 
+export * from 'kleur/colors';
+
 const rainbowColors = [red, yellow, green, cyan, blue, magenta];
 
 export const rainbow = (str: string): string =>

--- a/src/devServer/devServer.ts
+++ b/src/devServer/devServer.ts
@@ -9,8 +9,8 @@ import {
 } from 'http';
 import {ListenOptions} from 'net';
 import {resolve} from 'path';
-import {cyan, yellow, gray} from 'kleur/colors';
 
+import {cyan, yellow, gray} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {stripAfter} from '../utils/string.js';
 import {loadFile, getMimeType, File} from '../fs/nodeFile.js';

--- a/src/fs/modules.ts
+++ b/src/fs/modules.ts
@@ -1,5 +1,4 @@
-import {red} from 'kleur/colors';
-
+import {red} from '../colors/terminal.js';
 import {pathExists, stat} from './nodeFs.js';
 import {printPath, printError, printPathOrGroPath} from '../utils/print.js';
 import {loadSourcePathDataByInputPath, loadSourceIdsByInputPath} from '../fs/inputPath.js';

--- a/src/gen.task.ts
+++ b/src/gen.task.ts
@@ -1,5 +1,4 @@
-import {red, green, gray} from 'kleur/colors';
-
+import {red, green, gray} from './colors/terminal.js';
 import {outputFile} from './fs/nodeFs.js';
 import {Task, TaskError} from './task/task.js';
 import {runGen} from './gen/runGen.js';

--- a/src/gen/runGen.ts
+++ b/src/gen/runGen.ts
@@ -1,5 +1,4 @@
-import {red} from 'kleur/colors';
-
+import {red} from '../colors/terminal.js';
 import {GenModuleMeta} from './genModule.js';
 import {
 	GenResults,

--- a/src/oki/TestContext.ts
+++ b/src/oki/TestContext.ts
@@ -1,5 +1,4 @@
-import {cyan} from 'kleur/colors';
-
+import {cyan} from '../colors/terminal.js';
 import {Logger, LogLevel, SystemLogger} from '../utils/log.js';
 import {AsyncState} from '../utils/async.js';
 import {omitUndefined} from '../utils/object.js';

--- a/src/oki/report.ts
+++ b/src/oki/report.ts
@@ -1,5 +1,4 @@
-import {green, red, bgGreen, black, yellow, gray, cyan} from 'kleur/colors';
-
+import {green, red, bgGreen, black, yellow, gray, cyan} from '../colors/terminal.js';
 import {TestContext, TOTAL_TIMING, TestInstance} from './TestContext.js';
 import {printMs, printValue, printStr, printError} from '../utils/print.js';
 import {toSourcePath} from '../paths.js';

--- a/src/project/assets.ts
+++ b/src/project/assets.ts
@@ -1,6 +1,6 @@
 import {join} from 'path';
-import {magenta} from 'kleur/colors';
 
+import {magenta} from '../colors/terminal.js';
 import {copy} from '../fs/nodeFs.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {omitUndefined} from '../utils/object.js';

--- a/src/project/build.ts
+++ b/src/project/build.ts
@@ -10,8 +10,8 @@ import {
 import resolvePlugin from '@rollup/plugin-node-resolve';
 import commonjsPlugin from 'rollup-plugin-commonjs';
 import {resolve} from 'path';
-import {magenta} from 'kleur/colors';
 
+import {magenta} from '../colors/terminal.js';
 import {rainbow} from '../colors/terminal.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {diagnosticsPlugin} from './rollup-plugin-diagnostics.js';

--- a/src/project/cssCache.ts
+++ b/src/project/cssCache.ts
@@ -1,5 +1,4 @@
-import {green} from 'kleur/colors';
-
+import {green} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {printKeyValue, printPath} from '../utils/print.js';
 

--- a/src/project/fileCache.ts
+++ b/src/project/fileCache.ts
@@ -1,5 +1,4 @@
-import {green} from 'kleur/colors';
-
+import {green} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {omitUndefined} from '../utils/object.js';
 import {PathData} from '../fs/pathData.js';

--- a/src/project/rollup-plugin-diagnostics.ts
+++ b/src/project/rollup-plugin-diagnostics.ts
@@ -1,6 +1,6 @@
 import {Plugin} from 'rollup';
-import {gray} from 'kleur/colors';
 
+import {gray} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';
 import {createStopwatch} from '../utils/time.js';

--- a/src/project/rollup-plugin-gro-json.ts
+++ b/src/project/rollup-plugin-gro-json.ts
@@ -1,8 +1,8 @@
 import {Plugin} from 'rollup';
 import rollupPluginutils from '@rollup/pluginutils';
 const {createFilter, dataToEsm} = rollupPluginutils; // TODO esm
-import {magenta} from 'kleur/colors';
 
+import {magenta} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 import {omitUndefined} from '../utils/object.js';

--- a/src/project/rollup-plugin-gro-svelte.ts
+++ b/src/project/rollup-plugin-gro-svelte.ts
@@ -4,8 +4,8 @@ import {CompileOptions, Warning} from 'svelte/types/compiler/interfaces';
 import {Plugin, PluginContext, ExistingRawSourceMap} from 'rollup';
 import rollupPluginutils from '@rollup/pluginutils';
 const {createFilter} = rollupPluginutils; // TODO esm
-import {magenta, yellow, red} from 'kleur/colors';
 
+import {magenta, yellow, red} from '../colors/terminal.js';
 import {getPathStem, replaceExt} from '../utils/path.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';

--- a/src/project/rollup-plugin-gro-terser.ts
+++ b/src/project/rollup-plugin-gro-terser.ts
@@ -2,8 +2,8 @@ import terser from 'terser';
 import {Plugin} from 'rollup';
 import rollupPluginutils from '@rollup/pluginutils';
 const {createFilter} = rollupPluginutils; // TODO esm
-import {magenta} from 'kleur/colors';
 
+import {magenta} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 import {omitUndefined} from '../utils/object.js';

--- a/src/project/rollup-plugin-gro-typescript.ts
+++ b/src/project/rollup-plugin-gro-typescript.ts
@@ -3,8 +3,8 @@ import {Plugin, PluginContext} from 'rollup';
 import {resolve} from 'path';
 import rollupPluginutils from '@rollup/pluginutils';
 const {createFilter} = rollupPluginutils; // TODO esm
-import {magenta, red} from 'kleur/colors';
 
+import {magenta, red} from '../colors/terminal.js';
 import {createStopwatch} from '../utils/time.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';

--- a/src/project/rollup-plugin-output-css.ts
+++ b/src/project/rollup-plugin-output-css.ts
@@ -1,8 +1,8 @@
 import {Plugin} from 'rollup';
 import {dirname, join, relative} from 'path';
 import sourcemapCodec from 'sourcemap-codec';
-import {blue, gray} from 'kleur/colors';
 
+import {blue, gray} from '../colors/terminal.js';
 import {outputFile} from '../fs/nodeFs.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {GroCssBuild, GroCssBundle} from './types.js';

--- a/src/project/rollup-plugin-plain-css.ts
+++ b/src/project/rollup-plugin-plain-css.ts
@@ -3,8 +3,8 @@ import {resolve, dirname} from 'path';
 import {existsSync} from 'fs';
 import rollupPluginutils from '@rollup/pluginutils';
 const {createFilter} = rollupPluginutils; // TODO esm
-import {green} from 'kleur/colors';
 
+import {green} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {GroCssBuild} from './types.js';
 import {hasExt} from '../utils/path.js';

--- a/src/project/svelte-preprocess-typescript.ts
+++ b/src/project/svelte-preprocess-typescript.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import {PreprocessorGroup} from 'svelte/types/compiler/preprocess';
-import {magenta, red} from 'kleur/colors';
 
+import {magenta, red} from '../colors/terminal.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {loadTsconfig} from './tsHelpers.js';
 import {printPath} from '../utils/print.js';

--- a/src/project/tsHelpers.ts
+++ b/src/project/tsHelpers.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import {dirname} from 'path';
-import {black, bgRed} from 'kleur/colors';
 
+import {black, bgRed} from '../colors/terminal.js';
 import {Logger} from '../utils/log.js';
 
 // confusingly, TypeScript doesn't seem to be a good type for this

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -1,5 +1,4 @@
-import {magenta, cyan, red, gray} from 'kleur/colors';
-
+import {magenta, cyan, red, gray} from '../colors/terminal.js';
 import {spawnProcess} from '../utils/process.js';
 import {Args} from '../cli/types';
 import {SystemLogger, Logger} from '../utils/log.js';

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -1,5 +1,4 @@
-import {cyan, magenta, red, gray} from 'kleur/colors';
-
+import {cyan, magenta, red, gray} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {TaskModuleMeta} from './taskModule.js';
 import {Args} from '../cli/types.js';

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,5 +1,4 @@
-import {red, yellow, gray, black, bgYellow, bgRed} from 'kleur/colors';
-
+import {red, yellow, gray, black, bgYellow, bgRed} from '../colors/terminal.js';
 import {EMPTY_ARRAY} from './array.js';
 
 // TODO track warnings/errors (or anything above a certain threshold)

--- a/src/utils/print.ts
+++ b/src/utils/print.ts
@@ -1,5 +1,4 @@
-import {gray, white, green, yellow} from 'kleur/colors';
-
+import {gray, white, green, yellow} from '../colors/terminal.js';
 import {round} from '../utils/math.js';
 import {paths, toRootPath, groDirBasename, pathsFromId, groPaths} from '../paths.js';
 import {truncate} from './string.js';

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,6 +1,6 @@
 import {spawn, SpawnOptions} from 'child_process';
-import {red} from 'kleur/colors';
 
+import {red} from '../colors/terminal.js';
 import {SystemLogger} from './log.js';
 import {printError} from './print.js';
 


### PR DESCRIPTION
This exports all of the `kleur/colors` module from `src/colors/terminal.js` so dependents don't need to add an extra dependency. It's common enough to want to use terminal colors in an app, and since Gro already includes `kleur` as a runtime dependency it makes sense to just re-export them.