### PR TITLE
add svelte compilation to the unbundled compilation strategies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.4.1
+
+- add Svelte compilation to the unbundled compilation strategies
+  ([#52](https://github.com/feltcoop/gro/pull/52))
+
 ## 0.4.0
 
 - add `swc` dependency along with a Rollup plugin and Svelte preprocessor

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "gro",
     "test": "gro test",
     "bootstrap": "rm -rf build/ dist/ && tsc && cp -r build/ dist/ && npm link",
-    "preversion": "npm run bootstrap && gro check && npm run bootstrap && NODE_ENV=production gro project/build"
+    "preversion": "npm run bootstrap && gro check && npm run bootstrap && gro project/build"
   },
   "repository": {
     "type": "git",

--- a/src/compile/CachingCompiler.ts
+++ b/src/compile/CachingCompiler.ts
@@ -4,10 +4,10 @@ import {
 	basePathToBuildId,
 	basePathToSourceId,
 	fromSourceMappedBuildIdToSourceId,
+	hasSourceExtension,
 	paths,
 	toSourceId,
 	toSvelteExtension,
-	TS_EXTENSION,
 } from '../paths.js';
 import {omitUndefined} from '../utils/object.js';
 import {PathStats} from '../fs/pathData.js';
@@ -162,8 +162,7 @@ export class CachingCompiler {
 
 	private async compileSourceId(id: string, isDirectory: boolean) {
 		if (isDirectory) return; // TODO is this right? no behavior? the `fs-extra` methods handle missing directories
-		if (!isDirectory && !id.endsWith(TS_EXTENSION)) return; // TODO svelte, markdown etc - defer to the `compileFile` prop
-
+		if (!hasSourceExtension(id)) return; // TODO markdown etc - defer to the `compileFile` prop
 		const {compilations, log} = this;
 
 		const sourceContents = await readFile(id, 'utf8');
@@ -266,7 +265,6 @@ const syncFilesToDisk = async (
 					log.trace('writing new file to disk', printPath(newFile.id));
 					await outputFile(newFile.id, newFile.contents);
 				}
-				// else the cache was cold, but now it's warm
 			} else if (oldFile.contents === newFile.contents) {
 				return; // nothing changed, no need to update
 			} else {

--- a/src/compile/CachingCompiler.ts
+++ b/src/compile/CachingCompiler.ts
@@ -229,14 +229,16 @@ const sourceMapsAreBuilt = async (compilation: CachedCompilation): Promise<boole
 	return pathExists(sourceMapFile.id);
 };
 
-// This uses `Array#find` because the arrays are expected to be small,
-// because we're currently only using it for individual file compilations,
-// but that assumption might change and cause this code to be slow.
+// Given `newFiles` and `oldFiles`, updates everything on disk,
+// deleting files that no longer exist, writing new ones, and updating existing ones.
 const syncFilesToDisk = async (
 	newFiles: CompiledFile[],
 	oldFiles: CompiledFile[],
 	log: Logger,
 ): Promise<void> => {
+	// This uses `Array#find` because the arrays are expected to be small,
+	// because we're currently only using it for individual file compilations,
+	// but that assumption might change and cause this code to be slow.
 	await Promise.all([
 		...oldFiles.map((oldFile) => {
 			if (!newFiles.find((f) => f.id === oldFile.id)) {
@@ -252,13 +254,13 @@ const syncFilesToDisk = async (
 					!(await pathExists(newFile.id)) ||
 					(await readFile(newFile.id, 'utf8')) !== newFile.contents
 				) {
-					log.trace('writing new file to disk', printPath(newFile.id));
+					log.trace('creating file on disk', printPath(newFile.id));
 					await outputFile(newFile.id, newFile.contents);
 				}
 			} else if (oldFile.contents === newFile.contents) {
 				return; // nothing changed, no need to update
 			} else {
-				log.trace('writing changed file to disk', printPath(newFile.id));
+				log.trace('updating file on disk', printPath(newFile.id));
 				await outputFile(newFile.id, newFile.contents);
 			}
 		}),

--- a/src/compile/CachingCompiler.ts
+++ b/src/compile/CachingCompiler.ts
@@ -221,22 +221,12 @@ export class CachingCompiler {
 	}
 }
 
-// This assumes that if we find any source maps, the rest are there.
-// Seems like a safe assumption. The check is really needed when toggling source maps on and off.
+// The check is needed to handle source maps being toggled on and off.
+// It assumes that if we find any source maps, the rest are there.
 const sourceMapsAreBuilt = async (compilation: CachedCompilation): Promise<boolean> => {
 	const sourceMapFile = compilation.files.find((f) => f.sourceMapOf);
 	if (!sourceMapFile) return true;
 	return pathExists(sourceMapFile.id);
-	// This code checks all source maps. I think it's unnececessary.
-	// let missing = false;
-	// await Promise.all(
-	// 	compilation.files.map(async (f) => {
-	// 		if (f.sourceMapOf && !(await pathExists(f.sourceMapOf))) {
-	// 			missing = true;
-	// 		}
-	// 	}),
-	// );
-	// return !missing;
 };
 
 // This uses `Array#find` because the arrays are expected to be small,

--- a/src/compile/CachingCompiler.ts
+++ b/src/compile/CachingCompiler.ts
@@ -5,8 +5,6 @@ import {
 	basePathToSourceId,
 	fromSourceMappedBuildIdToSourceId,
 	paths,
-	SOURCE_MAP_EXTENSION,
-	toBuildId,
 	toSourceId,
 	toSvelteExtension,
 	TS_EXTENSION,
@@ -19,22 +17,14 @@ import {UnreachableError} from '../utils/error.js';
 import {Logger, SystemLogger} from '../utils/log.js';
 import {magenta, red} from '../colors/terminal.js';
 import {printError, printPath} from '../utils/print.js';
-import {CompiledOutput, CompileFile} from './compileFile.js';
+import {CompileResult, CompiledFile, CompileFile} from './compileFile.js';
+import {extname} from 'path';
 
-// TODO look at unifying `PathInfo` with `PathData`, also `nodeFile.ts` with `loadFile` and `File`
-type PathInfo = FilePathInfo | DirectoryPathInfo;
-interface FilePathInfo {
-	id: string;
-	isDirectory: false;
-	// can be `null` during the file's compilation process
-	// TODO is this type the best way to handle this issue?
-	// happens on initialization, and maybe on errors?
-	// or do we keep previous values on errors?
-	contents: string | null;
-}
-interface DirectoryPathInfo {
-	id: string;
-	isDirectory: true;
+interface CachedCompilation {
+	sourceId: string;
+	sourceExtension: string;
+	sourceContents: string;
+	files: CompiledFile[];
 }
 
 interface Options {
@@ -64,8 +54,7 @@ export class CachingCompiler {
 	readonly log: Logger;
 	readonly sourceDir: string;
 	readonly buildDir: string;
-	readonly pathInfoByBuildId: Map<string, PathInfo> = new Map();
-	readonly pathInfoBySourceId: Map<string, PathInfo> = new Map();
+	readonly compilations: Map<string, CachedCompilation> = new Map();
 
 	initStatus: AsyncStatus = 'initial';
 
@@ -172,137 +161,57 @@ export class CachingCompiler {
 	// and if not abort early
 
 	private async compileSourceId(id: string, isDirectory: boolean) {
+		if (isDirectory) return; // TODO is this right? no behavior? the `fs-extra` methods handle missing directories
 		if (!isDirectory && !id.endsWith(TS_EXTENSION)) return; // TODO svelte, markdown etc - defer to the `compileFile` prop
 
-		const {pathInfoBySourceId, pathInfoByBuildId, log} = this;
+		const {compilations, log} = this;
 
-		// We're not trusting 'create' vs 'update' from our file watcher.
-		// I think things are still efficient despite the slightly more complicated code.
-		// The flags `sourceNotInCache` and `buildNotInCache` handle those conditions.
-		let sourcePathInfo = pathInfoBySourceId.get(id);
-		if (!sourcePathInfo) {
-			sourcePathInfo = isDirectory
-				? {id, isDirectory: true}
-				: {id, isDirectory: false, contents: null};
-			pathInfoBySourceId.set(id, sourcePathInfo);
-		}
-		const buildId = toBuildId(id);
-		let buildPathInfo = pathInfoByBuildId.get(buildId);
-		if (!buildPathInfo) {
-			// Read from disk and cache if it's a file.
-			// We can't defer populating the cache from disk because
-			// we exit early before getting to the `buildPathInfo.contents` comparison below
-			// if the source file has not changed.
-			// However we could parallelize this with reading the `sourceContents` from disk below.
-			buildPathInfo = isDirectory
-				? {id: buildId, isDirectory: true}
-				: {
-						id: buildId,
-						isDirectory: false,
-						contents: (await pathExists(buildId)) ? await readFile(buildId, 'utf8') : null,
-				  };
-			pathInfoByBuildId.set(buildId, buildPathInfo);
-		}
-		if (isDirectory) {
-			// Since `fs-extra` handles the creation of directories,
-			// we can just exit early without ensuring that it exists.
-			// We may want to ensure the directory exists but it seems like unnecessary overhead.
-			return;
-		}
-
-		// TypeScript workaround - by this point we're exited for directories
-		sourcePathInfo = sourcePathInfo as FilePathInfo;
-		buildPathInfo = buildPathInfo as FilePathInfo;
-
-		const buildSourceMapId = buildId + SOURCE_MAP_EXTENSION;
-
-		// Handle a new or updated file
 		const sourceContents = await readFile(id, 'utf8');
-		if (sourcePathInfo.contents === sourceContents) {
-			// Source code hasn't changed, do nothing and exit early!
-			// But wait, what if the source map is missing because the `sourceMap` option was off?
-			// We're going to assume that if the source map exists, it's in sync,
-			// in the same way that we're assuming that the build file is in sync
+
+		let compilation = compilations.get(id);
+		if (!compilation) {
+			// Memory cache is cold.
+			compilation = {sourceId: id, sourceExtension: extname(id), sourceContents, files: []};
+			compilations.set(id, compilation);
+		} else if (compilation.sourceContents === sourceContents) {
+			// Memory cache is warm and source code hasn't changed, do nothing and exit early!
+			// But wait, what if the source maps are missing because the `sourceMap` option was off
+			// the last time the files were built?
+			// We're going to assume that if the source maps exist, they're in sync,
+			// in the same way that we're assuming that the build file is in sync if it exists
 			// when the cached source file hasn't changed.
-			if (!this.sourceMap || (await pathExists(buildSourceMapId))) {
+			if (!this.sourceMap || (await sourceMapsAreBuilt(compilation))) {
 				// TODO what about pending compilations? I think that'd be a bug, we'd need to track the current compilations and throw away work that's not the most recent
 				return;
 			}
+		} else {
+			// Memory cache is warm, but contents have changed.
+			compilation.sourceContents = sourceContents;
 		}
-		sourcePathInfo.contents = sourceContents;
 
-		// compile!
-		let output: CompiledOutput;
+		// Compile this one file, which may turn into one or many.
+		let result: CompileResult;
 		try {
-			output = await this.compileFile(id, sourceContents);
+			result = await this.compileFile(id, sourceContents, compilation?.sourceExtension);
 		} catch (err) {
 			log.error(red('compileFile failed for'), printPath(id), printError(err));
 			return;
 		}
 
-		const promises: Promise<void>[] = [];
+		// Update the cache.
+		const oldFiles = compilation.files;
+		compilation.files = result.files;
 
-		// Compare the compiled code with the cache
-		if (buildPathInfo.contents !== output.code) {
-			log.trace('writing compiled file to disk', printPath(buildId));
-			buildPathInfo.contents = output.code;
-			promises.push(outputFile(buildId, buildPathInfo.contents));
-		}
-
-		// Even if output code has not changed,
-		// we still want to check the source map because it involves tricky corner cases.
-		// Without this, there could be stale or missing source maps in the cache
-		// when toggling source maps on and off.
-
-		// `output.map === undefined` when `sourceMap === false`
-		if (output.map === undefined) {
-			const deletedSourceMap = pathInfoByBuildId.delete(buildSourceMapId);
-			if (deletedSourceMap) {
-				log.trace('deleting source map on disk', printPath(buildSourceMapId));
-				promises.push(remove(buildSourceMapId));
-			}
-		} else {
-			let shouldOutputSourceMap = true;
-			let buildPathSourceMapInfo = pathInfoByBuildId.get(buildSourceMapId) as
-				| FilePathInfo
-				| undefined;
-			if (!buildPathSourceMapInfo) {
-				buildPathSourceMapInfo = {
-					id: buildSourceMapId,
-					isDirectory: false,
-					contents: output.map,
-				};
-				pathInfoByBuildId.set(buildSourceMapId, buildPathSourceMapInfo);
-				// TODO can we avoid this check through inference?
-				// if the source map `pathExists` and we didn't `outputFile` for the build contents above, we could skip `readFile` I think
-				if (
-					(await pathExists(buildSourceMapId)) &&
-					(await readFile(buildSourceMapId, 'utf8')) === output.map
-				) {
-					shouldOutputSourceMap = false;
-				}
-			} else if (buildPathSourceMapInfo.contents === output.map) {
-				shouldOutputSourceMap = false;
-			} else {
-				buildPathSourceMapInfo.contents = output.map;
-			}
-			if (shouldOutputSourceMap) {
-				log.trace('writing source map to disk', printPath(buildSourceMapId));
-				promises.push(outputFile(buildSourceMapId, buildPathSourceMapInfo.contents));
-			}
-		}
-
-		await Promise.all(promises);
+		// Write to disk.
+		await syncFilesToDisk(compilation.files, oldFiles, log);
 	}
 
 	private async destroySourceId(id: string): Promise<void> {
 		this.log.trace('destroying file', printPath(id));
-		this.pathInfoBySourceId.delete(id);
-		const buildId = toBuildId(id);
-		this.pathInfoByBuildId.delete(buildId);
-		const sourceMapBuildId = buildId + SOURCE_MAP_EXTENSION;
-		const deletedSourceMap = this.pathInfoByBuildId.delete(sourceMapBuildId);
-		await Promise.all([remove(buildId), deletedSourceMap ? remove(sourceMapBuildId) : null]);
+		const compilation = this.compilations.get(id);
+		if (!compilation) throw Error(`Cannot destroy missing compilation ${id}`);
+		this.compilations.delete(id);
+		await syncFilesToDisk([], compilation.files, this.log);
 	}
 
 	enqueuedWatcherChanges: [change: WatcherChange, path: string, stats: PathStats][] = [];
@@ -312,3 +221,58 @@ export class CachingCompiler {
 		}
 	}
 }
+
+// This assumes that if we find any source maps, the rest are there.
+// Seems like a safe assumption. The check is really needed when toggling source maps on and off.
+const sourceMapsAreBuilt = async (compilation: CachedCompilation): Promise<boolean> => {
+	const sourceMapFile = compilation.files.find((f) => f.sourceMapOf);
+	if (!sourceMapFile) return true;
+	return pathExists(sourceMapFile.id);
+	// This code checks all source maps. I think it's unnececessary.
+	// let missing = false;
+	// await Promise.all(
+	// 	compilation.files.map(async (f) => {
+	// 		if (f.sourceMapOf && !(await pathExists(f.sourceMapOf))) {
+	// 			missing = true;
+	// 		}
+	// 	}),
+	// );
+	// return !missing;
+};
+
+// This uses `Array#find` because the arrays are expected to be small,
+// because we're currently only using it for individual file compilations,
+// but that assumption might change and cause this code to be slow.
+const syncFilesToDisk = async (
+	newFiles: CompiledFile[],
+	oldFiles: CompiledFile[],
+	log: Logger,
+): Promise<void> => {
+	await Promise.all([
+		...oldFiles.map((oldFile) => {
+			if (!newFiles.find((f) => f.id === oldFile.id)) {
+				log.trace('deleting file on disk', printPath(oldFile.id));
+				return remove(oldFile.id);
+			}
+			return undefined;
+		}),
+		...newFiles.map(async (newFile) => {
+			const oldFile = oldFiles.find((f) => f.id === newFile.id);
+			if (!oldFile) {
+				if (
+					!(await pathExists(newFile.id)) ||
+					(await readFile(newFile.id, 'utf8')) !== newFile.contents
+				) {
+					log.trace('writing new file to disk', printPath(newFile.id));
+					await outputFile(newFile.id, newFile.contents);
+				}
+				// else the cache was cold, but now it's warm
+			} else if (oldFile.contents === newFile.contents) {
+				return; // nothing changed, no need to update
+			} else {
+				log.trace('writing changed file to disk', printPath(newFile.id));
+				await outputFile(newFile.id, newFile.contents);
+			}
+		}),
+	]);
+};

--- a/src/compile/compileFile.ts
+++ b/src/compile/compileFile.ts
@@ -26,7 +26,7 @@ import {
 	TS_EXTENSION,
 } from '../paths.js';
 import {sveltePreprocessSwc} from '../project/svelte-preprocess-swc.js';
-import {getPathStem, replaceExtension} from '../utils/path.js';
+import {replaceExtension} from '../utils/path.js';
 import {omitUndefined} from '../utils/object.js';
 
 export interface CompileFile {
@@ -87,6 +87,7 @@ export const createCompileFile = (opts: InitialOptions): CompileFile => {
 	const {
 		log,
 		dev,
+		sourceMap,
 		swcOptions,
 		svelteCompileOptions,
 		sveltePreprocessor,
@@ -145,7 +146,7 @@ export const createCompileFile = (opts: InitialOptions): CompileFile => {
 					dev,
 					...svelteCompileOptions,
 					filename: id,
-					name: getPathStem(id),
+					// name: getPathStem(id), // TODO this causes warnings with Sapper routes
 				});
 				const {js, css, warnings, stats} = output;
 
@@ -158,7 +159,7 @@ export const createCompileFile = (opts: InitialOptions): CompileFile => {
 				const cssBuildId = replaceExtension(jsBuildId, CSS_EXTENSION);
 
 				const files: CompiledFile[] = [{id: jsBuildId, contents: js.code}];
-				if (js.map) {
+				if (sourceMap && js.map) {
 					files.push({
 						id: jsBuildId + SOURCE_MAP_EXTENSION,
 						contents: JSON.stringify(js.map), // TODO ??? do we want to also store the object version?
@@ -167,7 +168,7 @@ export const createCompileFile = (opts: InitialOptions): CompileFile => {
 				}
 				if (css.code) {
 					files.push({id: cssBuildId, contents: css.code});
-					if (css.map) {
+					if (sourceMap && css.map) {
 						files.push({
 							id: cssBuildId + SOURCE_MAP_EXTENSION,
 							contents: JSON.stringify(css.map), // TODO ??? do we want to also store the object version?

--- a/src/compile/compileFile.ts
+++ b/src/compile/compileFile.ts
@@ -11,7 +11,7 @@ import {
 	getDefaultSwcOptions,
 	addSourceMapFooter,
 } from './swcHelpers.js';
-import {baseCompileOptions, SvelteCompilation} from './svelteHelpers.js';
+import {baseSvelteCompileOptions, SvelteCompilation} from './svelteHelpers.js';
 import {Logger} from '../utils/log.js';
 import {
 	CSS_EXTENSION,
@@ -86,8 +86,11 @@ export const createCompileFile = (log: Logger): CompileFile => {
 			// We should also unify this API with `GenFile` and the rest.
 			case SVELTE_EXTENSION: {
 				// TODO options
-				const compileOptions: CompileOptions = {};
-				const preprocessor: PreprocessorGroup | PreprocessorGroup[] | null = sveltePreprocessSwc({
+				const svelteOptions: CompileOptions = {};
+				const sveltePreprocessor:
+					| PreprocessorGroup
+					| PreprocessorGroup[]
+					| null = sveltePreprocessSwc({
 					swcOptions,
 				});
 
@@ -95,9 +98,9 @@ export const createCompileFile = (log: Logger): CompileFile => {
 
 				// TODO see rollup-plugin-svelte for how to track deps
 				// let dependencies = [];
-				if (preprocessor) {
+				if (sveltePreprocessor) {
 					// log.trace('preprocess', printPath(id));
-					const preprocessed = await svelte.preprocess(contents, preprocessor, {
+					const preprocessed = await svelte.preprocess(contents, sveltePreprocessor, {
 						filename: id,
 					});
 					preprocessedCode = preprocessed.code;
@@ -108,9 +111,9 @@ export const createCompileFile = (log: Logger): CompileFile => {
 
 				// log.trace('compile', printPath(id));
 				const output: SvelteCompilation = svelte.compile(preprocessedCode, {
-					...baseCompileOptions,
+					...baseSvelteCompileOptions,
 					dev,
-					...compileOptions,
+					...svelteOptions,
 					filename: id,
 					name: getPathStem(id),
 				});

--- a/src/compile/compileFile.ts
+++ b/src/compile/compileFile.ts
@@ -79,10 +79,6 @@ export const initOptions = (opts: InitialOptions): Options => {
 };
 
 // TODO maybe make this optionally synchronous, so not `async` and not using promises when not needeD?
-// TODO how should options be handled? and additional file type compilations?
-// should `swcOptions` be passed in instead? Required or optional?
-// Or is this the friendliest way to do it,
-// so consumers can instantiate the `CachingCompiler` without any options?
 export const createCompileFile = (opts: InitialOptions): CompileFile => {
 	const {
 		log,
@@ -121,9 +117,6 @@ export const createCompileFile = (opts: InitialOptions): CompileFile => {
 				}
 				return {files};
 			}
-			// TODO Svelte, see `src/build/rollup-plugin-gro-svelte.ts`
-			// Need to rework the caching compiler API to handle multiple output files.
-			// We should also unify this API with `GenFile` and the rest.
 			case SVELTE_EXTENSION: {
 				let preprocessedCode: string;
 

--- a/src/compile/compileFile.ts
+++ b/src/compile/compileFile.ts
@@ -9,14 +9,22 @@ import {
 	addSourceMapFooter,
 } from './swcHelpers.js';
 import {Logger} from '../utils/log.js';
-import {SVELTE_EXTENSION, toSourceMapPath, TS_EXTENSION} from '../paths.js';
+import {SOURCE_MAP_EXTENSION, SVELTE_EXTENSION, toBuildId, TS_EXTENSION} from '../paths.js';
 
 export interface CompileFile {
-	(id: string, contents: string): Promise<CompiledOutput>;
+	(id: string, contents: string, extension?: string): Promise<CompileResult>;
 }
-export interface CompiledOutput {
-	code: string;
-	map?: string;
+export interface CompileResult {
+	// TODO might need to be a union with a type, like `extension: '.svelte'` with additional properties.
+	// Svelte compilation properties include `ast`, `warnings`, `vars`, and `stats`
+	files: CompiledFile[];
+}
+
+// TODO name? so close to `CompileFile` - maybe that should be renamed `FileCompiler`?
+export interface CompiledFile {
+	id: string;
+	contents: string;
+	sourceMapOf?: string; // TODO for source maps? hmm. maybe we want a union with an `isSourceMap` boolean flag?
 }
 
 // TODO maybe make this optionally synchronous, so not `async` and not using promises when not needeD?
@@ -37,23 +45,35 @@ export const createCompileFile = (log: Logger): CompileFile => {
 	const compileFile: CompileFile = async (
 		id: string,
 		contents: string,
-	): Promise<CompiledOutput> => {
-		switch (extname(id)) {
+		extension = extname(id),
+	): Promise<CompileResult> => {
+		switch (extension) {
 			case TS_EXTENSION: {
 				const finalSwcOptions = mergeSwcOptions(swcOptions, id);
 				const output = await swc.transform(contents, finalSwcOptions);
-
+				const buildId = toBuildId(id);
+				const sourceMapBuildId = buildId + SOURCE_MAP_EXTENSION;
+				const files: CompiledFile[] = [
+					{
+						id: buildId,
+						contents: output.map ? addSourceMapFooter(output.code, sourceMapBuildId) : output.code,
+					},
+				];
 				if (output.map) {
-					output.code = addSourceMapFooter(output.code, toSourceMapPath(id));
+					files.push({
+						id: sourceMapBuildId,
+						contents: output.map,
+						sourceMapOf: buildId,
+					});
 				}
-				return output;
+				return {files};
 			}
 			// TODO Svelte, see `src/build/rollup-plugin-gro-svelte.ts`
 			// Need to rework the caching compiler API to handle multiple output files.
 			// We should also unify this API with `GenFile` and the rest.
 			case SVELTE_EXTENSION:
 			default: {
-				return {code: contents};
+				return {files: [{id, contents}]};
 			}
 		}
 	};

--- a/src/compile/compileFile.ts
+++ b/src/compile/compileFile.ts
@@ -1,5 +1,8 @@
 import {extname} from 'path';
 import swc from '@swc/core';
+import svelte from 'svelte/compiler.js';
+import {PreprocessorGroup} from 'svelte/types/compiler/preprocess';
+import {CompileOptions} from 'svelte/types/compiler/interfaces';
 
 import {loadTsconfig} from './tsHelpers.js';
 import {
@@ -8,8 +11,17 @@ import {
 	getDefaultSwcOptions,
 	addSourceMapFooter,
 } from './swcHelpers.js';
+import {baseCompileOptions, SvelteCompilation} from './svelteHelpers.js';
 import {Logger} from '../utils/log.js';
-import {SOURCE_MAP_EXTENSION, SVELTE_EXTENSION, toBuildId, TS_EXTENSION} from '../paths.js';
+import {
+	CSS_EXTENSION,
+	SOURCE_MAP_EXTENSION,
+	SVELTE_EXTENSION,
+	toBuildId,
+	TS_EXTENSION,
+} from '../paths.js';
+import {sveltePreprocessSwc} from '../project/svelte-preprocess-swc.js';
+import {getPathStem, replaceExtension} from '../utils/path.js';
 
 export interface CompileFile {
 	(id: string, contents: string, extension?: string): Promise<CompileResult>;
@@ -33,13 +45,14 @@ export interface CompiledFile {
 // Or is this the friendliest way to do it,
 // so consumers can instantiate the `CachingCompiler` without any options?
 export const createCompileFile = (log: Logger): CompileFile => {
+	const dev = process.env.NODE_ENV === 'development'; // TODO
 	// load the TypeScript and swc options
 	// TODO somehow parameterize these
 	const tsconfigPath = undefined;
 	const basePath = undefined;
 	const tsconfig = loadTsconfig(log, tsconfigPath, basePath);
 	const target = toSwcCompilerTarget(tsconfig.compilerOptions?.target);
-	const sourceMap = tsconfig.compilerOptions?.sourceMap ?? process.env.NODE_ENV === 'development';
+	const sourceMap = tsconfig.compilerOptions?.sourceMap ?? dev;
 	const swcOptions = getDefaultSwcOptions(target, sourceMap);
 
 	const compileFile: CompileFile = async (
@@ -71,7 +84,65 @@ export const createCompileFile = (log: Logger): CompileFile => {
 			// TODO Svelte, see `src/build/rollup-plugin-gro-svelte.ts`
 			// Need to rework the caching compiler API to handle multiple output files.
 			// We should also unify this API with `GenFile` and the rest.
-			case SVELTE_EXTENSION:
+			case SVELTE_EXTENSION: {
+				// TODO options
+				const compileOptions: CompileOptions = {};
+				const preprocessor: PreprocessorGroup | PreprocessorGroup[] | null = sveltePreprocessSwc({
+					swcOptions,
+				});
+
+				let preprocessedCode: string;
+
+				// TODO see rollup-plugin-svelte for how to track deps
+				// let dependencies = [];
+				if (preprocessor) {
+					// log.trace('preprocess', printPath(id));
+					const preprocessed = await svelte.preprocess(contents, preprocessor, {
+						filename: id,
+					});
+					preprocessedCode = preprocessed.code;
+					// dependencies = preprocessed.dependencies; // TODO
+				} else {
+					preprocessedCode = contents;
+				}
+
+				// log.trace('compile', printPath(id));
+				const output: SvelteCompilation = svelte.compile(preprocessedCode, {
+					...baseCompileOptions,
+					dev,
+					...compileOptions,
+					filename: id,
+					name: getPathStem(id),
+				});
+				const {js, css /*, warnings, stats*/} = output;
+
+				// for (const warning of warnings) {
+				// 	onwarn(id, warning, handleWarn, this, log);
+				// }
+
+				const jsBuildId = toBuildId(id);
+				const cssBuildId = replaceExtension(jsBuildId, CSS_EXTENSION);
+
+				const files: CompiledFile[] = [{id: jsBuildId, contents: js.code}];
+				if (js.map) {
+					files.push({
+						id: jsBuildId + SOURCE_MAP_EXTENSION,
+						contents: JSON.stringify(js.map), // TODO ??? do we want to also store the object version?
+						sourceMapOf: jsBuildId,
+					});
+				}
+				if (css.code) {
+					files.push({id: cssBuildId, contents: css.code});
+					if (css.map) {
+						files.push({
+							id: cssBuildId + SOURCE_MAP_EXTENSION,
+							contents: JSON.stringify(css.map), // TODO ??? do we want to also store the object version?
+							sourceMapOf: cssBuildId,
+						});
+					}
+				}
+				return {files};
+			}
 			default: {
 				return {files: [{id, contents}]};
 			}

--- a/src/compile/compileSourceDirectory.ts
+++ b/src/compile/compileSourceDirectory.ts
@@ -12,6 +12,9 @@ import {CompileResult, createCompileFile} from './compileFile.js';
 export const compileSourceDirectory = async (log: Logger): Promise<void> => {
 	log.info('compiling...');
 
+	// TODO how to do this?
+	const dev = process.env.NODE_ENV === 'development';
+
 	const totalTiming = createStopwatch();
 	const timings = new Timings();
 	const logTimings = () => {
@@ -21,7 +24,7 @@ export const compileSourceDirectory = async (log: Logger): Promise<void> => {
 		log.info(`🕒 compiled in ${printMs(totalTiming())}`);
 	};
 
-	if (process.env.NODE_ENV === 'production') {
+	if (!dev) {
 		await spawnProcess('node_modules/.bin/tsc'); // ignore compiler errors
 		logTimings();
 		return;
@@ -46,7 +49,7 @@ export const compileSourceDirectory = async (log: Logger): Promise<void> => {
 	const results = new Map<string, string>();
 
 	const timingToSetupCompiler = timings.start('setup compiler');
-	const compileFile = createCompileFile(log);
+	const compileFile = createCompileFile({dev, log});
 	timingToSetupCompiler();
 
 	// compile everything

--- a/src/compile/compileSourceDirectory.ts
+++ b/src/compile/compileSourceDirectory.ts
@@ -1,7 +1,7 @@
 import {join} from 'path';
 
 import {spawnProcess} from '../utils/process.js';
-import {printMs, printPath, printTiming} from '../utils/print.js';
+import {printError, printMs, printPath, printTiming} from '../utils/print.js';
 import {Logger} from '../utils/log.js';
 import {createStopwatch, Timings} from '../utils/time.js';
 import {findFiles, outputFile, readFile} from '../fs/nodeFs.js';
@@ -56,15 +56,16 @@ export const compileSourceDirectory = async (log: Logger): Promise<void> => {
 	const timingToCompile = timings.start('compile');
 	await Promise.all(
 		Array.from(codeBySourceId.entries()).map(async ([id, code]) => {
-			let result: CompileResult;
+			let result: CompileResult | null = null;
 			try {
 				result = await compileFile(id, code);
 			} catch (err) {
-				log.error(red('Failed to transpile TypeScript'), printPath(id));
-				throw err;
+				log.error(red('Failed to transpile TypeScript'), printPath(id), printError(err));
 			}
-			for (const file of result.files) {
-				results.set(file.id, file.contents);
+			if (result) {
+				for (const file of result.files) {
+					results.set(file.id, file.contents);
+				}
 			}
 		}),
 	);

--- a/src/compile/compileSourceDirectory.ts
+++ b/src/compile/compileSourceDirectory.ts
@@ -5,7 +5,7 @@ import {printMs, printPath, printTiming} from '../utils/print.js';
 import {Logger} from '../utils/log.js';
 import {createStopwatch, Timings} from '../utils/time.js';
 import {findFiles, outputFile, readFile} from '../fs/nodeFs.js';
-import {paths, toBuildId} from '../paths.js';
+import {hasSourceExtension, paths, toBuildId} from '../paths.js';
 import {red} from '../colors/terminal.js';
 import {CompileResult, createCompileFile} from './compileFile.js';
 
@@ -29,7 +29,7 @@ export const compileSourceDirectory = async (log: Logger): Promise<void> => {
 
 	// load all files into memory
 	const stopTimingToFindFiles = timings.start('find files');
-	const statsByPath = await findFiles(paths.source, ({path}) => path.endsWith('.ts'), null);
+	const statsByPath = await findFiles(paths.source, ({path}) => hasSourceExtension(path), null);
 	stopTimingToFindFiles();
 	const timingToReadFiles = timings.start('read files');
 	const codeBySourceId = new Map<string, string>();

--- a/src/compile/svelteHelpers.ts
+++ b/src/compile/svelteHelpers.ts
@@ -31,21 +31,26 @@ export type SvelteCompilation = OmitStrict<
 	stats: SvelteCompileStats;
 };
 
+// Commented-out values are the same as the defaults.
 export const baseCompileOptions: CompileOptions = {
-	format: 'esm', // If "esm", creates a JavaScript module (with import and export). If "cjs", creates a CommonJS module (with require and module.exports), which is useful in some server-side rendering situations or for testing.
-	generate: 'dom', // If "dom", Svelte emits a JavaScript class for mounting to the DOM. If "ssr", Svelte emits an object with a render method suitable for server-side rendering. If false, no JavaScript or CSS is returned; just metadata.
-	dev: false, // If true, causes extra code to be added to components that will perform runtime checks and provide debugging information during development.
+	// filename: undefined, // `string` used for debugging hints and sourcemaps. Your bundler plugin will set it automatically.
+	// name: 'Component', // `string` that sets the name of the resulting JavaScript class (though the compiler will rename it if it would otherwise conflict with other variables in scope). It will normally be inferred from `filename`.
+	// format: 'esm', // If "esm", creates a JavaScript module (with import and export). If "cjs", creates a CommonJS module (with require and module.exports), which is useful in some server-side rendering situations or for testing.
+	// generate: 'dom', // If "dom", Svelte emits a JavaScript class for mounting to the DOM. If "ssr", Svelte emits an object with a render method suitable for server-side rendering. If false, no JavaScript or CSS is returned; just metadata.
+	// dev: false, // If true, causes extra code to be added to components that will perform runtime checks and provide debugging information during development.
 	immutable: true, // If true, tells the compiler that you promise not to mutate any objects. This allows it to be less conservative about checking whether values have changed.
-	hydratable: false, // If true, enables the hydrate: true runtime option, which allows a component to upgrade existing DOM rather than creating new DOM from scratch.
-	legacy: false, // If true, generates code that will work in IE9 and IE10, which don't support things like element.dataset.
-	accessors: false, // If true, getters and setters will be created for the component's props. If false, they will only be created for readonly exported values (i.e. those declared with const, class and function). If compiling with customElement: true this option defaults to true.
-	customElement: false, // If true, tells the compiler to generate a custom element constructor instead of a regular Svelte component.
-	tag: undefined, // A string that tells Svelte what tag name to register the custom element with. It must be a lowercase alphanumeric string with at least one hyphen, e.g. "my-element".
+	// hydratable: false, // If true, enables the hydrate: true runtime option, which allows a component to upgrade existing DOM rather than creating new DOM from scratch.
+	// legacy: false, // If true, generates code that will work in IE9 and IE10, which don't support things like element.dataset.
+	// accessors: false, // If true, getters and setters will be created for the component's props. If false, they will only be created for readonly exported values (i.e. those declared with const, class and function). If compiling with customElement: true this option defaults to true.
+	// customElement: false, // If true, tells the compiler to generate a custom element constructor instead of a regular Svelte component.
+	// tag: undefined, // A string that tells Svelte what tag name to register the custom element with. It must be a lowercase alphanumeric string with at least one hyphen, e.g. "my-element".
 	css: false, // If true, styles will be included in the JavaScript class and injected at runtime. It's recommended that you set this to false and use the CSS that is statically generated, as it will result in smaller JavaScript bundles and better performance.
-	preserveComments: false, // If true, your HTML comments will be preserved during server-side rendering. By default, they are stripped out.
-	preserveWhitespace: false, // If true, whitespace inside and between elements is kept as you typed it, rather than optimised by Svelte.
-	outputFilename: undefined, // A string used for your JavaScript sourcemap.
-	cssOutputFilename: undefined, // A string used for your CSS sourcemap.
+	// loopGuardTimeout: 0, // A `number` that tells Svelte to break the loop if it blocks the thread for more than `loopGuardTimeout` ms. This is useful to prevent infinite loops. Only available when `dev: true`
+	// preserveComments: false, // If true, your HTML comments will be preserved during server-side rendering. By default, they are stripped out.
+	// preserveWhitespace: false, // If true, whitespace inside and between elements is kept as you typed it, rather than optimised by Svelte.
+	// outputFilename: undefined, // A string used for your JavaScript sourcemap.
+	// cssOutputFilename: undefined, // A string used for your CSS sourcemap.
+	// sveltePath: 'svelte', //  	The location of the `svelte` package. Any imports from `svelte` or `svelte/[module]` will be modified accordingly.
 };
 
 // TODO make this more generic than tied to Svelte?

--- a/src/compile/svelteHelpers.ts
+++ b/src/compile/svelteHelpers.ts
@@ -58,8 +58,8 @@ export const handleWarn = (
 	id: string,
 	warning: Warning,
 	_handleWarn: (id: string, warning: Warning, ...args: any[]) => void,
-	_pluginContext: PluginContext,
 	log: Logger,
+	_pluginContext?: PluginContext,
 ): void => {
 	const warnArgs: any[] = [id, warning];
 	if (typeof warning !== 'string' && warning.frame) {
@@ -72,8 +72,8 @@ export const handleStats = (
 	id: string,
 	stats: SvelteCompileStats,
 	_handleStats: (id: string, stats: SvelteCompileStats, ...args: any[]) => void,
-	_pluginContext: PluginContext,
 	log: Logger,
+	_pluginContext?: PluginContext,
 ): void => {
 	log.info(
 		printKeyValue('stats', toRootPath(id)),

--- a/src/compile/svelteHelpers.ts
+++ b/src/compile/svelteHelpers.ts
@@ -32,7 +32,7 @@ export type SvelteCompilation = OmitStrict<
 };
 
 // Commented-out values are the same as the defaults.
-export const baseCompileOptions: CompileOptions = {
+export const baseSvelteCompileOptions: CompileOptions = {
 	// filename: undefined, // `string` used for debugging hints and sourcemaps. Your bundler plugin will set it automatically.
 	// name: 'Component', // `string` that sets the name of the resulting JavaScript class (though the compiler will rename it if it would otherwise conflict with other variables in scope). It will normally be inferred from `filename`.
 	// format: 'esm', // If "esm", creates a JavaScript module (with import and export). If "cjs", creates a CommonJS module (with require and module.exports), which is useful in some server-side rendering situations or for testing.

--- a/src/compile/svelteHelpers.ts
+++ b/src/compile/svelteHelpers.ts
@@ -1,0 +1,82 @@
+import type {ExistingRawSourceMap, PluginContext} from 'rollup';
+import type svelte from 'svelte/compiler.js';
+import {CompileOptions, Warning} from 'svelte/types/compiler/interfaces';
+
+import {Logger} from '../utils/log.js';
+import {yellow} from '../colors/terminal.js';
+import {printKeyValue, printMs} from '../utils/print.js';
+import {toRootPath} from '../paths.js';
+
+// TODO type could be improved, not sure how tho
+export interface SvelteCompileStats {
+	timings: {
+		total: number;
+		parse?: {total: number};
+		'create component'?: {total: number};
+	};
+}
+// TODO type belongs upstream - augmented for better safety
+export type SvelteCompilation = OmitStrict<
+	ReturnType<typeof svelte.compile>,
+	'js' | 'css' | 'stats'
+> & {
+	js: {
+		code: string;
+		map: ExistingRawSourceMap | undefined;
+	};
+	css: {
+		code: string | null;
+		map: ExistingRawSourceMap | undefined;
+	};
+	stats: SvelteCompileStats;
+};
+
+export const baseCompileOptions: CompileOptions = {
+	format: 'esm', // If "esm", creates a JavaScript module (with import and export). If "cjs", creates a CommonJS module (with require and module.exports), which is useful in some server-side rendering situations or for testing.
+	generate: 'dom', // If "dom", Svelte emits a JavaScript class for mounting to the DOM. If "ssr", Svelte emits an object with a render method suitable for server-side rendering. If false, no JavaScript or CSS is returned; just metadata.
+	dev: false, // If true, causes extra code to be added to components that will perform runtime checks and provide debugging information during development.
+	immutable: true, // If true, tells the compiler that you promise not to mutate any objects. This allows it to be less conservative about checking whether values have changed.
+	hydratable: false, // If true, enables the hydrate: true runtime option, which allows a component to upgrade existing DOM rather than creating new DOM from scratch.
+	legacy: false, // If true, generates code that will work in IE9 and IE10, which don't support things like element.dataset.
+	accessors: false, // If true, getters and setters will be created for the component's props. If false, they will only be created for readonly exported values (i.e. those declared with const, class and function). If compiling with customElement: true this option defaults to true.
+	customElement: false, // If true, tells the compiler to generate a custom element constructor instead of a regular Svelte component.
+	tag: undefined, // A string that tells Svelte what tag name to register the custom element with. It must be a lowercase alphanumeric string with at least one hyphen, e.g. "my-element".
+	css: false, // If true, styles will be included in the JavaScript class and injected at runtime. It's recommended that you set this to false and use the CSS that is statically generated, as it will result in smaller JavaScript bundles and better performance.
+	preserveComments: false, // If true, your HTML comments will be preserved during server-side rendering. By default, they are stripped out.
+	preserveWhitespace: false, // If true, whitespace inside and between elements is kept as you typed it, rather than optimised by Svelte.
+	outputFilename: undefined, // A string used for your JavaScript sourcemap.
+	cssOutputFilename: undefined, // A string used for your CSS sourcemap.
+};
+
+// TODO make this more generic than tied to Svelte?
+export const handleWarn = (
+	id: string,
+	warning: Warning,
+	_handleWarn: (id: string, warning: Warning, ...args: any[]) => void,
+	_pluginContext: PluginContext,
+	log: Logger,
+): void => {
+	const warnArgs: any[] = [id, warning];
+	if (typeof warning !== 'string' && warning.frame) {
+		warnArgs.push('\n' + warning.frame, '\n', yellow(warning.message));
+	}
+	log.warn(...warnArgs);
+};
+
+export const handleStats = (
+	id: string,
+	stats: SvelteCompileStats,
+	_handleStats: (id: string, stats: SvelteCompileStats, ...args: any[]) => void,
+	_pluginContext: PluginContext,
+	log: Logger,
+): void => {
+	log.info(
+		printKeyValue('stats', toRootPath(id)),
+		...[
+			printKeyValue('total', printMs(stats.timings.total)),
+			stats.timings.parse && printKeyValue('parse', printMs(stats.timings.parse.total)),
+			stats.timings['create component'] &&
+				printKeyValue('create', printMs(stats.timings['create component'].total)),
+		].filter(Boolean),
+	);
+};

--- a/src/compile/svelteHelpers.ts
+++ b/src/compile/svelteHelpers.ts
@@ -77,7 +77,7 @@ export const handleStats = (
 	log: Logger,
 	_pluginContext?: PluginContext,
 ): void => {
-	log.info(
+	log.trace(
 		printKeyValue('stats', toRootPath(id)),
 		...[
 			printKeyValue('total', printMs(stats.timings.total)),

--- a/src/compile/svelteHelpers.ts
+++ b/src/compile/svelteHelpers.ts
@@ -4,7 +4,7 @@ import {CompileOptions, Warning} from 'svelte/types/compiler/interfaces';
 
 import {Logger} from '../utils/log.js';
 import {yellow} from '../colors/terminal.js';
-import {printKeyValue, printMs} from '../utils/print.js';
+import {printKeyValue, printMs, printPath} from '../utils/print.js';
 import {toRootPath} from '../paths.js';
 
 // TODO type could be improved, not sure how tho
@@ -61,9 +61,11 @@ export const handleWarn = (
 	log: Logger,
 	_pluginContext?: PluginContext,
 ): void => {
-	const warnArgs: any[] = [id, warning];
-	if (typeof warning !== 'string' && warning.frame) {
+	const warnArgs: any[] = [printPath(id)];
+	if (warning.frame) {
 		warnArgs.push('\n' + warning.frame, '\n', yellow(warning.message));
+	} else {
+		warnArgs.push(warning);
 	}
 	log.warn(...warnArgs);
 };

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -18,7 +18,10 @@ export const task: Task = {
 		// .option('-w, --watch', 'Watch for changes and rebuild')
 		// .option('-P, --production', 'Set NODE_ENV to production')
 
-		const compiler = new CachingCompiler({compileFile: createCompileFile(log)});
+		// TODO how to do this?
+		const dev = process.env.NODE_ENV === 'development';
+
+		const compiler = new CachingCompiler({compileFile: createCompileFile({dev, log})});
 
 		await Promise.all([invokeTask('build'), compiler.init(), invokeTask('serve')]);
 

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -22,7 +22,6 @@ import {
 	toPathParts,
 	toPathSegments,
 	toImportId,
-	toSourceMapPath,
 } from './paths.js';
 
 test('createPaths()', () => {
@@ -217,12 +216,6 @@ test('toCompiledExtension()', () => {
 	test('svelte', () => {
 		t.is(toCompiledExtension('foo/bar/baz.svelte'), 'foo/bar/baz.js');
 	});
-});
-
-test('toSourceMapPath()', () => {
-	t.is(toSourceMapPath('foo.ts'), 'foo.js.map');
-	t.is(toSourceMapPath('foo.svelte'), 'foo.js.map');
-	t.is(toSourceMapPath('foo.js'), 'foo.js.map');
 });
 
 test('toPathSegments()', () => {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -136,9 +136,6 @@ export const toCompiledExtension = (path: string): string =>
 export const toSvelteExtension = (path: string): string =>
 	path.endsWith(JS_EXTENSION) ? replaceExtension(path, SVELTE_EXTENSION) : path;
 
-export const toSourceMapPath = (path: string): string =>
-	`${toCompiledExtension(path)}${SOURCE_MAP_EXTENSION}`;
-
 // This differs from `toSourceId` by handling `.map` files, so it's not two-way.
 // There might be a cleaner design in here somewhere.
 export const fromSourceMappedBuildIdToSourceId = (id: string): string =>

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -120,9 +120,11 @@ export const stripRelativePath = (path: string): string => stripStart(path, RELA
 export const JS_EXTENSION = '.js';
 export const TS_EXTENSION = '.ts';
 export const SVELTE_EXTENSION = '.svelte';
+export const CSS_EXTENSION = '.css';
 export const SOURCE_EXTENSIONS = [TS_EXTENSION, SVELTE_EXTENSION];
 export const SOURCE_MAP_EXTENSION = '.map';
 
+// TODO probably change this to use a regexp (benchmark?)
 export const hasSourceExtension = (path: string): boolean => hasExtension(path, SOURCE_EXTENSIONS);
 
 export const toSourceExtension = (path: string): string =>
@@ -133,8 +135,7 @@ export const toCompiledExtension = (path: string): string =>
 	hasSourceExtension(path) ? replaceExtension(path, JS_EXTENSION) : path;
 
 // TODO need better integration with this
-export const toSvelteExtension = (path: string): string =>
-	path.endsWith(JS_EXTENSION) ? replaceExtension(path, SVELTE_EXTENSION) : path;
+export const toSvelteExtension = (path: string): string => replaceExtension(path, SVELTE_EXTENSION);
 
 // This differs from `toSourceId` by handling `.map` files, so it's not two-way.
 // There might be a cleaner design in here somewhere.

--- a/src/project/build.ts
+++ b/src/project/build.ts
@@ -120,9 +120,7 @@ const createInputOptions = (inputFile: string, options: Options, _log: Logger): 
 				dev,
 				addCssBuild: addSvelteCssBuild,
 				preprocessor: [sveltePreprocessSwc({swcOptions})],
-				compileOptions: {
-					immutable: true,
-				},
+				compileOptions: {},
 			}),
 			groSwcPlugin({swcOptions}),
 			plainCssPlugin({addCssBuild: addPlainCssBuild}),

--- a/src/project/cssCache.ts
+++ b/src/project/cssCache.ts
@@ -4,7 +4,7 @@ import {printKeyValue, printPath} from '../utils/print.js';
 
 export interface CssBuild {
 	id: string;
-	code: string;
+	code: string | null;
 }
 
 export type CssBundle<T extends CssBuild = CssBuild> = {

--- a/src/project/dev.task.ts
+++ b/src/project/dev.task.ts
@@ -7,9 +7,11 @@ import {createCompileFile} from '../compile/compileFile.js';
 export const task: Task = {
 	description: 'build typescript in watch mode for development',
 	run: async ({log}) => {
-		const timings = new Timings();
+		// TODO how to do this?
+		const dev = process.env.NODE_ENV === 'development';
 
-		const compiler = new CachingCompiler({compileFile: createCompileFile(log)});
+		const timings = new Timings();
+		const compiler = new CachingCompiler({compileFile: createCompileFile({dev, log})});
 
 		const timingToInitCachingCompiler = timings.start('init caching compiler');
 		await compiler.init();

--- a/src/project/rollup-plugin-gro-svelte.ts
+++ b/src/project/rollup-plugin-gro-svelte.ts
@@ -113,10 +113,10 @@ export const groSveltePlugin = (opts: InitialOptions): GroSveltePlugin => {
 			const {js, css, warnings, stats} = svelteCompilation;
 
 			for (const warning of warnings) {
-				onwarn(id, warning, handleWarn, this, log);
+				onwarn(id, warning, handleWarn, log, this);
 			}
 
-			onstats(id, stats, handleStats, this, log);
+			onstats(id, stats, handleStats, log, this);
 
 			let cssId = replaceExtension(id, '.css');
 			log.trace('add css import', printPath(cssId));

--- a/src/project/rollup-plugin-gro-svelte.ts
+++ b/src/project/rollup-plugin-gro-svelte.ts
@@ -1,43 +1,24 @@
 import svelte from 'svelte/compiler.js';
 import {PreprocessorGroup} from 'svelte/types/compiler/preprocess';
-import {CompileOptions, Warning} from 'svelte/types/compiler/interfaces';
-import {Plugin, PluginContext, ExistingRawSourceMap} from 'rollup';
+import {CompileOptions} from 'svelte/types/compiler/interfaces';
+import {Plugin} from 'rollup';
 import {createFilter} from '@rollup/pluginutils';
 
-import {magenta, yellow, red} from '../colors/terminal.js';
+import {magenta, red} from '../colors/terminal.js';
 import {getPathStem, replaceExtension} from '../utils/path.js';
-import {SystemLogger, Logger} from '../utils/log.js';
-import {printKeyValue, printMs, printPath} from '../utils/print.js';
-import {toRootPath} from '../paths.js';
+import {SystemLogger} from '../utils/log.js';
+import {printPath} from '../utils/print.js';
 import {GroCssBuild} from './types.js';
 import {omitUndefined} from '../utils/object.js';
+import {
+	SvelteCompilation,
+	baseCompileOptions,
+	handleWarn,
+	handleStats,
+} from '../compile/svelteHelpers.js';
 
 // TODO support `package.json` "svelte" field
 // see reference here https://github.com/rollup/rollup-plugin-svelte/blob/master/index.js#L190
-
-// TODO type could be improved, not sure how tho
-interface Stats {
-	timings: {
-		total: number;
-		parse?: {total: number};
-		'create component'?: {total: number};
-	};
-}
-// TODO type belongs upstream - augmented for better safety
-export type SvelteCompilation = OmitStrict<
-	ReturnType<typeof svelte.compile>,
-	'js' | 'css' | 'stats'
-> & {
-	js: {
-		code: string;
-		map: ExistingRawSourceMap | undefined;
-	};
-	css: {
-		code: string;
-		map: ExistingRawSourceMap | undefined;
-	};
-	stats: Stats;
-};
 
 export type GroSvelteCompilation = SvelteCompilation & {
 	id: string;
@@ -69,23 +50,6 @@ export const initOptions = (opts: InitialOptions): Options => ({
 	onstats: handleStats,
 	...omitUndefined(opts),
 });
-
-const baseCompileOptions: CompileOptions = {
-	format: 'esm', // If "esm", creates a JavaScript module (with import and export). If "cjs", creates a CommonJS module (with require and module.exports), which is useful in some server-side rendering situations or for testing.
-	generate: 'dom', // If "dom", Svelte emits a JavaScript class for mounting to the DOM. If "ssr", Svelte emits an object with a render method suitable for server-side rendering. If false, no JavaScript or CSS is returned; just metadata.
-	dev: false, // If true, causes extra code to be added to components that will perform runtime checks and provide debugging information during development.
-	immutable: false, // If true, tells the compiler that you promise not to mutate any objects. This allows it to be less conservative about checking whether values have changed.
-	hydratable: false, // If true, enables the hydrate: true runtime option, which allows a component to upgrade existing DOM rather than creating new DOM from scratch.
-	legacy: false, // If true, generates code that will work in IE9 and IE10, which don't support things like element.dataset.
-	accessors: false, // If true, getters and setters will be created for the component's props. If false, they will only be created for readonly exported values (i.e. those declared with const, class and function). If compiling with customElement: true this option defaults to true.
-	customElement: false, // If true, tells the compiler to generate a custom element constructor instead of a regular Svelte component.
-	tag: undefined, // A string that tells Svelte what tag name to register the custom element with. It must be a lowercase alphanumeric string with at least one hyphen, e.g. "my-element".
-	css: false, // If true, styles will be included in the JavaScript class and injected at runtime. It's recommended that you set this to false and use the CSS that is statically generated, as it will result in smaller JavaScript bundles and better performance.
-	preserveComments: false, // If true, your HTML comments will be preserved during server-side rendering. By default, they are stripped out.
-	preserveWhitespace: false, // If true, whitespace inside and between elements is kept as you typed it, rather than optimised by Svelte.
-	outputFilename: undefined, // A string used for your JavaScript sourcemap.
-	cssOutputFilename: undefined, // A string used for your CSS sourcemap.
-};
 
 export interface GroSveltePlugin extends Plugin {
 	getCompilation: (id: string) => GroSvelteCompilation | undefined;
@@ -183,36 +147,4 @@ export const groSveltePlugin = (opts: InitialOptions): GroSveltePlugin => {
 			// };
 		},
 	};
-};
-
-const handleWarn = (
-	id: string,
-	warning: Warning,
-	_handleWarn: (id: string, warning: Warning, ...args: any[]) => void,
-	_pluginContext: PluginContext,
-	log: Logger,
-): void => {
-	const warnArgs: any[] = [id, warning];
-	if (typeof warning !== 'string' && warning.frame) {
-		warnArgs.push('\n' + warning.frame, '\n', yellow(warning.message));
-	}
-	log.warn(...warnArgs);
-};
-
-const handleStats = (
-	id: string,
-	stats: Stats,
-	_handleStats: (id: string, stats: Stats, ...args: any[]) => void,
-	_pluginContext: PluginContext,
-	log: Logger,
-): void => {
-	log.info(
-		printKeyValue('stats', toRootPath(id)),
-		...[
-			printKeyValue('total', printMs(stats.timings.total)),
-			stats.timings.parse && printKeyValue('parse', printMs(stats.timings.parse.total)),
-			stats.timings['create component'] &&
-				printKeyValue('create', printMs(stats.timings['create component'].total)),
-		].filter(Boolean),
-	);
 };

--- a/src/project/rollup-plugin-gro-svelte.ts
+++ b/src/project/rollup-plugin-gro-svelte.ts
@@ -12,7 +12,7 @@ import {GroCssBuild} from './types.js';
 import {omitUndefined} from '../utils/object.js';
 import {
 	SvelteCompilation,
-	baseCompileOptions,
+	baseSvelteCompileOptions,
 	handleWarn,
 	handleStats,
 } from '../compile/svelteHelpers.js';
@@ -100,7 +100,7 @@ export const groSveltePlugin = (opts: InitialOptions): GroSveltePlugin => {
 			let svelteCompilation: SvelteCompilation;
 			try {
 				svelteCompilation = svelte.compile(preprocessedCode, {
-					...baseCompileOptions,
+					...baseSvelteCompileOptions,
 					dev,
 					...compileOptions,
 					filename: id,

--- a/src/project/rollup-plugin-output-css.ts
+++ b/src/project/rollup-plugin-output-css.ts
@@ -10,7 +10,7 @@ import {omitUndefined} from '../utils/object.js';
 
 export interface Options {
 	getCssBundles(): Map<string, GroCssBundle>;
-	toFinalCss(build: GroCssBuild, log: Logger): string;
+	toFinalCss(build: GroCssBuild, log: Logger): string | null;
 	sourcemap: boolean; // TODO consider per-bundle options
 }
 export type RequiredOptions = 'getCssBundles';
@@ -116,4 +116,4 @@ export const outputCssPlugin = (opts: InitialOptions): Plugin => {
 	};
 };
 
-const toFinalCss = ({code}: GroCssBuild, _log: Logger): string => code || '';
+const toFinalCss = ({code}: GroCssBuild, _log: Logger): string | null => code;

--- a/src/project/rollup-plugin-output-css.ts
+++ b/src/project/rollup-plugin-output-css.ts
@@ -116,4 +116,4 @@ export const outputCssPlugin = (opts: InitialOptions): Plugin => {
 	};
 };
 
-const toFinalCss = ({code}: GroCssBuild, _log: Logger): string => code;
+const toFinalCss = ({code}: GroCssBuild, _log: Logger): string => code || '';

--- a/src/project/svelte-preprocess-swc.ts
+++ b/src/project/svelte-preprocess-swc.ts
@@ -43,7 +43,7 @@ export const sveltePreprocessSwc = (opts: InitialOptions): PreprocessorGroup => 
 			if (lang && !langs.includes(lang as string)) {
 				return null as any; // type is wrong
 			}
-			log.info('transpiling with swc', printPath(filename || ''));
+			// log.trace('transpiling with swc', printPath(filename || ''));
 			const finalSwcOptions = filename ? mergeSwcOptions(swcOptions, filename) : swcOptions;
 			let output: swc.Output;
 			try {


### PR DESCRIPTION
This adds Svelte compilation to the two unbundled compilation strategies, `compileSourceDirectory` and `CachingCompiler`, which replace `tsc` and `tsc -w` respectively during development. Gro already supports Svelte compilation through its Rollup plugin, but we're moving toward unbundled compilation during development (inspired by [Snowpack](https://www.snowpack.dev/)), and this is an important step, although the usecases it's designed for need more pieces finished before they're ready. The PR also significantly refactors `CachingCompiler`.