### PR TITLE
add stop function return value to timings api

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
   ([#45](https://github.com/feltcoop/gro/pull/45))
 - add the `compile` task and use `swc` for non-watchmode builds
   ([#46](https://github.com/feltcoop/gro/pull/46))
-- add stop function return value to timings api
+- add stop function return value to `Timing#start`
   ([#47](https://github.com/feltcoop/gro/pull/47))
 
 ## 0.3.0

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
   ([#45](https://github.com/feltcoop/gro/pull/45))
 - add the `compile` task and use `swc` for non-watchmode builds
   ([#46](https://github.com/feltcoop/gro/pull/46))
-- add stop function return value to `Timing#start`
+- add stop function return value to `Timings#start`
   ([#47](https://github.com/feltcoop/gro/pull/47))
 
 ## 0.3.0

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
   ([#45](https://github.com/feltcoop/gro/pull/45))
 - add the `compile` task and use `swc` for non-watchmode builds
   ([#46](https://github.com/feltcoop/gro/pull/46))
+- add stop function return value to timings api
+  ([#47](https://github.com/feltcoop/gro/pull/47))
 
 ## 0.3.0
 

--- a/src/fs/modules.ts
+++ b/src/fs/modules.ts
@@ -93,14 +93,14 @@ export const findModules = async (
 ): Promise<FindModulesResult> => {
 	// Check which extension variation works - if it's a directory, prefer others first!
 	const timings = new Timings<FindModulesTimings>();
-	timings.start('map input paths');
+	const timingToMapInputPaths = timings.start('map input paths');
 	const {sourceIdPathDataByInputPath, unmappedInputPaths} = await loadSourcePathDataByInputPath(
 		inputPaths,
 		pathExists,
 		stat,
 		getPossibleSourceIds,
 	);
-	timings.stop('map input paths');
+	timingToMapInputPaths();
 
 	// Error if any input path could not be mapped.
 	if (unmappedInputPaths.length) {
@@ -121,12 +121,12 @@ export const findModules = async (
 	}
 
 	// Find all of the files for any directories.
-	timings.start('find files');
+	const timingToFindFiles = timings.start('find files');
 	const {
 		sourceIdsByInputPath,
 		inputDirectoriesWithNoFiles,
 	} = await loadSourceIdsByInputPath(sourceIdPathDataByInputPath, (id) => findFiles(id));
-	timings.stop('find files');
+	timingToFindFiles();
 
 	// Error if any input path has no files. (means we have an empty directory)
 	return inputDirectoriesWithNoFiles.length
@@ -161,7 +161,7 @@ export const loadModules = async <ModuleType, ModuleMetaType extends ModuleMeta<
 	loadModuleById: (sourceId: string) => Promise<LoadModuleResult<ModuleMetaType>>,
 ): Promise<LoadModulesResult<ModuleMetaType>> => {
 	const timings = new Timings<LoadModulesTimings>();
-	timings.start('load modules');
+	const timingToLoadModules = timings.start('load modules');
 	const modules: ModuleMetaType[] = [];
 	const loadModuleFailures: LoadModuleFailure[] = [];
 	const reasons: string[] = [];
@@ -194,7 +194,7 @@ export const loadModules = async <ModuleType, ModuleMetaType extends ModuleMeta<
 			}
 		}
 	}
-	timings.stop('load modules');
+	timingToLoadModules();
 
 	return loadModuleFailures.length
 		? {

--- a/src/gen/runGen.ts
+++ b/src/gen/runGen.ts
@@ -18,7 +18,7 @@ export const runGen = async (
 	let inputCount = 0;
 	let outputCount = 0;
 	const timings = new Timings();
-	timings.start('total');
+	const timingForTotal = timings.start('total');
 	const results = await Promise.all(
 		genModules.map(
 			async ({id, mod}): Promise<GenModuleResult> => {
@@ -80,6 +80,6 @@ export const runGen = async (
 		failures: results.filter((r) => !r.ok) as GenModuleResultFailure[],
 		inputCount,
 		outputCount,
-		elapsed: timings.stop('total'),
+		elapsed: timingForTotal(),
 	};
 };

--- a/src/oki/TestContext.ts
+++ b/src/oki/TestContext.ts
@@ -110,7 +110,7 @@ export class TestContext {
 	runState = AsyncState.Initial;
 	async run(): Promise<TestRunResult> {
 		const timings = new Timings<TestRunTimings>();
-		timings.start('run tests');
+		const timingToRunTests = timings.start('run tests');
 		if (this.runState !== AsyncState.Initial) {
 			throw Error(`TestContext was already run`);
 		}
@@ -125,7 +125,7 @@ export class TestContext {
 		}
 		this.runState = AsyncState.Success;
 		this.onRunEnd();
-		timings.stop('run tests');
+		timingToRunTests();
 		return {stats: this.stats!, timings};
 	}
 

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -9,16 +9,29 @@ test('createStopwatch', () => {
 });
 
 test('Timings', () => {
-	const timings = new Timings<'foo' | 'bar'>(4);
-	timings.start('foo');
-	t.throws(() => timings.start('foo'));
-	timings.stop('foo');
-	t.throws(() => timings.stop('foo'));
-	t.throws(() => timings.stop('bar'));
-	const elapsed = timings.get('foo');
-	t.is(typeof elapsed, 'number');
-	t.throws(() => timings.get('bar'));
-	t.ok(elapsed.toString().split('.')[1].length <= 4);
+	test('start and stop', () => {
+		const timings = new Timings<'foo' | 'bar'>(4);
+		timings.start('foo');
+		t.throws(() => timings.start('foo'));
+		t.ok(typeof timings.stop('foo') === 'number');
+		t.throws(() => timings.stop('foo'));
+		t.throws(() => timings.stop('bar'));
+		const elapsed = timings.get('foo');
+		t.is(typeof elapsed, 'number');
+		t.throws(() => timings.get('bar'));
+		t.ok(elapsed.toString().split('.')[1].length <= 4);
+	});
+
+	test('start with stop callback', () => {
+		const timings = new Timings<'foo'>(4);
+		const timingToFoo = timings.start('foo');
+		const elapsed = timingToFoo();
+		t.is(typeof elapsed, 'number');
+		t.ok(elapsed.toString().split('.')[1].length <= 4);
+		t.throws(() => timingToFoo());
+		t.throws(() => timings.stop('foo'));
+		t.is(elapsed, timings.get('foo'));
+	});
 
 	test('merge timings', () => {
 		const a = new Timings(10);

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -21,11 +21,12 @@ export class Timings<T extends string | number = string | number> {
 
 	constructor(public readonly decimals?: number) {}
 
-	start(key: T, replace = false, decimals = this.decimals): void {
+	start(key: T, replace = false, decimals = this.decimals): () => number {
 		if (!replace && this.stopwatches.has(key)) {
 			throw Error(`Timing key is already in use: ${key}`);
 		}
 		this.stopwatches.set(key, createStopwatch(decimals));
+		return () => this.stop(key);
 	}
 	stop(key: T): number {
 		const stopwatch = this.stopwatches.get(key);


### PR DESCRIPTION
This adds a feature to `Timings`. `Timings#start` now returns a callback that does the same thing as calling `Timings#stop` with the same key. This new API should be preferred in the general case because it relies on the TypeScript language to ensure the callback gets called at least once and with the same key. The old API duplicates keys and has no language-level help for ensuring they get called, which can be errorful when refactoring. The old API is still useful when keys are programmatically defined, which Gro uses in several places, e.g. tracking the timings for many generated files.