### PR TITLE
add swc rollup plugin and svelte preprocessor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.4.0
+
+- add `swc` dependency along with a Rollup plugin and Svelte preprocessor
+  ([#45](https://github.com/feltcoop/gro/pull/45))
+
 ## 0.3.0
 
 - handle build errors in the deploy task and add the `--dry` deploy flag

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,15 @@
       "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-1.0.1.tgz",
       "integrity": "sha512-shtopUGL/WuVicOTppRGDb2he9aGp+OF5EB11Xsbe3K4W6qN7HtK3F+ayNxcfbrG/SSL/Z9B+Xrb0Foz9x83gw=="
     },
+    "@node-rs/helper": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-0.4.0.tgz",
+      "integrity": "sha512-fSyHEXmlt/FueKqAYiGFCnkohnQBMQwUr6VYPeZEeVBAzQzhioS1WaRe2fSpOuRKIimCQEvxhQ6fwsYxYakfGA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.1"
+      }
+    },
     "@rollup/plugin-commonjs": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.0.0.tgz",
@@ -93,6 +102,39 @@
           "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g=="
         }
       }
+    },
+    "@swc/core": {
+      "version": "1.2.28",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.28.tgz",
+      "integrity": "sha512-qAnHHJBu1I3Ch6Gfcqaa+zB3q9u0Mo9m714qPNFC3EXx9FbNrb8DInCU+MKGi1yFnzQ3bk+bLEEmUTcLw0wy4g==",
+      "dev": true,
+      "requires": {
+        "@node-rs/helper": "^0.4.0",
+        "@swc/core-darwin": "^1.2.28",
+        "@swc/core-linux": "^1.2.28",
+        "@swc/core-win32": "^1.2.28"
+      }
+    },
+    "@swc/core-darwin": {
+      "version": "1.2.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin/-/core-darwin-1.2.28.tgz",
+      "integrity": "sha512-y1zNWliaMlLUuZw3DEve41M0h+b9Gw+LRfOAs6HW+eVdidHb7M08fpMoSczVlGMwsCd+yzWff4/onjhY4s+ppg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux": {
+      "version": "1.2.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux/-/core-linux-1.2.28.tgz",
+      "integrity": "sha512-Zlyt7PTIyT4I4ARZWhfEThL+Ge8lN6IygHo3NqNuu5I6icIJa4c/LLzExML6YgeIA5Rg6Sjprsb84ETEc3Lx/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32": {
+      "version": "1.2.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32/-/core-win32-1.2.28.tgz",
+      "integrity": "sha512-ryFMUdekRGVAZ8/MnjSFR1NG+sYtAVLvEyobSvgtMjpyPKj8rR3JWLv3otS1Kq1igIyJK2Cp6FIoN/MrTtY81g==",
+      "dev": true,
+      "optional": true
     },
     "@types/estree": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "terser": "^5.3.0"
   },
   "peerDependencies": {
+    "@swc/core": "^1.2.28",
     "rollup": "^2.26.11",
     "svelte": "^3.24.1",
     "typescript": "^4.0.2",
@@ -68,6 +69,7 @@
     "prettier-plugin-svelte": "^1.2.1"
   },
   "devDependencies": {
+    "@swc/core": "^1.2.28",
     "@types/prettier": "^2.1.0",
     "prettier": "^2.1.1",
     "prettier-plugin-svelte": "^1.2.1",

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -16,6 +16,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 - [format](../format.task.ts) - format source files
 - [gen](../gen.task.ts) - run code generation scripts
 - [project/build](../project/build.task.ts) - build, create, and link the distribution
+- [project/compilerBenchmark](../project/compilerBenchmark.task.ts) - benchmark compilation with different libraries
 - [project/dev](../project/dev.task.ts) - build typescript in watch mode for development
 - [project/dist](../project/dist.task.ts) - create and link the distribution
 - [project/link](../project/link.task.ts) - link the distribution

--- a/src/fs/nodeFs.ts
+++ b/src/fs/nodeFs.ts
@@ -4,6 +4,7 @@ import fsExtra from 'fs-extra';
 import {PathStats, PathFilter} from './pathData.js';
 import {sortMap, compareSimpleMapEntries} from '../utils/map.js';
 
+// This uses `CheapWatch` which probably isn't the fastest, but it works fine for now.
 // TODO should this API be changed to only include files and not directories?
 // or maybe change the name so it's not misleading?
 export const findFiles = async (

--- a/src/project/build.ts
+++ b/src/project/build.ts
@@ -21,10 +21,10 @@ import {outputCssPlugin} from './rollup-plugin-output-css.js';
 import {createCssCache, CssCache} from './cssCache.js';
 import {groJsonPlugin} from './rollup-plugin-gro-json.js';
 import {groTerserPlugin} from './rollup-plugin-gro-terser.js';
-import {groTypescriptPlugin} from './rollup-plugin-gro-typescript.js';
+import {groSwcPlugin} from './rollup-plugin-gro-swc.js';
 import {groSveltePlugin} from './rollup-plugin-gro-svelte.js';
 import {GroCssBuild} from './types.js';
-import {sveltePreprocessTypescript} from './svelte-preprocess-typescript.js';
+import {sveltePreprocessSwc} from './svelte-preprocess-swc.js';
 import {omitUndefined} from '../utils/object.js';
 import {UnreachableError} from '../utils/error.js';
 import {identity} from '../utils/function.js';
@@ -114,12 +114,12 @@ const createInputOptions = (inputFile: string, options: Options, _log: Logger): 
 			groSveltePlugin({
 				dev,
 				addCssBuild: addSvelteCssBuild,
-				preprocessor: [sveltePreprocessTypescript()],
+				preprocessor: [sveltePreprocessSwc()],
 				compileOptions: {
 					immutable: true,
 				},
 			}),
-			groTypescriptPlugin(),
+			groSwcPlugin(),
 			plainCssPlugin({addCssBuild: addPlainCssBuild}),
 			outputCssPlugin({
 				getCssBundles: cssCache.getCssBundles,

--- a/src/project/compilerBenchmark.task.ts
+++ b/src/project/compilerBenchmark.task.ts
@@ -1,0 +1,148 @@
+import swc from '@swc/core';
+import ts from 'typescript';
+import {join} from 'path';
+
+import {Task} from '../task/task.js';
+import {loadTsconfig} from './tsHelpers.js';
+import {findFiles, readFile, outputFile} from '../fs/nodeFs.js';
+import {paths} from '../paths.js';
+import {printMs} from '../utils/print.js';
+import {Timings} from '../utils/time.js';
+
+/*
+
+This is a benchmark comparing transpilation speed of the official TypeScript compiler and `swc`.
+I'm not including `esbuild` for now because it always strips unused imports,
+which makes it unsuitable as a Svelte preprocessor.
+I'd like to revisit this if the API adds support for transpile-only behavior like swc and tsc.
+
+Results:
+
+➤ [project/compilerBenchmark:log] tscTranspileOnly ...
+➤ [project/compilerBenchmark:log] 🕒 tscTranspileOnly 1905.0ms
+➤ [project/compilerBenchmark:log] swcSync ...
+➤ [project/compilerBenchmark:log] 🕒 swcSync 58.7ms
+➤ [project/compilerBenchmark:log] swcAsync ...
+➤ [project/compilerBenchmark:log] 🕒 swcAsync 87.6ms
+➤ [project/compilerBenchmark:log] swcParallel ...
+➤ [project/compilerBenchmark:log] 🕒 swcParallel 17.4ms
+
+Conclusion: use `swc` instead. lol. Start with the Svelte preprocessor.
+
+Notes:
+
+`swc` doesn't seem to add the sourcemap footer and I don't see an option.
+```
+//# sourceMappingURL=foo.js.map
+```
+
+*/
+
+// TODO maybe add source maps?
+
+export const task: Task = {
+	description: 'benchmark compilation with different libraries',
+	run: async ({log}) => {
+		// load all files into memory
+		log.info('loading files');
+		const statsByPath = await findFiles(paths.source, ({path}) => path.endsWith('.ts'), null);
+		const codeByPath = new Map<string, string>();
+		for (const [path, stats] of statsByPath) {
+			if (stats.isDirectory()) continue;
+			const contents = await readFile(join(paths.source, path), 'utf8');
+			// console.log('file', path, contents.length);
+			codeByPath.set(path, contents);
+		}
+
+		const timings = new Timings();
+
+		const tsconfig = loadTsconfig(log);
+		const {compilerOptions} = tsconfig;
+
+		const testFile = 'utils/json.ts';
+		const writeTestFile = async (suffix: string, contents: string, map = false) => {
+			await outputFile(`src/${testFile}.${suffix}.js${map ? '.map' : ''}`, contents, 'utf8');
+		};
+		const startBenchmark = (name: string) => {
+			log.info(name, '...');
+			timings.start(name);
+			return async (resultsByPath: Map<string, string>) => {
+				log.info(`🕒 ${name} ${printMs(timings.stop(name))}`);
+				await writeTestFile(name, resultsByPath.get(testFile)!);
+				await writeTestFile(name, resultsByPath.get(`${testFile}.map`)!, true);
+			};
+		};
+
+		// tsc transpileOnly
+		const tscTranspileOnlyResults = new Map<string, string>();
+		const endTscTranspileOnlyBenchmark = startBenchmark('tscTranspileOnly');
+		for (const [path, code] of codeByPath) {
+			const result = ts.transpileModule(code, {
+				compilerOptions,
+				fileName: path,
+				// reportDiagnostics,
+				// moduleName?: string;
+				// renamedDependencies?: Map<string>;
+			});
+			tscTranspileOnlyResults.set(path, result.outputText);
+			tscTranspileOnlyResults.set(`${path}.map`, result.sourceMapText!);
+		}
+		await endTscTranspileOnlyBenchmark(tscTranspileOnlyResults);
+
+		// swcSync
+		const swcSyncResults = new Map<string, string>();
+		const endSwcSyncBenchmark = startBenchmark('swcSync');
+		for (const [path, code] of codeByPath) {
+			const result = swc.transformSync(code, {
+				filename: path,
+				sourceMaps: true,
+				jsc: {
+					parser: {syntax: 'typescript', tsx: false, decorators: false, dynamicImport: true},
+					target: 'es2019',
+					loose: true,
+				},
+			});
+			swcSyncResults.set(path, result.code);
+			swcSyncResults.set(`${path}.map`, result.map!);
+		}
+		endSwcSyncBenchmark(swcSyncResults);
+
+		// swc async
+		const swcAsyncResults = new Map<string, string>();
+		const endSwcAsyncBenchmark = startBenchmark('swcAsync');
+		for (const [path, code] of codeByPath) {
+			const result = await swc.transform(code, {
+				filename: path,
+				sourceMaps: true,
+				jsc: {
+					parser: {syntax: 'typescript', tsx: false, decorators: false, dynamicImport: true},
+					target: 'es2019',
+					loose: true,
+				},
+			});
+			swcAsyncResults.set(path, result.code);
+			swcAsyncResults.set(`${path}.map`, result.map!);
+		}
+		endSwcAsyncBenchmark(swcAsyncResults);
+
+		// swcParallel
+		const swcParallelResults = new Map<string, string>();
+		const endSwcParallelBenchmark = startBenchmark('swcParallel');
+		await Promise.all(
+			Array.from(codeByPath.entries()).map(async ([path, code]) => {
+				const result = await swc.transform(code, {
+					filename: path,
+					sourceMaps: true,
+					jsc: {
+						parser: {syntax: 'typescript', tsx: false, decorators: false, dynamicImport: true},
+						target: 'es2019',
+						loose: true,
+					},
+				});
+				swcParallelResults.set(path, result.code);
+				swcParallelResults.set(`${path}.map`, result.map!);
+			}),
+		);
+		endSwcParallelBenchmark(swcParallelResults);
+	},
+};

--- a/src/project/rollup-plugin-gro-swc.ts
+++ b/src/project/rollup-plugin-gro-swc.ts
@@ -12,8 +12,6 @@ import {toRootPath, isSourceId, toSourceExt} from '../paths.js';
 import {loadTsconfig} from './tsHelpers.js';
 import {omitUndefined} from '../utils/object.js';
 
-// TODO parallelize with workers?
-
 // TODO improve along with Svelte compile stats
 interface Stats {
 	timings: {
@@ -97,7 +95,6 @@ export const groSwcPlugin = (opts: InitialOptions = {}): Plugin => {
 			};
 			onstats(id, stats, handleStats, this, log);
 
-			// TODO does map need parsing like the TypeScript version? JSON.parse(sourceMapText) : null,
 			return output;
 		},
 	};

--- a/src/project/svelte-preprocess-swc.ts
+++ b/src/project/svelte-preprocess-swc.ts
@@ -1,0 +1,68 @@
+import swc from '@swc/core';
+import {PreprocessorGroup} from 'svelte/types/compiler/preprocess';
+
+import {toSwcCompilerTarget, mergeSwcOptions, getDefaultSwcOptions} from './swcHelpers.js';
+import {magenta, red} from '../colors/terminal.js';
+import {SystemLogger} from '../utils/log.js';
+import {loadTsconfig} from './tsHelpers.js';
+import {printPath} from '../utils/print.js';
+import {omitUndefined} from '../utils/object.js';
+
+/*
+
+This preprocessor transpiles the script portion of Svelte files
+if the script tag has a `lang="typescript"` or `lang="ts"` attribute.
+No typechecking is performed - that's left for a separate build step.
+
+It uses swc for speeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeed.
+
+TODO use swc's JS parser options if it's not TypeScript for downtranspilation
+
+*/
+
+export interface Options {
+	swcOptions: swc.Options;
+	tsconfigPath: string | undefined;
+	basePath: string | undefined;
+	langs: string[];
+}
+export type InitialOptions = Partial<Options>;
+export const initOptions = (opts: InitialOptions): Options => ({
+	swcOptions: getDefaultSwcOptions(),
+	tsconfigPath: undefined,
+	basePath: undefined,
+	langs: ['typescript', 'ts'],
+	...omitUndefined(opts),
+});
+
+const name = 'svelte-preprocess-swc';
+
+export const sveltePreprocessSwc = (opts: InitialOptions = {}): PreprocessorGroup => {
+	const {swcOptions, langs, tsconfigPath, basePath} = initOptions(opts);
+
+	const log = new SystemLogger([magenta(`[${name}]`)]);
+
+	const tsconfig = loadTsconfig(log, tsconfigPath, basePath);
+	const {compilerOptions} = tsconfig;
+	const target = toSwcCompilerTarget(compilerOptions && compilerOptions.target);
+
+	return {
+		script({content, attributes, filename}) {
+			const {lang} = attributes;
+			if (lang && !langs.includes(lang as string)) {
+				return null as any; // type is wrong
+			}
+			log.info('transpiling with swc', printPath(filename || ''));
+			const finalSwcOptions = mergeSwcOptions(swcOptions, target, filename);
+			let output: swc.Output;
+			try {
+				// TODO maybe use the async version so we can preprocess in parallel?
+				output = swc.transformSync(content, finalSwcOptions);
+			} catch (err) {
+				log.error(red('Failed to transpile TypeScript'), printPath(filename || ''));
+				throw err;
+			}
+			return output;
+		},
+	};
+};

--- a/src/project/svelte-preprocess-typescript.ts
+++ b/src/project/svelte-preprocess-typescript.ts
@@ -9,6 +9,9 @@ import {omitUndefined} from '../utils/object.js';
 
 /*
 
+This module is no longer used, see `./svelte-preprocess-swc.ts`.
+It may be used in the future for generating type mappings in production.
+
 This preprocessor transpiles the script portion of Svelte files
 if the script tag has a `lang="typescript"` attribute.
 No typechecking is performed - that's left for a separate build step.
@@ -38,7 +41,7 @@ export const sveltePreprocessTypescript = (opts: InitialOptions = {}): Preproces
 	return {
 		script({content, attributes, filename}) {
 			if (!langs.includes(attributes.lang as any)) return null as any; // type is wrong
-			log.info('transpiling', printPath(filename || ''));
+			// log.info('transpiling', printPath(filename || ''));
 			const transpileOptions: ts.TranspileOptions = {
 				compilerOptions: tsconfig.compilerOptions,
 				fileName: filename,

--- a/src/project/swcHelpers.ts
+++ b/src/project/swcHelpers.ts
@@ -1,0 +1,51 @@
+import swc from '@swc/core';
+import {ScriptTarget} from 'typescript';
+
+const DEFAULT_TARGET = 'es2019'; // TODO?
+
+export const toSwcCompilerTarget = (target: ScriptTarget | undefined): swc.JscTarget => {
+	switch (target) {
+		case 0: // ES3 = 0,
+			return 'es3';
+		case 1: // ES5 = 1,
+			return 'es5';
+		case 2: // ES2015 = 2,
+			return 'es2015';
+		case 3: // ES2016 = 3,
+			return 'es2016';
+		case 4: // ES2017 = 4,
+			return 'es2017';
+		case 5: // ES2018 = 5,
+			return 'es2018';
+		case 6: // ES2019 = 6,
+			return 'es2019';
+		// ES2020 = 7,
+		// ESNext = 99,
+		// JSON = 100,
+		// Latest = 99
+		default:
+			return DEFAULT_TARGET;
+	}
+};
+
+export const mergeSwcOptions = (
+	options: swc.Options,
+	target: swc.JscTarget,
+	filename?: string,
+): swc.Options => ({
+	...options,
+	jsc: {
+		...options.jsc,
+		target,
+	},
+	filename,
+});
+
+export const getDefaultSwcOptions = (): swc.Options => ({
+	sourceMaps: true,
+	jsc: {
+		parser: {syntax: 'typescript', tsx: false, decorators: false, dynamicImport: true},
+		externalHelpers: true,
+		loose: true, // TODO?
+	},
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
 
   "compilerOptions": {
     // Main options
-    "target": "es2018", // Specify ECMAScript target version: 'es3' (default), 'es5', 'es2015', 'es2016', 'es2017','es2018' or 'esnext'.
+    "target": "es2019", // Specify ECMAScript target version: 'es3' (default), 'es5', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', or 'esnext'.
     "module": "esnext", // Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'.
     "lib": ["esnext", "dom"], // Specify library files to be included in the compilation.
     // "allowJs": false, // Allow javascript files to be compiled.


### PR DESCRIPTION
This adds a new dependency, [swc](https://github.com/swc-project/swc), which is an alternative to compilers like Babel and TypeScript. We will continue using the TypeScript compiler for typechecking and for generating type mappings in production builds, but I believe everything else can be migrated over to use `swc` with no impact except 20-100x faster builds.

This is the first PR to integrate `swc`, and the main thing it adds are a Rollup plugin and Svelte preprocessor. There's also a benchmark task that shows the 20-100x speedup. I was planning a revamp of various pieces of the tools and tasks Gro has for building code, and I think this is a good time to do that work. I'll probably make several smallish PRs over the next couple months, and likely at least one big one that introduces a bunch of machinery for a much improved watch mode and caching system.