### PR TITLE
add caching compiler to replace tsc watchmode with swc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
   ([#45](https://github.com/feltcoop/gro/pull/45))
 - add the `compile` task and use `swc` for non-watchmode builds
   ([#46](https://github.com/feltcoop/gro/pull/46))
+- add `CachingCompiler` which uses `swc` to replace `tsc` watchmode
+  ([#51](https://github.com/feltcoop/gro/pull/51))
 - add stop function return value to `Timings#start`
   ([#47](https://github.com/feltcoop/gro/pull/47))
 - rename identifiers from "ext" to "extension" to follow newer convention

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "gro",
     "test": "gro test",
     "bootstrap": "rm -rf build/ dist/ && tsc && cp -r build/ dist/ && npm link",
-    "preversion": "npm run bootstrap && gro check && npm run bootstrap && gro project/build"
+    "preversion": "npm run bootstrap && gro check && npm run bootstrap && NODE_ENV=production gro project/build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "gro",
     "test": "gro test",
     "bootstrap": "rm -rf build/ dist/ && tsc && cp -r build/ dist/ && npm link",
-    "preversion": "npm run bootstrap && gro check && npm run bootstrap && NODE_ENV=production gro project/build"
+    "preversion": "npm run bootstrap && gro check && npm run bootstrap && gro project/build"
   },
   "repository": {
     "type": "git",

--- a/src/compile.task.ts
+++ b/src/compile.task.ts
@@ -1,11 +1,11 @@
 import {Task} from './task/task.js';
-import {compile} from './compile/compile.js';
+import {compileSourceDirectory} from './compile/compileSourceDirectory.js';
 import {cleanBuild} from './project/clean.js';
 
 export const task: Task = {
 	description: 'compiles all files to the build directory',
 	run: async ({log}) => {
 		await cleanBuild(log);
-		await compile(log);
+		await compileSourceDirectory(log);
 	},
 };

--- a/src/compile/CachingCompiler.ts
+++ b/src/compile/CachingCompiler.ts
@@ -1,0 +1,355 @@
+import {watchNodeFs, DEBOUNCE_DEFAULT, WatcherChange} from '../fs/watchNodeFs.js';
+import type {WatchNodeFs} from '../fs/watchNodeFs.js';
+import {
+	basePathToBuildId,
+	basePathToSourceId,
+	fromSourceMappedBuildIdToSourceId,
+	paths,
+	SOURCE_MAP_EXTENSION,
+	toBuildId,
+	toSourceId,
+	toSvelteExtension,
+	TS_EXTENSION,
+} from '../paths.js';
+import {omitUndefined} from '../utils/object.js';
+import {PathStats} from '../fs/pathData.js';
+import {findFiles, readFile, remove, ensureDir, outputFile, pathExists} from '../fs/nodeFs.js';
+import type {AsyncStatus} from '../utils/async.js';
+import {UnreachableError} from '../utils/error.js';
+import {Logger, SystemLogger} from '../utils/log.js';
+import {magenta, red} from '../colors/terminal.js';
+import {printPath} from '../utils/print.js';
+import {CompiledOutput, CompileFile} from './compileFile.js';
+
+// TODO ?? PathData ? look at its usage to unify, also `nodeFile.ts` with `loadFile` and `File`
+type PathInfo = FilePathInfo | DirectoryPathInfo;
+interface FilePathInfo {
+	id: string;
+	isDirectory: false;
+	// can be `null` during the file's compilation process
+	// TODO is this type the best way to handle this issue?
+	// happens on initialization, and maybe on errors?
+	// or do we keep previous values on errors?
+	contents: string | null;
+}
+interface DirectoryPathInfo {
+	id: string;
+	isDirectory: true;
+}
+
+interface Options {
+	compileFile: CompileFile;
+	sourceMap: boolean;
+	log: Logger;
+	sourceDir: string;
+	buildDir: string;
+	debounce: number;
+}
+type RequiredOptions = 'compileFile';
+type InitialOptions = PartialExcept<Options, RequiredOptions>;
+const initOptions = (opts: InitialOptions): Options => ({
+	sourceMap: true,
+	log: new SystemLogger([magenta('[CachingCompiler]')]),
+	sourceDir: paths.source,
+	buildDir: paths.build,
+	debounce: DEBOUNCE_DEFAULT,
+	...omitUndefined(opts),
+});
+
+export class CachingCompiler {
+	protected readonly watcher: WatchNodeFs;
+
+	readonly compileFile: CompileFile;
+	readonly sourceMap: boolean;
+	readonly log: Logger;
+	readonly sourceDir: string;
+	readonly buildDir: string;
+	readonly pathInfoByBuildId: Map<string, PathInfo> = new Map();
+	readonly pathInfoBySourceId: Map<string, PathInfo> = new Map();
+
+	initStatus: AsyncStatus = 'initial';
+
+	constructor(opts: InitialOptions) {
+		const {compileFile, sourceMap, log, sourceDir, buildDir, debounce} = initOptions(opts);
+		this.compileFile = compileFile;
+		this.sourceMap = sourceMap;
+		this.log = log;
+		this.sourceDir = sourceDir;
+		this.buildDir = buildDir;
+		this.watcher = watchNodeFs({
+			dir: sourceDir,
+			debounce,
+			onChange: this.onWatcherChange,
+		});
+	}
+
+	destroy(): void {
+		this.watcher.destroy();
+	}
+
+	async init(): Promise<void> {
+		if (this.initStatus !== 'initial') throw Error(`init cannot be called twice`);
+		this.initStatus = 'pending';
+
+		const [statsBySourcePath, statsByBuildPath] = await Promise.all([
+			this.watcher.init(),
+			findFiles(this.buildDir, undefined, null), // TODO gross
+		]);
+
+		const statsBySourceId = new Map<string, PathStats>();
+		for (const [path, stats] of statsBySourcePath) {
+			statsBySourceId.set(basePathToSourceId(path), stats);
+		}
+		const buildIds = Array.from(statsByBuildPath.keys()).map((p) => basePathToBuildId(p));
+
+		// this pattern helps us more easily parallelize work
+		const promises: Promise<void>[] = [];
+
+		// Clean up the build directory, removing any files that can't be mapped back to source files.
+		// This id helper makes it so `foo.js.map` files get deleted if source maps are turned off,
+		// unless there's a `foo.js.map` file in the source directory.
+		const fromBuildIdToSourceId = this.sourceMap ? fromSourceMappedBuildIdToSourceId : toSourceId;
+		for (const buildId of buildIds) {
+			const sourceId = fromBuildIdToSourceId(buildId);
+			if (statsBySourceId.has(sourceId)) continue;
+			const svelteSourceId = toSvelteExtension(sourceId);
+			if (statsBySourceId.has(svelteSourceId)) continue;
+			promises.push(remove(buildId));
+		}
+		await Promise.all(promises);
+		promises.length = 0;
+
+		// compile the source files and update the build directory's files and directories
+		for (const [id, stats] of statsBySourceId) {
+			promises.push(this.compileSourceId(id, stats.isDirectory()));
+		}
+		// promises.push(this.compileSourceId('/home/ryan/dev/gro/src/z.ts', false));
+
+		await Promise.all(promises);
+
+		this.initStatus = 'success';
+
+		// For efficiency, we initialize the watcher at the beginning of `init`,
+		// but this means watcher events may arrive before we finish initialization.
+		// Those should be enqueued until the `initStatus` is 'success',
+		// so we can flush them here to get up to speed.
+		await this.flushEnqueuedWatcherChanges();
+	}
+
+	// TODO similarly to the flushing enqueued changes,
+	// we may need to defer queries with a "compile lock" against the cache until any current processing is complete,
+	// at least for particular files,
+	// otherwise you may see bad mutated values while it's reading or writing to disk in `compileSourceId`.
+	// could it be as simple as `await currentCompilations`?
+	// or can we set `contents` to be `string | null` and be done with it?
+
+	private onWatcherChange = async (
+		change: WatcherChange,
+		path: string,
+		stats: PathStats,
+	): Promise<void> => {
+		if (this.initStatus !== 'success') {
+			this.enqueuedWatcherChanges.push([change, path, stats]);
+			return;
+		}
+		const id = basePathToSourceId(path);
+		switch (change) {
+			case 'create':
+			case 'update': {
+				this.compileSourceId(id, stats.isDirectory());
+				break;
+			}
+			case 'delete': {
+				this.destroySourceId(id);
+				break;
+			}
+			default:
+				throw new UnreachableError(change);
+		}
+	};
+
+	// TODO I thought source maps were NOT being checked for contents but they seem to be? (edit one in build)
+
+	// TODO could save in a map or set each id being compiled, and cancel compilation if a new one comes in
+	// store a global counter that increments each compile call, and store that in a map by id
+	// during compilation, after each async call check if the original id in the function closure is still current,
+	// and if not abort early
+
+	private async compileSourceId(id: string, isDirectory: boolean) {
+		if (!isDirectory && !id.endsWith(TS_EXTENSION)) return; // TODO svelte, markdown etc - pluggable compiler hooks!
+
+		// console.log('-------------------------------------------');
+		// console.log(id);
+		const {pathInfoBySourceId, pathInfoByBuildId, log} = this;
+
+		// We're not trusting 'create' vs 'update' from our file watcher.
+		// I think things are still efficient despite the slightly more complicated code.
+		// The flags `sourceNotInCache` and `buildNotInCache` handle those conditions.
+		let sourcePathInfo = pathInfoBySourceId.get(id);
+		let sourceNotInCache = !sourcePathInfo;
+		if (sourceNotInCache) {
+			sourcePathInfo = isDirectory
+				? {id, isDirectory: true}
+				: {id, isDirectory: false, contents: null};
+			pathInfoBySourceId.set(id, sourcePathInfo);
+			// if (isDirectory) {
+			// 	console.log('sourceNotInCache directory');
+			// } else {
+			// 	console.log('sourceNotInCache file READ DISK src/');
+			// }
+		}
+		const buildId = toBuildId(id);
+		let buildPathInfo = pathInfoByBuildId.get(buildId);
+		let buildNotInCache = !buildPathInfo;
+		if (buildNotInCache) {
+			// Read from disk and cache if it's a file.
+			// We can't defer populating the cache from disk because
+			// we exit early before getting to the `buildPathInfo.contents` comparison below
+			// if the source file has not changed.
+			// However we could parallelize this with reading the `sourceContents` from disk below.
+			buildPathInfo = isDirectory
+				? {id: buildId, isDirectory: true}
+				: {
+						id: buildId,
+						isDirectory: false,
+						contents: (await pathExists(buildId)) ? await readFile(buildId, 'utf8') : null,
+				  };
+			pathInfoByBuildId.set(buildId, buildPathInfo);
+			// if (isDirectory) {
+			// 	console.log('buildNotInCache directory');
+			// } else {
+			// 	console.log('buildNotInCache READ DISK build/');
+			// }
+		}
+		if (isDirectory) {
+			// handle a new or updated directory and exit early!!!
+			// console.log('EXIT EARLY dir!');
+			if (buildNotInCache) {
+				// TODO can we get away without this? seems a bit excessive
+				// console.log('NEW dir');
+				await ensureDir(buildId);
+			}
+			// console.log('-------------------------------------------');
+			return;
+		}
+
+		// TypeScript workaround - by this point we're exited for directories
+		sourcePathInfo = sourcePathInfo as FilePathInfo;
+		buildPathInfo = buildPathInfo as FilePathInfo;
+
+		const buildSourceMapId = buildId + SOURCE_MAP_EXTENSION;
+
+		// handle a new or updated file
+		const sourceContents = await readFile(id, 'utf8');
+		if (sourcePathInfo.contents !== sourceContents) {
+			sourcePathInfo.contents = sourceContents;
+		} else {
+			// Source code hasn't changed, do nothing and exit early!
+			// But wait, what if the source map is missing because the `sourceMap` option was off?
+			// We're going to assume that if the source map exists, it's in sync,
+			// in the same way that we're assuming that the build file is in sync
+			// when the cached source file hasn't changed.
+			// (TODO I'm beginning to think we want "dirty" flag checking - this could be flagged at startup,
+			// or whenever the `sourceMap` option changes at runtime)
+			if (!this.sourceMap || (await pathExists(buildSourceMapId))) {
+				// console.log('EXIT EARLY no change to source!  ' + id);
+				// console.log('-------------------------------------------');
+				// TODO what about pending compilations? hmmm........................ I think that'd be a bug, we'd need to track the current compilations and throw away work that's not the most recent
+				return;
+			}
+		}
+
+		// compile!
+		let output: CompiledOutput;
+		try {
+			// TODO doesn't handle multiple files for e.g. Svelte,
+			// and we're going to have to check each file against the compilation
+			// to avoid writing to disk like Svelte's CSS.
+			// Can we share code or at least interfaces with gen files? That's compilation!
+			output = await this.compileFile(id, sourceContents);
+		} catch (err) {
+			log.error(red('Failed to transpile TypeScript'), printPath(id));
+			throw err;
+		}
+
+		const promises: Promise<void>[] = [];
+
+		// compare the compiled code with the cache
+		if (buildPathInfo.contents !== output.code) {
+			log.trace('writing compiled file to disk', printPath(buildId));
+			buildPathInfo.contents = output.code;
+			promises.push(outputFile(buildId, buildPathInfo.contents));
+		} else {
+			// console.log('contents have NOT CHANGED! must have been cached in build directory');
+		}
+
+		// Even if output code has not changed,
+		// we still want to check the source map because it involves tricky corner cases.
+		// Without this, there could be stale or missing source maps in the cache
+		// when toggling source maps on and off.
+
+		// `output.map === undefined` when `sourceMap === false`
+		if (output.map === undefined) {
+			const deletedSourceMap = pathInfoByBuildId.delete(buildSourceMapId);
+			if (deletedSourceMap) {
+				log.trace('deleting source map on disk', printPath(buildSourceMapId));
+				promises.push(remove(buildSourceMapId));
+			}
+		} else {
+			let shouldOutputSourceMap = true;
+			let buildPathSourceMapInfo = pathInfoByBuildId.get(buildSourceMapId) as
+				| FilePathInfo
+				| undefined;
+			if (!buildPathSourceMapInfo) {
+				// console.log('new source map!');
+				buildPathSourceMapInfo = {
+					id: buildSourceMapId,
+					isDirectory: false,
+					contents: output.map,
+				};
+				pathInfoByBuildId.set(buildSourceMapId, buildPathSourceMapInfo);
+				// TODO can we avoid this check through inference?
+				// if the source map `pathExists` and we didn't `outputFile` for the build contents above, we could skip `readFile` I think
+				if (
+					(await pathExists(buildSourceMapId)) &&
+					(await readFile(buildSourceMapId, 'utf8')) === output.map
+				) {
+					// console.log('but not writing to disk because already there!');
+					shouldOutputSourceMap = false;
+				}
+			} else if (buildPathSourceMapInfo.contents === output.map) {
+				// probably can't happen but w/e
+				// console.log('source map unchanged!');
+				shouldOutputSourceMap = false;
+			} else {
+				// console.log('update source map!');
+				buildPathSourceMapInfo.contents = output.map;
+			}
+			if (shouldOutputSourceMap) {
+				log.trace('writing source map to disk', printPath(buildSourceMapId));
+				promises.push(outputFile(buildSourceMapId, buildPathSourceMapInfo.contents));
+			}
+		}
+
+		await Promise.all(promises);
+
+		// console.log('-------------------------------------------');
+	}
+
+	private async destroySourceId(id: string): Promise<void> {
+		this.log.trace('destroying file', printPath(id));
+		this.pathInfoBySourceId.delete(id);
+		const buildId = toBuildId(id);
+		this.pathInfoByBuildId.delete(buildId);
+		const sourceMapBuildId = buildId + SOURCE_MAP_EXTENSION;
+		const deletedSourceMap = this.pathInfoByBuildId.delete(sourceMapBuildId);
+		await Promise.all([remove(buildId), deletedSourceMap ? remove(sourceMapBuildId) : null]);
+	}
+
+	enqueuedWatcherChanges: [change: WatcherChange, path: string, stats: PathStats][] = [];
+	private async flushEnqueuedWatcherChanges(): Promise<void> {
+		for (const change of this.enqueuedWatcherChanges) {
+			await this.onWatcherChange(...change);
+		}
+	}
+}

--- a/src/compile/compileFile.ts
+++ b/src/compile/compileFile.ts
@@ -1,0 +1,61 @@
+import {extname} from 'path';
+import swc from '@swc/core';
+
+import {loadTsconfig} from './tsHelpers.js';
+import {
+	toSwcCompilerTarget,
+	mergeSwcOptions,
+	getDefaultSwcOptions,
+	addSourceMapFooter,
+} from './swcHelpers.js';
+import {Logger} from '../utils/log.js';
+import {SVELTE_EXTENSION, toSourceMapPath, TS_EXTENSION} from '../paths.js';
+
+export interface CompileFile {
+	(id: string, contents: string): Promise<CompiledOutput>;
+}
+export interface CompiledOutput {
+	code: string;
+	map?: string;
+}
+
+// TODO maybe make this optionally synchronous, so not `async` and not using promises when not needeD?
+// TODO how should options be handled? and additional file type compilations?
+// should `swcOptions` be passed in instead? Required or optional?
+// Or is this the friendliest way to do it,
+// so consumers can instantiate the `CachingCompiler` without any options?
+export const createCompileFile = (log: Logger): CompileFile => {
+	// load the TypeScript and swc options
+	// TODO somehow parameterize these
+	const tsconfigPath = undefined;
+	const basePath = undefined;
+	const tsconfig = loadTsconfig(log, tsconfigPath, basePath);
+	const target = toSwcCompilerTarget(tsconfig.compilerOptions?.target);
+	const sourceMap = tsconfig.compilerOptions?.sourceMap ?? process.env.NODE_ENV === 'development';
+	const swcOptions = getDefaultSwcOptions(target, sourceMap);
+
+	const compileFile: CompileFile = async (
+		id: string,
+		contents: string,
+	): Promise<CompiledOutput> => {
+		switch (extname(id)) {
+			case TS_EXTENSION: {
+				const finalSwcOptions = mergeSwcOptions(swcOptions, id);
+				const output = await swc.transform(contents, finalSwcOptions);
+
+				if (output.map) {
+					output.code = addSourceMapFooter(output.code, toSourceMapPath(id));
+				}
+				return output;
+			}
+			// TODO Svelte, see `src/build/rollup-plugin-gro-svelte.ts`
+			// Need to rework the caching compiler API to handle multiple output files.
+			// We should also unify this API with `GenFile` and the rest.
+			case SVELTE_EXTENSION:
+			default: {
+				return {code: contents};
+			}
+		}
+	};
+	return compileFile;
+};

--- a/src/compile/swcHelpers.ts
+++ b/src/compile/swcHelpers.ts
@@ -1,5 +1,5 @@
 import swc from '@swc/core';
-import {ScriptTarget} from 'typescript';
+import type {ScriptTarget} from 'typescript';
 import {dirname, relative, basename} from 'path';
 
 import {toBuildId, toSourceId} from '../paths.js';
@@ -31,30 +31,26 @@ export const toSwcCompilerTarget = (target: ScriptTarget | undefined): swc.JscTa
 	}
 };
 
-export const mergeSwcOptions = (
-	options: swc.Options,
-	target: swc.JscTarget,
-	path?: string,
-): swc.Options => ({
+export const mergeSwcOptions = (options: swc.Options, sourcePath: string): swc.Options => ({
 	...options,
-	jsc: {
-		...options.jsc,
-		target,
-	},
-	filename: path ? pathToSwcFilename(path) : undefined,
+	filename: sourcePath ? sourcePathToSwcFilename(sourcePath) : undefined,
 });
 
-export const getDefaultSwcOptions = (): swc.Options => ({
-	sourceMaps: true,
+export const getDefaultSwcOptions = (
+	target: swc.JscTarget = DEFAULT_TARGET,
+	sourceMap = true, // sticking with the naming convention of TypeScript and some other libs
+): swc.Options => ({
+	sourceMaps: sourceMap,
 	jsc: {
 		parser: {syntax: 'typescript', tsx: false, decorators: false, dynamicImport: true},
+		target,
 		externalHelpers: true,
 		loose: true, // TODO?
 	},
 });
 
-const pathToSwcFilename = (path: string): string =>
-	relative(dirname(toBuildId(path)), toSourceId(path));
+const sourcePathToSwcFilename = (sourcePath: string): string =>
+	relative(dirname(toBuildId(sourcePath)), toSourceId(sourcePath));
 
 export const addSourceMapFooter = (code: string, sourceMapPath: string): string =>
-	`${code}\n//# sourceMappingURL=${basename(sourceMapPath)}`;
+	`${code}//# sourceMappingURL=${basename(sourceMapPath)}`;

--- a/src/compile/tsHelpers.ts
+++ b/src/compile/tsHelpers.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import {dirname} from 'path';
+import {join, dirname, resolve} from 'path';
 
 import {black, bgRed} from '../colors/terminal.js';
 import {Logger} from '../utils/log.js';
@@ -18,11 +18,26 @@ export interface TsConfig {
 	compileOnSave?: boolean;
 }
 
+const tsconfigCache: Map<string, TsConfig> = new Map();
+
+// TODO This is pretty slow.
+// (10ms last I measured, might seem small but you can do a LOT of work in 10ms and it's *blocking*)
+// Caching helps but maybe we should just import the JSON, at least when only using swc?
+// Also we don't currently watch for changes, but could eventually,
+// way down the line when that's the biggest issue to address!
 export const loadTsconfig = (
 	log: Logger,
 	tsconfigPath?: string,
 	basePath = tsconfigPath ? dirname(tsconfigPath) : process.cwd(),
+	forceReload = false,
 ): TsConfig => {
+	// create a canonical cache key that can accept multiple variations
+	const cacheKey = join(resolve(basePath), tsconfigPath || 'tsconfig.json');
+	if (!forceReload) {
+		const cachedTsconfig = tsconfigCache.get(cacheKey);
+		if (cachedTsconfig) return cachedTsconfig;
+	}
+
 	if (!tsconfigPath) {
 		const searchPath = tsconfigPath || basePath;
 		tsconfigPath = ts.findConfigFile(searchPath, ts.sys.fileExists);
@@ -34,18 +49,20 @@ export const loadTsconfig = (
 	const readResult = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
 	if (readResult.error) logTsDiagnostics([readResult.error], log);
 
-	const config: TsConfig = readResult.config;
-	if (!config) throw Error(`Unable to read tsconfig from ${tsconfigPath}`);
+	const tsconfig: TsConfig = readResult.config;
+	if (!tsconfig) throw Error(`Unable to read tsconfig from ${tsconfigPath}`);
 
-	const rawCompilerOptions = config.compilerOptions;
+	const rawCompilerOptions = tsconfig.compilerOptions;
 	const convertResult = ts.convertCompilerOptionsFromJson(rawCompilerOptions, basePath);
 	if (convertResult.errors) logTsDiagnostics(convertResult.errors, log);
 
-	return {
-		...config,
-		compilerOptions: convertResult.options,
-		rawCompilerOptions,
-	};
+	// the TypeScript API generally uses the converted options,
+	// but sometimes it's better to have the plain JSON versions so we store both
+	tsconfig.compilerOptions = convertResult.options;
+	tsconfig.rawCompilerOptions = rawCompilerOptions;
+	tsconfigCache.set(cacheKey, tsconfig);
+
+	return tsconfig;
 };
 
 export const logTsDiagnostics = (diagnostics: ReadonlyArray<ts.Diagnostic>, log: Logger): void => {

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -1,11 +1,12 @@
 import {Task} from './task/task.js';
-import {spawnProcess} from './utils/process.js';
+import {CachingCompiler} from './compile/CachingCompiler.js';
+import {createCompileFile} from './compile/compileFile.js';
 
 const DEFAULT_SERVE_DIR = 'dist/';
 
 export const task: Task = {
 	description: 'start development server',
-	run: async ({args, invokeTask}): Promise<void> => {
+	run: async ({args, log, invokeTask}): Promise<void> => {
 		// TODO fix these
 		args.watch = true; // TODO always?
 		args.dir = args.dir || DEFAULT_SERVE_DIR;
@@ -17,11 +18,9 @@ export const task: Task = {
 		// .option('-w, --watch', 'Watch for changes and rebuild')
 		// .option('-P, --production', 'Set NODE_ENV to production')
 
-		await Promise.all([
-			invokeTask('build'),
-			spawnProcess('node_modules/.bin/tsc', ['-w']),
-			invokeTask('serve'),
-		]);
+		const compiler = new CachingCompiler({compileFile: createCompileFile(log)});
+
+		await Promise.all([invokeTask('build'), compiler.init(), invokeTask('serve')]);
 
 		// ...
 	},

--- a/src/fs/modules.ts
+++ b/src/fs/modules.ts
@@ -15,6 +15,8 @@ This has significant performance consequences and is friendly to future changes.
 Currently the implementations only use the filesystem,
 but eventually we'll have an in-memory virtual filesystem for dev watch mode.
 
+TODO now that `CachingCompiler` is here, integrate it further
+
 */
 
 export interface ModuleMeta<ModuleType = Obj> {

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -139,6 +139,14 @@ test('toSourceId()', () => {
 	test('distId with ts extension', () => {
 		t.is(toSourceId(resolve('dist/foo/bar/baz.ts')), resolve('src/foo/bar/baz.ts'));
 	});
+	test('directory sourceId', () => {
+		t.is(toSourceId(resolve('src/foo/bar')), resolve('src/foo/bar/'));
+		t.is(toSourceId(resolve('src/foo/bar') + '/'), resolve('src/foo/bar') + '/');
+	});
+	test('directory buildId', () => {
+		t.is(toSourceId(resolve('build/foo/bar')), resolve('src/foo/bar'));
+		t.is(toSourceId(resolve('build/foo/bar') + '/'), resolve('src/foo/bar') + '/');
+	});
 });
 
 test('toBuildId()', () => {
@@ -159,6 +167,14 @@ test('toBuildId()', () => {
 	});
 	test('distId with ts extension', () => {
 		t.is(toBuildId(resolve('build/foo/bar/baz.ts')), resolve('build/foo/bar/baz.ts'));
+	});
+	test('directory sourceId', () => {
+		t.is(toBuildId(resolve('src/foo/bar')), resolve('build/foo/bar/'));
+		t.is(toBuildId(resolve('src/foo/bar') + '/'), resolve('build/foo/bar') + '/');
+	});
+	test('directory buildId', () => {
+		t.is(toBuildId(resolve('build/foo/bar')), resolve('build/foo/bar'));
+		t.is(toBuildId(resolve('build/foo/bar') + '/'), resolve('build/foo/bar') + '/');
 	});
 });
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,7 +1,7 @@
 import {sep, join, basename} from 'path';
 import {fileURLToPath} from 'url';
 
-import {replaceExtension} from './utils/path.js';
+import {hasExtension, replaceExtension} from './utils/path.js';
 import {stripStart} from './utils/string.js';
 
 /*
@@ -123,8 +123,7 @@ export const SVELTE_EXTENSION = '.svelte';
 export const SOURCE_EXTENSIONS = [TS_EXTENSION, SVELTE_EXTENSION];
 export const SOURCE_MAP_EXTENSION = '.map';
 
-export const hasSourceExtension = (path: string): boolean =>
-	SOURCE_EXTENSIONS.some((ext) => path.endsWith(ext));
+export const hasSourceExtension = (path: string): boolean => hasExtension(path, SOURCE_EXTENSIONS);
 
 export const toSourceExtension = (path: string): string =>
 	path.endsWith(JS_EXTENSION) ? replaceExtension(path, TS_EXTENSION) : path; // TODO? how does this work with `.svelte`? do we need more metadata?
@@ -133,8 +132,17 @@ export const toSourceExtension = (path: string): string =>
 export const toCompiledExtension = (path: string): string =>
 	hasSourceExtension(path) ? replaceExtension(path, JS_EXTENSION) : path;
 
+// TODO need better integration with this
+export const toSvelteExtension = (path: string): string =>
+	path.endsWith(JS_EXTENSION) ? replaceExtension(path, SVELTE_EXTENSION) : path;
+
 export const toSourceMapPath = (path: string): string =>
 	`${toCompiledExtension(path)}${SOURCE_MAP_EXTENSION}`;
+
+// This differs from `toSourceId` by handling `.map` files, so it's not two-way.
+// There might be a cleaner design in here somewhere.
+export const fromSourceMappedBuildIdToSourceId = (id: string): string =>
+	toSourceId(id.endsWith(SOURCE_MAP_EXTENSION) ? replaceExtension(id, '') : id);
 
 // Gets the individual parts of a path, ignoring dots and separators.
 // toPathSegments('/foo/bar/baz.ts') => ['foo', 'bar', 'baz.ts']

--- a/src/project/build.task.ts
+++ b/src/project/build.task.ts
@@ -1,5 +1,8 @@
 import {Task} from '../task/task.js';
 
+// TODO how should this be done?
+process.env.NODE_ENV = 'production';
+
 export const task: Task = {
 	description: 'build, create, and link the distribution',
 	run: async ({invokeTask}) => {

--- a/src/project/rollup-plugin-diagnostics.ts
+++ b/src/project/rollup-plugin-diagnostics.ts
@@ -5,7 +5,7 @@ import {SystemLogger} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';
 import {createStopwatch} from '../utils/time.js';
 
-const name = 'diagnostics';
+export const name = 'diagnostics';
 
 const tag = (s: string) => s; // maybe color this
 

--- a/src/project/svelte-preprocess-typescript.ts
+++ b/src/project/svelte-preprocess-typescript.ts
@@ -21,22 +21,24 @@ No typechecking is performed - that's left for a separate build step.
 export interface Options {
 	langs: string[];
 	tsconfigPath: string | undefined;
+	basePath: string | undefined;
 }
 export type InitialOptions = Partial<Options>;
 export const initOptions = (opts: InitialOptions): Options => ({
 	langs: ['typescript'],
 	tsconfigPath: undefined,
+	basePath: undefined,
 	...omitUndefined(opts),
 });
 
 const name = 'svelte-preprocess-typescript';
 
 export const sveltePreprocessTypescript = (opts: InitialOptions = {}): PreprocessorGroup => {
-	const {langs, tsconfigPath} = initOptions(opts);
+	const {langs, tsconfigPath, basePath} = initOptions(opts);
 
 	const log = new SystemLogger([magenta(`[${name}]`)]);
 
-	const tsconfig = loadTsconfig(log, tsconfigPath);
+	const tsconfig = loadTsconfig(log, tsconfigPath, basePath);
 
 	return {
 		script({content, attributes, filename}) {

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -1,5 +1,5 @@
 import {magenta, cyan, red, gray} from '../colors/terminal.js';
-import {compile} from '../compile/compile.js';
+import {compileSourceDirectory} from '../compile/compileSourceDirectory.js';
 import {Args} from '../cli/types';
 import {SystemLogger, Logger} from '../utils/log.js';
 import {runTask} from './runTask.js';
@@ -79,7 +79,7 @@ export const invokeTask = async (taskName: string, args: Args): Promise<void> =>
 			if (await shouldBuildProject(pathData)) {
 				log.info('Task file not found in build directory. Compiling TypeScript...');
 				const timingToBuildProject = timings.start('build project');
-				await compile(log);
+				await compileSourceDirectory(log);
 				timingToBuildProject();
 			}
 

--- a/src/typecheck.task.ts
+++ b/src/typecheck.task.ts
@@ -9,5 +9,6 @@ export const task: Task = {
 		if (!typecheckResult.ok) {
 			throw new TaskError(`Failed to typecheck. ${printKeyValue('code', typecheckResult.code)}`);
 		}
+		console.log('hey lol');
 	},
 };

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -6,6 +6,6 @@ export const replaceExtension = (path: string, newExtension: string): string => 
 };
 
 export const hasExtension = (path: string, extensions: string[]): boolean =>
-	extensions.some((e) => extname(path) === e);
+	extensions.includes(extname(path));
 
 export const getPathStem = (path: string): string => replaceExtension(basename(path), '');


### PR DESCRIPTION
This adds the `src/compile/CachingCompiler.ts` module which replaces the TypeScript compiler watch mode `tsc -w` with `swc`. It's designed to avoid writing to disk and caches compiled files from `src/` to `build/`. I held back on adding too many options and extension points until they're driven by use cases. It currently does not handle Svelte (or any other compilers that product multiple files from one input file), but it'll speed up development wherever `tsc -w` was used, which was in both Gro and Felt.
