### PR TITLE
add Result type helper

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.2.4
+
+- add `Result` type helper to `src/globalTypes.ts`
+  ([#29](https://github.com/feltcoop/gro/pull/29))
+
 ## 0.2.3
 
 - fix external module type declarations by merging

--- a/src/fs/modules.ts
+++ b/src/fs/modules.ts
@@ -22,7 +22,7 @@ export interface ModuleMeta<ModuleType = Obj> {
 	mod: ModuleType;
 }
 
-export type LoadModuleResult<T> = {ok: true; mod: T} | LoadModuleFailure;
+export type LoadModuleResult<T> = Result<{mod: T}, LoadModuleFailure>;
 export type LoadModuleFailure =
 	| {ok: false; type: 'importFailed'; id: string; error: Error}
 	| {ok: false; type: 'invalid'; id: string; mod: Obj; validation: string};
@@ -43,46 +43,42 @@ export const loadModule = async <T>(
 	return {ok: true, mod: {id, mod}};
 };
 
-export type FindModulesResult = FindModulesSuccess | FindModulesFailure;
-export type FindModulesSuccess = {
-	ok: true;
-	sourceIdsByInputPath: Map<string, string[]>;
-	sourceIdPathDataByInputPath: Map<string, PathData>;
-	timings: Timings<FindModulesTimings>;
-};
-export type FindModulesFailure =
+export type FindModulesResult = Result<
+	{
+		sourceIdsByInputPath: Map<string, string[]>;
+		sourceIdPathDataByInputPath: Map<string, PathData>;
+		timings: Timings<FindModulesTimings>;
+	},
 	| {
-			ok: false;
 			type: 'unmappedInputPaths';
 			sourceIdPathDataByInputPath: Map<string, PathData>;
 			unmappedInputPaths: string[];
 			reasons: string[];
 	  }
 	| {
-			ok: false;
 			type: 'inputDirectoriesWithNoFiles';
 			sourceIdsByInputPath: Map<string, string[]>;
 			sourceIdPathDataByInputPath: Map<string, PathData>;
 			inputDirectoriesWithNoFiles: string[];
 			reasons: string[];
-	  };
+	  }
+>;
 type FindModulesTimings = 'map input paths' | 'find files';
 
-export type LoadModulesResult<ModuleMetaType extends ModuleMeta> =
-	| {
-			ok: true;
-			modules: ModuleMetaType[];
-			timings: Timings<LoadModulesTimings>;
-	  }
-	| {
-			ok: false;
-			type: 'loadModuleFailures';
-			loadModuleFailures: LoadModuleFailure[];
-			reasons: string[];
-			// still return the modules and timings, deferring to the caller
-			modules: ModuleMetaType[];
-			timings: Timings<LoadModulesTimings>;
-	  };
+export type LoadModulesResult<ModuleMetaType extends ModuleMeta> = Result<
+	{
+		modules: ModuleMetaType[];
+		timings: Timings<LoadModulesTimings>;
+	},
+	{
+		type: 'loadModuleFailures';
+		loadModuleFailures: LoadModuleFailure[];
+		reasons: string[];
+		// still return the modules and timings, deferring to the caller
+		modules: ModuleMetaType[];
+		timings: Timings<LoadModulesTimings>;
+	}
+>;
 type LoadModulesTimings = 'load modules';
 
 /*

--- a/src/globalTypes.ts
+++ b/src/globalTypes.ts
@@ -24,6 +24,8 @@ declare type PartialValues<T> = {
 	[P in keyof T]: Partial<T[P]>;
 };
 
+declare type Result<TValue = {}, TError = {}> = ({ok: true} & TValue) | ({ok: false} & TError);
+
 /*
 
 The `Flavored` and `Branded` type helpers add varying degrees of nominal typing to other types.

--- a/src/oki/TestContext.ts
+++ b/src/oki/TestContext.ts
@@ -31,14 +31,10 @@ export interface TestInstanceContext {
 	log: Logger;
 }
 
-export type TestResult = TestResultSuccess | TestResultFailure;
-export type TestResultSuccess = {
-	ok: true;
-};
-export type TestResultFailure = {
-	ok: false;
-	error: Error; // is an `AssertionError` or some runtime error
-};
+export type TestResult = Result<
+	{},
+	{error: Error} // is an `AssertionError` or some runtime error
+>;
 export interface TestStats {
 	passCount: number;
 	failCount: number;


### PR DESCRIPTION
This adds the `Result` type helper [discussed here for Felt](https://github.com/feltcoop/felt/pull/33#discussion_r451855156). It's simple and doesn't do much, but it formalizes a common pattern that I found myself duplicating a helper for in multiple projects.

I decided to err on the side of flexibility over a more rigid convention. This avoided needing to change any of Gro's functional code (only some type definitions changed), and I currently prefer its usage of `Result` values that are flat objects without nested `value`/`error` properties.

We can still use this type to write generic functions, but instead of always assuming a `value` or `error` property, it's flexible enough to work for any properties, so its functionality is a superset of option 4 described in the above link. Here's one possible generic function - the type signature is slightly more complex, but it's far more flexible this way:

```ts
export const unwrap = <T>(result: Result<{value: T}>) => {
	if (result.ok) return result.value;
	throw Error();
};
const unwrapped = unwrap({ok: true, value: 1}); // type of `unwrapped` is "number"
```
