### PR TITLE
build TypeScript in the dev task

### DIFF
--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -1,4 +1,5 @@
 import {Task} from './task/task.js';
+import {spawnProcess} from './utils/process.js';
 
 const DEFAULT_SERVE_DIR = 'dist/';
 
@@ -16,7 +17,11 @@ export const task: Task = {
 		// .option('-w, --watch', 'Watch for changes and rebuild')
 		// .option('-P, --production', 'Set NODE_ENV to production')
 
-		await Promise.all([invokeTask('build'), invokeTask('serve')]);
+		await Promise.all([
+			invokeTask('build'),
+			spawnProcess('node_modules/.bin/tsc', ['-w']),
+			invokeTask('serve'),
+		]);
 
 		// ...
 	},


### PR DESCRIPTION
The default `gro dev` task now builds TypeScript to the `build/` directory. The build process is still a work in progress - this only affects running `gro` commands right now, as the default `gro build` task doesn't use the `build/` directory artifacts yet.