### PR TITLE
postprocess compiled files to change svelte imports to js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,12 @@
       "dev": true,
       "optional": true
     },
+    "@types/es-module-lexer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/es-module-lexer/-/es-module-lexer-0.3.0.tgz",
+      "integrity": "sha512-XI3MGSejUQIJ3wzY0i5IHy5J3eb36M/ytgG8jIOssP08ovtRPcjpjXQqrx51AHBNBOisTS/NQNWJitI17+EwzQ==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -230,6 +236,11 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
+    "es-module-lexer": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.25.tgz",
+      "integrity": "sha512-H9VoFD5H9zEfiOX2LeTWDwMvAbLqcAyA2PIb40TOAvGpScOjit02oTGWgIh+M0rx2eJOKyJVM9wtpKFVgnyC3A=="
     },
     "estree-walker": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/node": "^12.12.50",
     "@types/source-map-support": "^0.5.2",
     "cheap-watch": "^1.0.2",
+    "es-module-lexer": "^0.3.25",
     "fs-extra": "^9.0.1",
     "kleur": "^4.1.1",
     "mri": "^1.1.6",
@@ -70,6 +71,7 @@
   },
   "devDependencies": {
     "@swc/core": "^1.2.28",
+    "@types/es-module-lexer": "^0.3.0",
     "@types/prettier": "^2.1.0",
     "prettier": "^2.1.1",
     "prettier-plugin-svelte": "^1.2.1",

--- a/src/fs/Filer.ts
+++ b/src/fs/Filer.ts
@@ -483,9 +483,6 @@ const areContentsEqual = (encoding: Encoding, a: string | Buffer, b: string | Bu
 const loadContents = (encoding: Encoding, id: string): Promise<string | Buffer> =>
 	encoding === null ? readFile(id) : readFile(id, encoding);
 
-// TODO delete - this does NOT support type narrowing!
-// const postprocess = <T extends Compilation>(compilation: T): T['contents'] => {
-
 // TODO this is rough! needs to be majorly refactored, made pluggable, maybe extracted
 // the API is minimal right now, but may need to return the entire CompiledFile
 function postprocess(compilation: TextCompilation): string;

--- a/src/fs/Filer.ts
+++ b/src/fs/Filer.ts
@@ -483,8 +483,7 @@ const areContentsEqual = (encoding: Encoding, a: string | Buffer, b: string | Bu
 const loadContents = (encoding: Encoding, id: string): Promise<string | Buffer> =>
 	encoding === null ? readFile(id) : readFile(id, encoding);
 
-// TODO this is rough! needs to be majorly refactored, made pluggable, maybe extracted
-// the API is minimal right now, but may need to return the entire CompiledFile
+// TODO this needs some major refactoring and redesigning
 function postprocess(compilation: TextCompilation): string;
 function postprocess(compilation: BinaryCompilation): Buffer;
 function postprocess(compilation: Compilation) {

--- a/src/fs/Filer.ts
+++ b/src/fs/Filer.ts
@@ -321,7 +321,6 @@ export class Filer {
 		const result = await this.compiler.compile(id, newSourceContents, sourceFile.extension);
 
 		// Update the cache.
-		// TODO mutate the existing compiledFiles? what about diffing and sending diffs to sync instead of the files?
 		const oldFiles = sourceFile.compiledFiles;
 		sourceFile.compiledFiles = result.compilations.map(
 			(compilation): CompiledFile => {

--- a/src/fs/Filer.ts
+++ b/src/fs/Filer.ts
@@ -487,7 +487,7 @@ function postprocess(compilation: TextCompilation): string;
 function postprocess(compilation: BinaryCompilation): Buffer;
 function postprocess(compilation: Compilation) {
 	if (compilation.encoding === 'utf8' && compilation.extension === JS_EXTENSION) {
-		const result: string[] = [];
+		let result = '';
 		let index = 0;
 		const {contents} = compilation;
 		// TODO what should we pass as the second arg to parse? the id? nothing? `lexer.parse(code, id);`
@@ -497,13 +497,12 @@ function postprocess(compilation: Compilation) {
 			const end = d > -1 ? e - 1 : e;
 			const moduleName = contents.substring(start, end);
 			if (moduleName.endsWith(SVELTE_EXTENSION)) {
-				result.push(contents.substring(index, start) + replaceExtension(moduleName, JS_EXTENSION));
+				result += contents.substring(index, start) + replaceExtension(moduleName, JS_EXTENSION);
 				index = end;
 			}
 		}
 		if (index > 0) {
-			result.push(contents.substring(index));
-			return result.join('');
+			return result + contents.substring(index);
 		} else {
 			return contents;
 		}


### PR DESCRIPTION
This adds a new dependency, [`es-module-lexer`](https://github.com/guybedford/es-module-lexer), which is a tiny and super fast tool for extracting the import information from a JS module. The added `postprocess` function takes a compilation and uses `es-module-lexer` to change Svelte imports from `*.svelte` to `*.js`. There's a lot more work that needs to be done to make Gro support Svelte in the browser, but this is a significant step because it demonstrates high performance rewriting of import paths. We'll further refactor this code but it makes sense to merge this piece now.