### PR TITLE
rename AsyncState to AsyncStatus and convert it to union type

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@
   ([#48](https://github.com/feltcoop/gro/pull/48))
 - convert `AssertionOperator` from an enum to a union of string types
   ([#49](https://github.com/feltcoop/gro/pull/49))
+- rename `AsyncState` to `AsyncStatus` and convert it from an enum to a union of string types
+  ([#50](https://github.com/feltcoop/gro/pull/50))
 
 ## 0.3.0
 

--- a/src/oki/TestContext.ts
+++ b/src/oki/TestContext.ts
@@ -1,6 +1,6 @@
 import {cyan} from '../colors/terminal.js';
 import {Logger, LogLevel, SystemLogger} from '../utils/log.js';
-import {AsyncState} from '../utils/async.js';
+import {AsyncStatus} from '../utils/async.js';
 import {omitUndefined} from '../utils/object.js';
 import {createFileCache} from '../project/fileCache.js';
 import {Timings} from '../utils/time.js';
@@ -107,23 +107,23 @@ export class TestContext {
 	}
 
 	// TODO re-run?
-	runState = AsyncState.Initial;
+	runState: AsyncStatus = 'initial';
 	async run(): Promise<TestRunResult> {
 		const timings = new Timings<TestRunTimings>();
 		const timingToRunTests = timings.start('run tests');
-		if (this.runState !== AsyncState.Initial) {
+		if (this.runState !== 'initial') {
 			throw Error(`TestContext was already run`);
 		}
-		this.runState = AsyncState.Pending;
+		this.runState = 'pending';
 		this.onRunBegin();
 		try {
 			await this.runTests();
 		} catch (err) {
-			this.runState = AsyncState.Failure;
+			this.runState = 'failure';
 			this.onRunEnd();
 			throw err;
 		}
-		this.runState = AsyncState.Success;
+		this.runState = 'success';
 		this.onRunEnd();
 		timingToRunTests();
 		return {stats: this.stats!, timings};

--- a/src/oki/TestContext.ts
+++ b/src/oki/TestContext.ts
@@ -1,6 +1,6 @@
 import {cyan} from '../colors/terminal.js';
 import {Logger, LogLevel, SystemLogger} from '../utils/log.js';
-import {AsyncStatus} from '../utils/async.js';
+import type {AsyncStatus} from '../utils/async.js';
 import {omitUndefined} from '../utils/object.js';
 import {createFileCache} from '../project/fileCache.js';
 import {Timings} from '../utils/time.js';

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,8 +1,3 @@
-export enum AsyncState {
-	Initial,
-	Pending,
-	Success,
-	Failure,
-}
+export type AsyncStatus = 'initial' | 'pending' | 'success' | 'failure';
 
 export const wait = (duration = 0) => new Promise((resolve) => setTimeout(resolve, duration));


### PR DESCRIPTION
This converts the `AsyncState` enum to a string union type and renames it to `AsyncStatus`. The name had been a continuous source of weirdness in consumer code, because "state" is a much less meaningful name than "status". Changing it to a string enum makes it less verbose and easier for consumer code because an explicit import is no longer required.