### PR TITLE
enable sourcemaps for build in development mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.2.7
+
+- enable sourcemaps for build in development mode
+  ([#32](https://github.com/feltcoop/gro/pull/32))
+
 ## 0.2.6
 
 - add `uuid` utilities

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.2.7
 
 - enable sourcemaps for build in development mode
-  ([#32](https://github.com/feltcoop/gro/pull/32))
+  ([#33](https://github.com/feltcoop/gro/pull/33))
 
 ## 0.2.6
 

--- a/src/project/build.ts
+++ b/src/project/build.ts
@@ -145,7 +145,7 @@ const createInputOptions = (inputFile: string, {dev}: Options, _log: Logger): In
 	return inputOptions;
 };
 
-const createOutputOptions = ({outputDir}: Options, log: Logger): OutputOptions => {
+const createOutputOptions = ({outputDir, dev}: Options, log: Logger): OutputOptions => {
 	const outputOptions: OutputOptions = {
 		// — core output options
 		dir: outputDir,
@@ -166,7 +166,7 @@ const createOutputOptions = ({outputDir}: Options, log: Logger): OutputOptions =
 		// intro,
 		// outro,
 		// paths,
-		// sourcemap,
+		sourcemap: dev,
 		// sourcemapExcludeSources,
 		// sourcemapFile,
 		// sourcemapPathTransform,


### PR DESCRIPTION
I don't remember why sourcemaps are turned off, but turning them on for development seems to work without any more changes.