### PR TITLE
add a default deploy task for gh-pages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.2.10
 
+- add a default `gro deploy` task for gh-pages
+  ([#39](https://github.com/feltcoop/gro/pull/39))
 - run the clean task at the beginning of the check task
   ([#37](https://github.com/feltcoop/gro/pull/37))
 

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -1,0 +1,65 @@
+import {join, basename} from 'path';
+
+import {Task} from './task/task.js';
+import {spawnProcess} from './utils/process.js';
+import {copy, pathExists} from './fs/nodeFs.js';
+import {paths} from './paths.js';
+
+// TODO customize?
+const distDirName = basename(paths.dist);
+const deploymentBranch = 'gh-pages';
+const deploymentStaticContentDir = join(paths.source, 'project/gh-pages/');
+const initialFile = 'package.json';
+const TEMP_PREFIX = '__TEMP__';
+
+// TODO support other kinds of deployments
+
+export const task: Task = {
+	description: 'deploy to gh-pages',
+	run: async ({invokeTask}): Promise<void> => {
+		// TODO how should this be done?
+		process.env.NODE_ENV = 'production';
+
+		// Set up the deployment branch if necessary.
+		await spawnProcess(
+			`git checkout --orphan ${deploymentBranch} && ` +
+				`cp ${initialFile} ${TEMP_PREFIX}${initialFile} && ` +
+				`git rm -rf . && ` +
+				`mv ${TEMP_PREFIX}${initialFile} ${initialFile} && ` +
+				`git add ${initialFile} && ` +
+				'git commit -m "setup" && git checkout master',
+			[],
+			{shell: true},
+		);
+
+		// Clean up any existing worktree.
+		await spawnProcess('git', ['worktree', 'remove', distDirName]);
+		await spawnProcess('git', ['worktree', 'prune']);
+
+		// Get ready to build from scratch.
+		await invokeTask('clean');
+
+		// Set up the deployment worktree in the dist directory.
+		await spawnProcess('git', ['worktree', 'add', distDirName, deploymentBranch]);
+
+		// Run the build.
+		await invokeTask('build');
+
+		// Copy everything from `src/project/gh-pages`. (like `CNAME` for GitHub custom domains)
+		// If any files conflict, throw an error!
+		// That should be part of the build process.
+		if (await pathExists(deploymentStaticContentDir)) {
+			await copy(deploymentStaticContentDir, paths.dist);
+		}
+		await copy(initialFile, join(paths.dist, initialFile));
+
+		// At this point, `dist/` is ready to be committed and deployed!
+		await spawnProcess('git', ['add', '.'], {cwd: paths.dist});
+		await spawnProcess('git', ['commit', '-m', 'deployment'], {
+			cwd: paths.dist,
+		});
+		await spawnProcess('git', ['push', 'origin', deploymentBranch], {
+			cwd: paths.dist,
+		});
+	},
+};

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -10,6 +10,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 - [build](../build.task.ts) - build the project
 - [check](../check.task.ts) - check that everything is ready to commit
 - [clean](../clean.task.ts) - remove build and temp files
+- [deploy](../deploy.task.ts) - deploy to gh-pages
 - [dev](../dev.task.ts) - start development server
 - [dist](../dist.task.ts) - create the distribution
 - [format](../format.task.ts) - format source files


### PR DESCRIPTION
This adds the `gro deploy` task for deployment of static builds to GitHub pages via the `gh-pages` branch. We can make it more configurable in a followup PR. It uses Git worktrees to simplify the process of managing a clean `gh-pages` branch with history without polluting anything outside of that branch.