### PR TITLE
make Rollup build extensible

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,9 @@
 # Gro changelog
 
-## 0.2.9
+## 0.2.8
 
 - make Rollup build extensible
   ([#35](https://github.com/feltcoop/gro/pull/35))
-
-## 0.2.8
-
 - upgrade peer dependencies
   ([#34](https://github.com/feltcoop/gro/pull/34))
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.2.9
+
+- make Rollup build extensible
+  ([#35](https://github.com/feltcoop/gro/pull/35))
+
 ## 0.2.8
 
 - upgrade peer dependencies

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -13,9 +13,13 @@ export const task: Task = {
 		const inputFiles = await resolveInputFiles(args._);
 		log.info('inputFiles', inputFiles);
 
-		const dev: boolean = process.env.NODE_ENV !== 'production';
+		// TODO what's the best way to define these types? make `Task` generic? schema validation?
+		const dev: boolean = 'dev' in args ? !!args.dev : process.env.NODE_ENV !== 'production';
 		const watch: boolean = (args.watch as any) || false;
 		const outputDir: string = (args.outputDir as any) || DEFAULT_OUTPUT_DIR;
+		const mapInputOptions = args.mapInputOptions as any;
+		const mapOutputOptions = args.mapOutputOptions as any;
+		const mapWatchOptions = args.mapWatchOptions as any;
 
 		if (inputFiles.length) {
 			const build = createBuild({
@@ -23,6 +27,9 @@ export const task: Task = {
 				inputFiles,
 				outputDir,
 				watch,
+				mapInputOptions,
+				mapOutputOptions,
+				mapWatchOptions,
 			});
 			await build.promise;
 		} else {

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,6 +1,6 @@
 export interface Args {
 	_: string[];
-	[key: string]: string | number | boolean | string[];
+	[key: string]: string | number | boolean | string[] | undefined;
 }
 
 // this is the same as NodeJS.Process.env but environment-agnostic

--- a/src/project/cssCache.ts
+++ b/src/project/cssCache.ts
@@ -15,7 +15,7 @@ export type CssBundle<T extends CssBuild = CssBuild> = {
 
 export interface CssCache<T extends CssBuild = CssBuild> {
 	getCssBundles(): Map<string, CssBundle<T>>;
-	getCssBuild(bundleName: string, id: string): T | undefined;
+	getCssBuild(bundleName: string, id: string): T;
 	addCssBuild(bundleName: string, build: T): boolean;
 }
 
@@ -29,10 +29,12 @@ export const createCssCache = <T extends CssBuild = CssBuild>(): CssCache<T> => 
 		getCssBundles: () => bundles,
 		getCssBuild: (bundleName, id) => {
 			const bundle = bundles.get(bundleName);
-			if (!bundle) return undefined;
-			return bundle.buildsById.get(id);
+			if (!bundle) throw Error(`Expected to find CSS bundle name '${bundleName}'`);
+			const cssBuild = bundle.buildsById.get(id);
+			if (!cssBuild) throw Error(`Expected to find CSS build with id '${id}' for '${bundleName}'`);
+			return cssBuild;
 		},
-		addCssBuild: (bundleName, build): boolean => {
+		addCssBuild: (bundleName, build) => {
 			const {id} = build;
 			let bundle = bundles.get(bundleName);
 			if (bundle) {


### PR DESCRIPTION
This makes the Rollup build extensible through the introduction of three optional mapping functions that can transform the `InputOptions`, `OutputOptions`, and `RollupWatchOptions` however they wish. This should give consumers a lot of control without directly exposing Rollup, allowing Gro to use a faster tool during development like [Nollup](https://github.com/PepsRyuu/nollup/) or [Vite](https://github.com/vuejs/vite) in the future.

The main behavioral change is that it separates the Svelte and plain CSS bundles into separate ones to fix source maps. These could be combined back into one if we generated a source map for all plain CSS, but currently no consumer projects need that.