### PR TITLE
sort CSS builds to make output deterministic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.2.9
+
+- sort CSS builds to make output deterministic
+  ([#36](https://github.com/feltcoop/gro/pull/36))
+
 ## 0.2.8
 
 - make Rollup build extensible

--- a/src/project/rollup-plugin-output-css.ts
+++ b/src/project/rollup-plugin-output-css.ts
@@ -57,7 +57,7 @@ export const outputCssPlugin = (opts: InitialOptions): Plugin => {
 
 				// sort the css builds, so the cascade works according to import order
 				const builds = Array.from(buildsById.values()).sort((a, b) =>
-					a.sortIndex > b.sortIndex ? 1 : -1,
+					a.sortIndex === b.sortIndex ? (a.id > b.id ? 1 : -1) : a.sortIndex > b.sortIndex ? 1 : -1,
 				);
 
 				// create the final css and sourcemap


### PR DESCRIPTION
This sorts CSS builds to make the output deterministic. Without this sorting, things like Svelte component CSS may appear in random order, making deployments non-deterministic and therefore uncacheable.