### PR TITLE
fix log message when listing all tasks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.2.12
+
+- fix log message when listing all tasks
+  ([#41](https://github.com/feltcoop/gro/pull/41))
+
 ## 0.2.11
 
 - change the deploy task to delete `dist/` when done to avoid git worktree issues

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -44,7 +44,7 @@ The comments describe each condition.
 */
 
 export const invokeTask = async (taskName: string, args: Args): Promise<void> => {
-	const log = new SystemLogger([`${gray('[')}${magenta(taskName)}${gray(']')}`]);
+	const log = new SystemLogger([`${gray('[')}${magenta(taskName || 'gro')}${gray(']')}`]);
 
 	// Check if the caller just wants to see the version.
 	if (!taskName && (args.version || args.v)) {


### PR DESCRIPTION
This fixes the log message label when no task is provided. Before it prints `[undefined]` and now it'll be `[gro]`.