### PR TITLE
change the deploy task to delete dist when done

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.2.11
+
+- change the deploy task to delete `dist/` when done to avoid git worktree issues
+  ([#40](https://github.com/feltcoop/gro/pull/40))
+
 ## 0.2.10
 
 - add a default `gro deploy` task for gh-pages

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -63,5 +63,11 @@ export const task: Task = {
 		await spawnProcess('git', ['push', 'origin', deploymentBranch], {
 			cwd: paths.dist,
 		});
+
+		// Clean up the worktree so it doesn't interfere with development.
+		// TODO maybe add a flag to preserve these files?
+		// or maybe just create a separate `deploy` dir to avoid problems?
+		await spawnProcess('git', ['worktree', 'remove', distDirName]);
+		await spawnProcess('git', ['worktree', 'prune']);
 	},
 };


### PR DESCRIPTION
This makes the `gro deploy` command delete the `dist/` directory once it's finished. The reasoning is that it uses the git worktree feature to simplify branch management for deployment, and since it uses the same `dist/` directory as development, it's likely to be confusing and error-prone.

We may want to revert this change and create a special `deploy/` directory instead of re-using `dist/`.