### PR TITLE
refactor filer types

### DIFF
--- a/src/compile/compiler.ts
+++ b/src/compile/compiler.ts
@@ -52,7 +52,7 @@ export interface BaseCompiledFile {
 export interface CompiledTextFile extends BaseCompiledFile {
 	encoding: 'utf8';
 	contents: string;
-	sourceMapOf?: string; // TODO for source maps? hmm. maybe we want a union with an `isSourceMap` boolean flag?
+	sourceMapOf: string | null; // TODO for source maps? hmm. maybe we want a union with an `isSourceMap` boolean flag?
 }
 export interface CompiledBinaryFile extends BaseCompiledFile {
 	encoding: null;
@@ -121,6 +121,7 @@ export const createCompiler = (opts: InitialOptions): Compiler => {
 						extension: JS_EXTENSION,
 						encoding: 'utf8',
 						contents: output.map ? addSourceMapFooter(output.code, sourceMapBuildId) : output.code,
+						sourceMapOf: null,
 					},
 				];
 				if (output.map) {
@@ -167,7 +168,13 @@ export const createCompiler = (opts: InitialOptions): Compiler => {
 				const cssBuildId = replaceExtension(jsBuildId, CSS_EXTENSION);
 
 				const files: CompiledFile[] = [
-					{id: jsBuildId, extension: JS_EXTENSION, encoding: 'utf8', contents: js.code},
+					{
+						id: jsBuildId,
+						extension: JS_EXTENSION,
+						encoding: 'utf8',
+						contents: js.code,
+						sourceMapOf: null,
+					},
 				];
 				if (sourceMap && js.map) {
 					files.push({
@@ -184,6 +191,7 @@ export const createCompiler = (opts: InitialOptions): Compiler => {
 						extension: CSS_EXTENSION,
 						encoding: 'utf8',
 						contents: css.code,
+						sourceMapOf: null,
 					});
 					if (sourceMap && css.map) {
 						files.push({
@@ -210,6 +218,7 @@ export const createCompiler = (opts: InitialOptions): Compiler => {
 							extension,
 							encoding,
 							contents: contents as string,
+							sourceMapOf: null,
 						};
 						break;
 					case null:

--- a/src/devServer/devServer.ts
+++ b/src/devServer/devServer.ts
@@ -14,13 +14,7 @@ import {cyan, yellow, gray} from '../colors/terminal.js';
 import {Logger, SystemLogger} from '../utils/log.js';
 import {stripAfter} from '../utils/string.js';
 import {omitUndefined} from '../utils/object.js';
-import {
-	Filer,
-	CompiledSourceFile,
-	getFileMimeType,
-	getFileBuffer,
-	getFileStats,
-} from '../fs/Filer.js';
+import {Filer, CompiledFile, getFileMimeType, getFileBuffer, getFileStats} from '../fs/Filer.js';
 
 export interface DevServer {
 	server: Server;
@@ -119,7 +113,7 @@ const send404 = (req: IncomingMessage, res: ServerResponse, path: string) => {
 	res.end(`404 not found: ${req.url} -> ${path}`);
 };
 
-const send200 = async (_req: IncomingMessage, res: ServerResponse, file: CompiledSourceFile) => {
+const send200 = async (_req: IncomingMessage, res: ServerResponse, file: CompiledFile) => {
 	const stats = await getFileStats(file);
 	const mimeType = getFileMimeType(file);
 	const headers: OutgoingHttpHeaders = {

--- a/src/fs/Filer.ts
+++ b/src/fs/Filer.ts
@@ -19,7 +19,7 @@ import {UnreachableError} from '../utils/error.js';
 import {Logger, SystemLogger} from '../utils/log.js';
 import {magenta, red} from '../colors/terminal.js';
 import {printError, printPath} from '../utils/print.js';
-import {Compiler, CompiledTextFile, CompiledBinaryFile} from '../compile/compiler.js';
+import {Compiler, TextCompilation, BinaryCompilation} from '../compile/compiler.js';
 import {getMimeTypeByExtension} from './mime.js';
 import {Encoding, inferEncoding} from './encoding.js';
 
@@ -27,7 +27,7 @@ export type SourceFile = SourceTextFile | SourceBinaryFile;
 interface BaseSourceFile {
 	id: string;
 	extension: string;
-	compiledFiles: CompiledSourceFile[];
+	compiledFiles: CompiledFile[];
 }
 export interface SourceTextFile extends BaseSourceFile {
 	encoding: 'utf8';
@@ -40,22 +40,24 @@ export interface SourceBinaryFile extends BaseSourceFile {
 	buffer: Buffer;
 }
 
-export type CompiledSourceFile = CompiledSourceTextFile | CompiledSourceBinaryFile;
-export interface BaseCompiledSourceFile {
+export type CompiledFile = CompiledTextFile | CompiledBinaryFile;
+export interface BaseCompiledFile {
 	id: string;
 	extension: string;
 	stats: Stats | undefined; // `undefined` for lazy loading
 	mimeType: string | null | undefined; // `null` means unknown, `undefined` for lazy loading
 	buffer: Buffer | undefined; // `undefined` for lazy loading
 }
-export interface CompiledSourceTextFile extends BaseCompiledSourceFile {
-	compiledFile: CompiledTextFile;
+export interface CompiledTextFile extends BaseCompiledFile {
+	// sourceFile: SourceTextFile; // TODO add this reference?
+	compilation: TextCompilation;
 	encoding: 'utf8';
 	contents: string;
 	sourceMapOf: string | null; // TODO for source maps? hmm. maybe we want a union with an `isSourceMap` boolean flag?
 }
-export interface CompiledSourceBinaryFile extends BaseCompiledSourceFile {
-	compiledFile: CompiledBinaryFile;
+export interface CompiledBinaryFile extends BaseCompiledFile {
+	// sourceFile: SourceBinaryFile; // TODO add this reference?
+	compilation: BinaryCompilation;
 	encoding: null;
 	contents: Buffer;
 	buffer: Buffer;
@@ -94,7 +96,7 @@ export class Filer {
 	private readonly include: (id: string) => boolean;
 
 	private readonly sourceFiles: Map<string, SourceFile> = new Map();
-	private readonly compiledFiles: Map<string, CompiledSourceFile> = new Map();
+	private readonly compiledFiles: Map<string, CompiledFile> = new Map();
 
 	private initStatus: AsyncStatus = 'initial';
 
@@ -117,7 +119,7 @@ export class Filer {
 
 	// TODO support lazy loading for some files - how? via a regexp?
 	// this will probably need to be async when that's added
-	getCompiledFile(id: string): CompiledSourceFile | null {
+	getCompiledFile(id: string): CompiledFile | null {
 		return this.compiledFiles.get(id) || null;
 	}
 
@@ -319,37 +321,37 @@ export class Filer {
 
 		// Update the cache.
 		const oldFiles = sourceFile.compiledFiles;
-		// TODO maybe merge the interfaces for the `CompiledFile` and `CompiledSourceFile`,
-		// won't need to do this inefficient copying or change the shape of objects
-		sourceFile.compiledFiles = result.files.map((compiledFile) => {
-			switch (compiledFile.encoding) {
-				case 'utf8':
-					return {
-						id: compiledFile.id,
-						extension: compiledFile.extension,
-						encoding: compiledFile.encoding,
-						contents: compiledFile.contents,
-						sourceMapOf: compiledFile.sourceMapOf,
-						compiledFile,
-						stats: undefined,
-						mimeType: undefined,
-						buffer: undefined,
-					};
-				case null:
-					return {
-						id: compiledFile.id,
-						extension: compiledFile.extension,
-						encoding: compiledFile.encoding,
-						contents: compiledFile.contents,
-						compiledFile,
-						stats: undefined,
-						mimeType: undefined,
-						buffer: compiledFile.contents,
-					};
-				default:
-					throw new UnreachableError(compiledFile);
-			}
-		});
+		sourceFile.compiledFiles = result.compilations.map(
+			(compilation): CompiledFile => {
+				switch (compilation.encoding) {
+					case 'utf8':
+						return {
+							id: compilation.id,
+							extension: compilation.extension,
+							encoding: compilation.encoding,
+							contents: compilation.contents,
+							sourceMapOf: compilation.sourceMapOf,
+							compilation,
+							stats: undefined,
+							mimeType: undefined, // TODO copy from old file?
+							buffer: undefined,
+						};
+					case null:
+						return {
+							id: compilation.id,
+							extension: compilation.extension,
+							encoding: compilation.encoding,
+							contents: compilation.contents,
+							compilation,
+							stats: undefined,
+							mimeType: undefined, // TODO copy from old file?
+							buffer: compilation.contents,
+						};
+					default:
+						throw new UnreachableError(compilation);
+				}
+			},
+		);
 
 		// Write to disk.
 		await syncFilesToDisk(sourceFile.compiledFiles, oldFiles, this.log);
@@ -386,8 +388,8 @@ const sourceMapsAreBuilt = async (sourceFile: SourceFile): Promise<boolean> => {
 // Given `newFiles` and `oldFiles`, updates everything on disk,
 // deleting files that no longer exist, writing new ones, and updating existing ones.
 const syncFilesToDisk = async (
-	newFiles: CompiledSourceFile[],
-	oldFiles: CompiledSourceFile[],
+	newFiles: CompiledFile[],
+	oldFiles: CompiledFile[],
 	log: Logger,
 ): Promise<void> => {
 	// This uses `Array#find` because the arrays are expected to be small,
@@ -428,9 +430,9 @@ const syncFilesToDisk = async (
 // Given `newFiles` and `oldFiles`, updates the memory cache,
 // deleting files that no longer exist and setting the new ones, replacing any old ones.
 const syncFilesToMemoryCache = async (
-	compiledFiles: Map<string, CompiledSourceFile>,
-	newFiles: CompiledSourceFile[],
-	oldFiles: CompiledSourceFile[],
+	compiledFiles: Map<string, CompiledFile>,
+	newFiles: CompiledFile[],
+	oldFiles: CompiledFile[],
 	_log: Logger,
 ): Promise<void> => {
 	// This uses `Array#find` because the arrays are expected to be small,
@@ -448,16 +450,16 @@ const syncFilesToMemoryCache = async (
 	}
 };
 
-export const getFileMimeType = (file: CompiledSourceFile): string | null =>
+export const getFileMimeType = (file: CompiledFile): string | null =>
 	file.mimeType !== undefined
 		? file.mimeType
 		: (file.mimeType = getMimeTypeByExtension(file.extension.substring(1)));
 
-export const getFileBuffer = (file: CompiledSourceFile): Buffer =>
+export const getFileBuffer = (file: CompiledFile): Buffer =>
 	file.buffer !== undefined ? file.buffer : (file.buffer = Buffer.from(file.contents));
 
 // Stats are currently lazily loaded. Should they be?
-export const getFileStats = (file: CompiledSourceFile): Stats | Promise<Stats> =>
+export const getFileStats = (file: CompiledFile): Stats | Promise<Stats> =>
 	file.stats !== undefined
 		? file.stats
 		: stat(file.id).then((stats) => {


### PR DESCRIPTION
This renames some of the `Filer` and `Compiler` types. It also changes the `Filer`'s compiled file type to wrap compilations instead of extending them. This provides a cleaner separation between the compiler's return value and all of the subsequent metadata that we add (there will be more in the future), at the cost of some duplication of properties.

This is in preparation for the postprocess step which makes the compiled file's contents potentially diverge from the original compilation's, and by storing the original reference, we retain the un-postprocessed version. We need to postprocess files to update their module paths to support Svelte and other usecases. I currently like the idea of isolating the `Compiler` to not touch module paths, just like the TypeScript and Svelte compilers.