### PR TITLE
run the clean task at the beginning of the check task

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.2.10
+
+- run the clean task at the beginning of the check task
+  ([#37](https://github.com/feltcoop/gro/pull/37))
+
 ## 0.2.9
 
 - sort CSS builds to make output deterministic

--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -5,6 +5,7 @@ import {findTestModules} from './oki/testModule.js';
 export const task: Task = {
 	description: 'check that everything is ready to commit',
 	run: async ({log, args, invokeTask}) => {
+		await invokeTask('clean');
 		await invokeTask('typecheck');
 
 		// Run tests only if the the project has some.


### PR DESCRIPTION
This ensures that the `gro check` task always starts from a clean slate. Previously, stale build files could cause incorrect checks.