### PR TITLE
convert AssertionOperator from an enum to a union of string types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
   ([#47](https://github.com/feltcoop/gro/pull/47))
 - rename identifiers from "ext" to "extension" to follow newer convention
   ([#48](https://github.com/feltcoop/gro/pull/48))
+- convert `AssertionOperator` from an enum to a union of string types
+  ([#49](https://github.com/feltcoop/gro/pull/49))
 
 ## 0.3.0
 

--- a/src/oki/assertions.test.ts
+++ b/src/oki/assertions.test.ts
@@ -1,5 +1,5 @@
 import {test, t} from '../oki/oki.js';
-import {AssertionError, AssertionOperator} from './assertions.js';
+import {AssertionError} from './assertions.js';
 
 test('assertions', () => {
 	test('fail()', () => {
@@ -8,8 +8,8 @@ test('assertions', () => {
 			t.fail(message);
 		} catch (err) {
 			if (err instanceof AssertionError) {
-				if (err.assertion.operator !== AssertionOperator.fail) {
-					throw Error(`Expected error operator to be "${AssertionOperator.fail}"`);
+				if (err.assertion.operator !== 'fail') {
+					throw Error(`Expected error operator to be "${'fail'}"`);
 				}
 				return;
 			} else {
@@ -23,8 +23,8 @@ test('assertions', () => {
 			cb();
 		} catch (err) {
 			if (err instanceof AssertionError) {
-				if (err.assertion.operator !== AssertionOperator.throws) {
-					t.fail(`Expected error operator to be "${AssertionOperator.throws}"`);
+				if (err.assertion.operator !== 'throws') {
+					t.fail(`Expected error operator to be "${'throws'}"`);
 				}
 				return err; // success
 			} else {
@@ -90,8 +90,8 @@ test('assertions', () => {
 			await cb();
 		} catch (err) {
 			if (err instanceof AssertionError) {
-				if (err.assertion.operator !== AssertionOperator.rejects) {
-					t.fail(`Expected error operator to be "${AssertionOperator.rejects}"`);
+				if (err.assertion.operator !== 'rejects') {
+					t.fail(`Expected error operator to be "${'rejects'}"`);
 				}
 				return err; // success
 			} else {

--- a/src/oki/assertions.ts
+++ b/src/oki/assertions.ts
@@ -9,31 +9,31 @@ export class AssertionError extends Error {
 
 export const ok: (value: any) => asserts value = (value) => {
 	if (!value) {
-		throw new AssertionError({operator: AssertionOperator.ok, value});
+		throw new AssertionError({operator: 'ok', value});
 	}
 };
 
 export const is = <T>(actual: T, expected: T): void => {
 	if (!Object.is(actual, expected)) {
-		throw new AssertionError({operator: AssertionOperator.is, actual, expected});
+		throw new AssertionError({operator: 'is', actual, expected});
 	}
 };
 
 export const isNot = (actual: any, expected: any): void => {
 	if (Object.is(actual, expected)) {
-		throw new AssertionError({operator: AssertionOperator.isNot, actual, expected});
+		throw new AssertionError({operator: 'isNot', actual, expected});
 	}
 };
 
 export const equal = <T>(actual: T, expected: T): void => {
 	if (!deepEqual(actual, expected)) {
-		throw new AssertionError({operator: AssertionOperator.equal, actual, expected});
+		throw new AssertionError({operator: 'equal', actual, expected});
 	}
 };
 
 export const notEqual = (actual: any, expected: any): void => {
 	if (deepEqual(actual, expected)) {
-		throw new AssertionError({operator: AssertionOperator.notEqual, actual, expected});
+		throw new AssertionError({operator: 'notEqual', actual, expected});
 	}
 };
 
@@ -42,11 +42,11 @@ export const throws = (cb: () => void, matcher?: ErrorClass | RegExp | string): 
 		cb();
 	} catch (error) {
 		if (matcher !== undefined && !matchError(matcher, error)) {
-			throw new AssertionError({operator: AssertionOperator.throws, matcher, error});
+			throw new AssertionError({operator: 'throws', matcher, error});
 		}
 		return;
 	}
-	throw new AssertionError({operator: AssertionOperator.throws, matcher, error: null});
+	throw new AssertionError({operator: 'throws', matcher, error: null});
 };
 
 export const rejects = async (
@@ -58,11 +58,11 @@ export const rejects = async (
 		await promise;
 	} catch (error) {
 		if (matcher !== undefined && !matchError(matcher, error)) {
-			throw new AssertionError({operator: AssertionOperator.rejects, matcher, error});
+			throw new AssertionError({operator: 'rejects', matcher, error});
 		}
 		return;
 	}
-	throw new AssertionError({operator: AssertionOperator.rejects, matcher, error: null});
+	throw new AssertionError({operator: 'rejects', matcher, error: null});
 };
 
 export const matchError = (matcher: ErrorClass | RegExp | string, error: Error): boolean => {
@@ -80,7 +80,7 @@ export const fail = (message: string): never => {
 
 export class TestFailureError extends AssertionError {
 	constructor(message: string) {
-		super({operator: AssertionOperator.fail, message}, message);
+		super({operator: 'fail', message}, message);
 	}
 }
 
@@ -116,16 +116,15 @@ export const t: Assertions = {
 	Error: TestFailureError,
 };
 
-export enum AssertionOperator {
-	ok = 'ok', // truthy
-	is = 'is', // Object.is
-	isNot = 'isNot', // !Object.is
-	equal = 'equal', // deeply equal
-	notEqual = 'notEqual', // !deeply equal
-	throws = 'throws', // expects `cb` to throw an error that matches optional `matcher`
-	rejects = 'rejects', // expects `cbOrPromise` to throw an error that matches optional `matcher`
-	fail = 'fail', // throws an error
-}
+export type AssertionOperator =
+	| 'ok' // truthy
+	| 'is' // Object.is
+	| 'isNot' // !Object.is
+	| 'equal' // deeply equal
+	| 'notEqual' // !deeply equal
+	| 'throws' // expects `cb` to throw an error that matches optional `matcher`
+	| 'rejects' // expects `cbOrPromise` to throw an error that matches optional `matcher`
+	| 'fail'; // throws an error
 
 export type FailedAssertion =
 	| FailedAssertionOk
@@ -137,40 +136,40 @@ export type FailedAssertion =
 	| FailedAssertionRejects
 	| FailedAssertionFail;
 export type FailedAssertionOk = {
-	operator: AssertionOperator.ok;
+	operator: 'ok';
 	value: any;
 };
 export type FailedAssertionIs = {
-	operator: AssertionOperator.is;
+	operator: 'is';
 	expected: any;
 	actual: any;
 };
 export type FailedAssertionIsNot = {
-	operator: AssertionOperator.isNot;
+	operator: 'isNot';
 	expected: any;
 	actual: any;
 };
 export type FailedAssertionEqual = {
-	operator: AssertionOperator.equal;
+	operator: 'equal';
 	expected: any;
 	actual: any;
 };
 export type FailedAssertionNotEqual = {
-	operator: AssertionOperator.notEqual;
+	operator: 'notEqual';
 	expected: any;
 	actual: any;
 };
 export type FailedAssertionThrows = {
-	operator: AssertionOperator.throws;
+	operator: 'throws';
 	matcher: ErrorClass | RegExp | string | undefined;
 	error: Error | null;
 };
 export type FailedAssertionRejects = {
-	operator: AssertionOperator.rejects;
+	operator: 'rejects';
 	matcher: ErrorClass | RegExp | string | undefined;
 	error: Error | null;
 };
 export type FailedAssertionFail = {
-	operator: AssertionOperator.fail;
+	operator: 'fail';
 	message: string;
 };

--- a/src/oki/report.ts
+++ b/src/oki/report.ts
@@ -2,7 +2,7 @@ import {green, red, bgGreen, black, yellow, gray, cyan} from '../colors/terminal
 import {TestContext, TOTAL_TIMING, TestInstance} from './TestContext.js';
 import {printMs, printValue, printStr, printError} from '../utils/print.js';
 import {toSourcePath} from '../paths.js';
-import {AssertionError, AssertionOperator, FailedAssertion} from './assertions.js';
+import {AssertionError, FailedAssertion} from './assertions.js';
 import {UnreachableError, ErrorClass} from '../utils/error.js';
 
 export const reportIntro = (ctx: TestContext): void => {
@@ -89,25 +89,25 @@ export const reportAssertionError = (
 	);
 
 	switch (assertion.operator) {
-		case AssertionOperator.ok:
+		case 'ok':
 			log.plain(printValue(assertion.value));
 			break;
-		case AssertionOperator.is:
+		case 'is':
 			log.plain(printValue(assertion.actual));
 			log.plain(printValue(assertion.expected));
 			break;
-		case AssertionOperator.isNot:
+		case 'isNot':
 			log.plain(printValue(assertion.expected));
 			break;
-		case AssertionOperator.equal:
+		case 'equal':
 			log.plain(printValue(assertion.actual));
 			log.plain(printValue(assertion.expected));
 			break;
-		case AssertionOperator.notEqual:
+		case 'notEqual':
 			log.plain(printValue(assertion.expected));
 			break;
-		case AssertionOperator.throws:
-		case AssertionOperator.rejects:
+		case 'throws':
+		case 'rejects':
 			const logArgs: any[] = [];
 			if (assertion.error) {
 				if (assertion.matcher) {
@@ -117,7 +117,7 @@ export const reportAssertionError = (
 			}
 			log.plain(...logArgs);
 			break;
-		case AssertionOperator.fail:
+		case 'fail':
 			log.plain(printError(error));
 			break;
 		default:
@@ -128,7 +128,7 @@ export const reportAssertionError = (
 
 const printFailedAssertion = (assertion: FailedAssertion): string => {
 	switch (assertion.operator) {
-		case AssertionOperator.fail: {
+		case 'fail': {
 			return red('fail asserted in test:');
 		}
 		default: {


### PR DESCRIPTION
This is a small breaking change that converts the `AssertionOperator` in the testing framework from a string enum to a union type of strings. This makes it less verbose and easier for consumers to use, because it no longer requires an explicit import.