### PR TITLE
rename identifiers from ext to extension

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
   ([#46](https://github.com/feltcoop/gro/pull/46))
 - add stop function return value to `Timings#start`
   ([#47](https://github.com/feltcoop/gro/pull/47))
+- rename identifiers from "ext" to "extension" to follow newer convention
+  ([#48](https://github.com/feltcoop/gro/pull/48))
 
 ## 0.3.0
 

--- a/src/fs/mime.test.ts
+++ b/src/fs/mime.test.ts
@@ -7,7 +7,7 @@ import {
 	removeMimeTypeExtension,
 } from './mime.js';
 
-test('extToMimeType()', () => {
+test('getMimeTypeByExtension()', () => {
 	t.is(getMimeTypeByExtension('txt'), 'text/plain');
 	t.is(getMimeTypeByExtension('log'), 'text/plain');
 	t.is(getMimeTypeByExtension('js'), 'text/javascript');
@@ -16,7 +16,7 @@ test('extToMimeType()', () => {
 	t.is(getMimeTypeByExtension('fakeext'), null);
 });
 
-test('mimeTypeToExts()', () => {
+test('getExtensionsByMimeType()', () => {
 	t.equal(getExtensionsByMimeType('text/plain'), ['txt', 'log']);
 	t.equal(getExtensionsByMimeType('application/json'), ['json']);
 	t.equal(getExtensionsByMimeType('text/javascript'), ['js', 'mjs']);

--- a/src/fs/mime.ts
+++ b/src/fs/mime.ts
@@ -43,9 +43,9 @@ export const addMimeTypeExtension = (mimeType: string, extension: string): void 
 export const removeMimeTypeExtension = (extension: string): boolean => {
 	const mimeType = mimeTypeByExtension.get(extension);
 	if (!mimeType) return false;
-	const newExts = extensionsByMimeType.get(mimeType)!.filter((e) => e !== extension);
-	if (newExts.length) {
-		extensionsByMimeType.set(mimeType, newExts);
+	const newExtensions = extensionsByMimeType.get(mimeType)!.filter((e) => e !== extension);
+	if (newExtensions.length) {
+		extensionsByMimeType.set(mimeType, newExtensions);
 	} else {
 		extensionsByMimeType.delete(mimeType);
 	}

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -16,9 +16,9 @@ import {
 	toDistPath,
 	toSourceId,
 	toBuildId,
-	hasSourceExt,
-	toSourceExt,
-	toCompiledExt,
+	hasSourceExtension,
+	toSourceExtension,
+	toCompiledExtension,
 	toPathParts,
 	toPathSegments,
 	toImportId,
@@ -180,25 +180,25 @@ test('basePathToDistId()', () => {
 	});
 });
 
-test('hasSourceExt()', () => {
+test('hasSourceExtension()', () => {
 	test('typescript', () => {
-		t.ok(hasSourceExt('foo/bar/baz.ts'));
+		t.ok(hasSourceExtension('foo/bar/baz.ts'));
 	});
 	test('svelte', () => {
-		t.ok(hasSourceExt('foo/bar/baz.svelte'));
+		t.ok(hasSourceExtension('foo/bar/baz.svelte'));
 	});
 });
 
-test('toSourceExt()', () => {
-	t.is(toSourceExt('foo/bar/baz.js'), 'foo/bar/baz.ts');
+test('toSourceExtension()', () => {
+	t.is(toSourceExtension('foo/bar/baz.js'), 'foo/bar/baz.ts');
 });
 
-test('toCompiledExt()', () => {
+test('toCompiledExtension()', () => {
 	test('typescript', () => {
-		t.is(toCompiledExt('foo/bar/baz.ts'), 'foo/bar/baz.js');
+		t.is(toCompiledExtension('foo/bar/baz.ts'), 'foo/bar/baz.js');
 	});
 	test('svelte', () => {
-		t.is(toCompiledExt('foo/bar/baz.svelte'), 'foo/bar/baz.js');
+		t.is(toCompiledExtension('foo/bar/baz.svelte'), 'foo/bar/baz.js');
 	});
 });
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,7 +1,7 @@
 import {sep, join, basename} from 'path';
 import {fileURLToPath} from 'url';
 
-import {replaceExt} from './utils/path.js';
+import {replaceExtension} from './utils/path.js';
 import {stripStart} from './utils/string.js';
 
 /*
@@ -74,7 +74,9 @@ export const toBasePath = (id: string, p = paths): string =>
 
 // '/home/me/app/build/foo/bar/baz.js' -> 'src/foo/bar/baz.ts'
 export const toSourcePath = (id: string, p = paths): string =>
-	isSourceId(id, p) ? stripStart(id, p.root) : toSourceExt(join(SOURCE_DIR, toBasePath(id, p)));
+	isSourceId(id, p)
+		? stripStart(id, p.root)
+		: toSourceExtension(join(SOURCE_DIR, toBasePath(id, p)));
 
 // '/home/me/app/src/foo/bar/baz.ts' -> 'build/foo/bar/baz.js'
 export const toBuildPath = (id: string, p = paths): string =>
@@ -82,7 +84,7 @@ export const toBuildPath = (id: string, p = paths): string =>
 		? stripStart(id, p.root)
 		: isDistId(id, p)
 		? join(BUILD_DIR, toBasePath(id, p))
-		: toCompiledExt(join(BUILD_DIR, toBasePath(id, p)));
+		: toCompiledExtension(join(BUILD_DIR, toBasePath(id, p)));
 
 // '/home/me/app/src/foo/bar/baz.ts' -> 'dist/foo/bar/baz.js'
 export const toDistPath = (id: string, p = paths): string =>
@@ -90,7 +92,7 @@ export const toDistPath = (id: string, p = paths): string =>
 		? stripStart(id, p.root)
 		: isBuildId(id, p)
 		? join(DIST_DIR, toBasePath(id, p))
-		: toCompiledExt(join(DIST_DIR, toBasePath(id, p)));
+		: toCompiledExtension(join(DIST_DIR, toBasePath(id, p)));
 
 // '/home/me/app/build/foo/bar/baz.js' -> '/home/me/app/src/foo/bar/baz.ts'
 export const toSourceId = (id: string, p = paths): string =>
@@ -115,20 +117,20 @@ export const basePathToDistId = (basePath: string, p = paths): string => join(p.
 
 export const stripRelativePath = (path: string): string => stripStart(path, RELATIVE_DIR_START);
 
-export const JS_EXT = '.js';
-export const TS_EXT = '.ts';
-export const SVELTE_EXT = '.svelte';
-export const SOURCE_EXTS = [TS_EXT, SVELTE_EXT];
+export const JS_EXTENSION = '.js';
+export const TS_EXTENSION = '.ts';
+export const SVELTE_EXTENSION = '.svelte';
+export const SOURCE_EXTENSIONS = [TS_EXTENSION, SVELTE_EXTENSION];
 
-export const hasSourceExt = (path: string): boolean =>
-	SOURCE_EXTS.some((ext) => path.endsWith(ext));
+export const hasSourceExtension = (path: string): boolean =>
+	SOURCE_EXTENSIONS.some((ext) => path.endsWith(ext));
 
-export const toSourceExt = (path: string): string =>
-	path.endsWith(JS_EXT) ? replaceExt(path, TS_EXT) : path; // TODO? how does this work with `.svelte`? do we need more metadata?
+export const toSourceExtension = (path: string): string =>
+	path.endsWith(JS_EXTENSION) ? replaceExtension(path, TS_EXTENSION) : path; // TODO? how does this work with `.svelte`? do we need more metadata?
 
 // compiled includes both build and dist
-export const toCompiledExt = (path: string): string =>
-	hasSourceExt(path) ? replaceExt(path, JS_EXT) : path;
+export const toCompiledExtension = (path: string): string =>
+	hasSourceExtension(path) ? replaceExtension(path, JS_EXTENSION) : path;
 
 // Gets the individual parts of a path, ignoring dots and separators.
 // toPathSegments('/foo/bar/baz.ts') => ['foo', 'bar', 'baz.ts']
@@ -158,5 +160,7 @@ export const replaceRootDir = (id: string, rootDir: string, p = paths): string =
 // When importing Gro paths, this correctly chooses the build or dist dir.
 export const toImportId = (id: string): string => {
 	const p = pathsFromId(id);
-	return p === groPaths ? toCompiledExt(join(groImportDir, toBasePath(id, p))) : toBuildId(id, p);
+	return p === groPaths
+		? toCompiledExtension(join(groImportDir, toBasePath(id, p)))
+		: toBuildId(id, p);
 };

--- a/src/project/rollup-plugin-gro-svelte.ts
+++ b/src/project/rollup-plugin-gro-svelte.ts
@@ -5,7 +5,7 @@ import {Plugin, PluginContext, ExistingRawSourceMap} from 'rollup';
 import {createFilter} from '@rollup/pluginutils';
 
 import {magenta, yellow, red} from '../colors/terminal.js';
-import {getPathStem, replaceExt} from '../utils/path.js';
+import {getPathStem, replaceExtension} from '../utils/path.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';
 import {toRootPath} from '../paths.js';
@@ -154,7 +154,7 @@ export const groSveltePlugin = (opts: InitialOptions): GroSveltePlugin => {
 
 			onstats(id, stats, handleStats, this, log);
 
-			let cssId = replaceExt(id, '.css');
+			let cssId = replaceExtension(id, '.css');
 			log.trace('add css import', printPath(cssId));
 			addCssBuild({
 				id: cssId,

--- a/src/project/rollup-plugin-gro-swc.ts
+++ b/src/project/rollup-plugin-gro-swc.ts
@@ -8,7 +8,7 @@ import {magenta, red} from '../colors/terminal.js';
 import {createStopwatch} from '../utils/time.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';
-import {toRootPath, isSourceId, toSourceExt} from '../paths.js';
+import {toRootPath, isSourceId, toSourceExtension} from '../paths.js';
 import {loadTsconfig} from '../compile/tsHelpers.js';
 import {omitUndefined} from '../utils/object.js';
 
@@ -63,7 +63,7 @@ export const groSwcPlugin = (opts: InitialOptions = {}): Plugin => {
 			if (importer && importee.endsWith('.js') && importee.startsWith('.')) {
 				const resolvedPath = resolve(importer, '../', importee);
 				if (isSourceId(resolvedPath)) {
-					return toSourceExt(resolvedPath);
+					return toSourceExtension(resolvedPath);
 				}
 			}
 			return null;

--- a/src/project/rollup-plugin-gro-typescript.ts
+++ b/src/project/rollup-plugin-gro-typescript.ts
@@ -7,7 +7,7 @@ import {magenta, red} from '../colors/terminal.js';
 import {createStopwatch} from '../utils/time.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';
-import {toRootPath, isSourceId, toSourceExt} from '../paths.js';
+import {toRootPath, isSourceId, toSourceExtension} from '../paths.js';
 import {loadTsconfig, logTsDiagnostics} from '../compile/tsHelpers.js';
 import {omitUndefined} from '../utils/object.js';
 
@@ -79,7 +79,7 @@ export const groTypescriptPlugin = (opts: InitialOptions = {}): Plugin => {
 			if (importer && importee.endsWith('.js') && importee.startsWith('.')) {
 				const resolvedPath = resolve(importer, '../', importee);
 				if (isSourceId(resolvedPath)) {
-					return toSourceExt(resolvedPath);
+					return toSourceExtension(resolvedPath);
 				}
 			}
 			return null;

--- a/src/project/rollup-plugin-plain-css.ts
+++ b/src/project/rollup-plugin-plain-css.ts
@@ -6,25 +6,25 @@ import {createFilter} from '@rollup/pluginutils';
 import {green} from '../colors/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import {GroCssBuild} from './types.js';
-import {hasExt} from '../utils/path.js';
+import {hasExtension} from '../utils/path.js';
 import {omitUndefined} from '../utils/object.js';
 
 export interface Options {
 	addCssBuild(build: GroCssBuild): boolean;
-	exts: string[]; // see comments below at `indexById` for why this exists
+	extensions: string[]; // see comments below at `sortIndexById` for why this exists
 	include: string | RegExp | (string | RegExp)[] | null;
 	exclude: string | RegExp | (string | RegExp)[] | null;
 }
 export type RequiredOptions = 'addCssBuild';
 export type InitialOptions = PartialExcept<Options, RequiredOptions>;
 export const initOptions = (opts: InitialOptions): Options => {
-	if (opts.include && !opts.exts) {
-		throw Error(`The 'exts' option must be provided along with 'include'`);
+	if (opts.include && !opts.extensions) {
+		throw Error(`The 'extensions' option must be provided along with 'include'`);
 	}
-	const exts = opts.exts || ['.css'];
+	const extensions = opts.extensions || ['.css'];
 	return {
-		exts,
-		include: opts.include || exts.map((ext) => `**/*${ext}`),
+		extensions,
+		include: opts.include || extensions.map((ext) => `**/*${ext}`),
 		exclude: null,
 		...omitUndefined(opts),
 	};
@@ -33,7 +33,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 export const name = 'plain-css';
 
 export const plainCssPlugin = (opts: InitialOptions): Plugin => {
-	const {addCssBuild, exts, include, exclude} = initOptions(opts);
+	const {addCssBuild, extensions, include, exclude} = initOptions(opts);
 
 	const log = new SystemLogger([green(`[${name}]`)]);
 
@@ -47,7 +47,7 @@ export const plainCssPlugin = (opts: InitialOptions): Plugin => {
 	const getSortIndex = (id: string): number => {
 		// Plain css is always appended to avoid messing up sourcemaps.
 		// Any css id that isn't plain css won't be cached, returning -1 here.
-		// See `indexById` above for why this exists.
+		// See `sortIndexById` above for why this exists.
 		const index = sortIndexById.get(id);
 		if (index === undefined) return -1;
 		return index;
@@ -58,8 +58,8 @@ export const plainCssPlugin = (opts: InitialOptions): Plugin => {
 		// see comments above for what this is doing
 		resolveId(importee, importer) {
 			// This is a hack that ignores `include`, but the whole thing is a hack.
-			// See the above comments at `indexById` for the explanation.
-			if (!hasExt(importee, exts) || !importer) return null;
+			// See the above comments at `sortIndexById` for the explanation.
+			if (!hasExtension(importee, extensions) || !importer) return null;
 			// Originally this used `this.resolve`,
 			// but it goes into an infinite loop when an importee doesn't exist,
 			// despite using `{skipSelf: true}`. So we manually resolve the id.

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,18 +1,18 @@
 import {test, t} from '../oki/oki.js';
-import {replaceExt, hasExt, getPathStem} from './path.js';
+import {replaceExtension, hasExtension, getPathStem} from './path.js';
 
-test('replaceExt', () => {
-	t.is(replaceExt('foo.ts', '.js'), 'foo.js');
-	t.is(replaceExt('foo.ts', ''), 'foo');
-	t.is(replaceExt('foo.ts', 'js'), 'foojs');
-	t.is(replaceExt('foo', '.js'), 'foo.js');
+test('replaceExtension', () => {
+	t.is(replaceExtension('foo.ts', '.js'), 'foo.js');
+	t.is(replaceExtension('foo.ts', ''), 'foo');
+	t.is(replaceExtension('foo.ts', 'js'), 'foojs');
+	t.is(replaceExtension('foo', '.js'), 'foo.js');
 });
 
-test('hasExt', () => {
-	t.ok(hasExt('foo.ts', ['.ts']));
-	t.ok(hasExt('foo.svelte', ['.ts', '.svelte']));
-	t.ok(!hasExt('foo.js', ['.ts', '.svelte']));
-	t.ok(!hasExt('foo.js', ['js']));
+test('hasExtension', () => {
+	t.ok(hasExtension('foo.ts', ['.ts']));
+	t.ok(hasExtension('foo.svelte', ['.ts', '.svelte']));
+	t.ok(!hasExtension('foo.js', ['.ts', '.svelte']));
+	t.ok(!hasExtension('foo.js', ['js']));
 });
 
 test('getPathStem', () => {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,11 +1,11 @@
 import {extname, basename} from 'path';
 
-export const replaceExt = (path: string, ext: string): string => {
+export const replaceExtension = (path: string, newExtension: string): string => {
 	const extension = extname(path);
-	return extension.length ? path.slice(0, -extension.length) + ext : path + ext;
+	return extension.length ? path.slice(0, -extension.length) + newExtension : path + newExtension;
 };
 
-export const hasExt = (path: string, exts: string[]): boolean =>
-	exts.some((ext) => extname(path) === ext);
+export const hasExtension = (path: string, extensions: string[]): boolean =>
+	extensions.some((e) => extname(path) === e);
 
-export const getPathStem = (path: string): string => replaceExt(basename(path), '');
+export const getPathStem = (path: string): string => replaceExtension(basename(path), '');


### PR DESCRIPTION
The preference I've shifted towards with your influence is to fully write out the names of things in most cases, and "ext" for "extension" is one of the last remaining examples that doesn't follow the newer pattern. Node and Unix use "ext" a lot but this fits the codebase better.