### PR TITLE
add uuid utilities

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.2.6
+
+- add `uuid` utilities
+  ([#31](https://github.com/feltcoop/gro/pull/31))
+
 ## 0.2.5
 
 - add `randomFloat` utility

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@lukeed/uuid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-1.0.1.tgz",
+      "integrity": "sha512-shtopUGL/WuVicOTppRGDb2he9aGp+OF5EB11Xsbe3K4W6qN7HtK3F+ayNxcfbrG/SSL/Z9B+Xrb0Foz9x83gw=="
+    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
+    "@lukeed/uuid": "^1.0.1",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/pluginutils": "^3.0.10",
     "@types/fs-extra": "^8.1.0",

--- a/src/utils/uuid.test.ts
+++ b/src/utils/uuid.test.ts
@@ -1,0 +1,19 @@
+import {test, t} from '../oki/oki.js';
+import {uuid, isUuid} from './uuid.js';
+
+test('uuid()', () => {
+	t.ok(uuid());
+	t.is(uuid().length, 36);
+});
+
+test('isUuid()', () => {
+	t.ok(isUuid(uuid()));
+	t.ok(isUuid('f81d4fae-7dec-11d0-a765-00a0c91e6bf6'));
+	t.ok(!isUuid('g81d4fae-7dec-11d0-a765-00a0c91e6bf6'));
+	t.ok(!isUuid(''));
+	t.ok(!isUuid(null!));
+	t.ok(!isUuid(undefined!));
+
+	// See the implementation's comments for why the namespace syntax is not supported.
+	t.ok(!isUuid('urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6'));
+});

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,12 @@
+import _uuid from '@lukeed/uuid';
+
+export type Uuid = Flavored<string, 'Uuid'>;
+
+export const uuid: () => Uuid = _uuid;
+
+export const isUuid = (s: string): s is Uuid => uuidMatcher.test(s);
+
+// Postgres doesn't support the namespace prefix, so neither does Gro.
+// For more see the UUID RFC - https://tools.ietf.org/html/rfc4122
+// The Ajv validator does support the namespace, hence this custom implementation.
+export const uuidMatcher = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i;


### PR DESCRIPTION
This wraps `@lukeed/uuid` with a flavored type and validation function. It includes a comment explaining why we're not using the `ajv` UUID validation regexp. (`ajv` isn't yet added as a dependency, but it will be soon)