### PR TITLE
handle build errors in the deploy task and add the dry flag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.2.13
+
+- handle build errors in the deploy task and add the `--dry` deploy flag
+  ([#42](https://github.com/feltcoop/gro/pull/42))
+
 ## 0.2.12
 
 - fix log message when listing all tasks


### PR DESCRIPTION
This makes the deploy task, which handles static deployments (currently hardcoded to GitHub pages), more robust by properly cleaning up if the build fails. It also adds the `--dry` flag, e.g. `gro deploy --dry`, to optionally preserve the build files and makes no remote changes to any git repos, which is helpful for diagnostic purposes.