### PR TITLE
make the compiler pluggable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
   ([#54](https://github.com/feltcoop/gro/pull/54))
 - add Svelte compilation to the unbundled compilation strategies
   ([#52](https://github.com/feltcoop/gro/pull/52))
+- make `createCompiler` pluggable allowing users to provide a compiler for every file
+  ([#57](https://github.com/feltcoop/gro/pull/57))
 
 ## 0.4.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
   ([#54](https://github.com/feltcoop/gro/pull/54))
 - add Svelte compilation to the unbundled compilation strategies
   ([#52](https://github.com/feltcoop/gro/pull/52))
-- make `createCompiler` pluggable allowing users to provide a compiler for every file
+- make `createCompiler` pluggable allowing users to select a compiler for each file
   ([#57](https://github.com/feltcoop/gro/pull/57))
 
 ## 0.4.0

--- a/src/compile/compileSourceDirectory.ts
+++ b/src/compile/compileSourceDirectory.ts
@@ -3,8 +3,8 @@ import {printMs, printTiming} from '../utils/print.js';
 import {Logger} from '../utils/log.js';
 import {createStopwatch, Timings} from '../utils/time.js';
 import {TS_EXTENSION} from '../paths.js';
-import {createCompiler} from './compiler.js';
 import {Filer} from '../fs/Filer.js';
+import {createDefaultCompiler} from './defaultCompiler.js';
 
 export const compileSourceDirectory = async (dev: boolean, log: Logger): Promise<void> => {
 	log.info('compiling...');
@@ -29,7 +29,7 @@ export const compileSourceDirectory = async (dev: boolean, log: Logger): Promise
 
 	const timingToCreateFiler = timings.start('create filer');
 	const filer = new Filer({
-		compiler: createCompiler({dev, log}),
+		compiler: createDefaultCompiler({dev, log}, {dev, log}),
 		watch: false,
 		include,
 	});

--- a/src/compile/compiler.ts
+++ b/src/compile/compiler.ts
@@ -1,42 +1,13 @@
-import swc from '@swc/core';
-import svelte from 'svelte/compiler.js';
-import {PreprocessorGroup} from 'svelte/types/compiler/preprocess';
-import {CompileOptions} from 'svelte/types/compiler/interfaces';
-
-import {loadTsconfig, TsConfig} from './tsHelpers.js';
-import {
-	toSwcCompilerTarget,
-	mergeSwcOptions,
-	getDefaultSwcOptions,
-	addSourceMapFooter,
-} from './swcHelpers.js';
-import {
-	baseSvelteCompileOptions,
-	handleStats,
-	handleWarn,
-	SvelteCompilation,
-} from './svelteHelpers.js';
-import {Logger} from '../utils/log.js';
-import {
-	CSS_EXTENSION,
-	JS_EXTENSION,
-	SOURCE_MAP_EXTENSION,
-	SVELTE_EXTENSION,
-	toBuildId,
-	TS_EXTENSION,
-} from '../paths.js';
-import {sveltePreprocessSwc} from '../project/svelte-preprocess-swc.js';
-import {replaceExtension} from '../utils/path.js';
+import {toBuildId} from '../paths.js';
 import {omitUndefined} from '../utils/object.js';
 import {UnreachableError} from '../utils/error.js';
 
-export interface Compiler {
-	// TODO maybe make `compile` optionally synchronous, depending on the kind of file? (Svelte is sync, swc allows async or sync)
-	compile(source: CompilationSource): Promise<CompileResult>;
+export interface Compiler<T extends Compilation = Compilation> {
+	compile(source: CompilationSource): CompileResult<T> | Promise<CompileResult<T>>;
 }
 
-export interface CompileResult {
-	compilations: Compilation[];
+export interface CompileResult<T extends Compilation = Compilation> {
+	compilations: T[];
 }
 
 export type Compilation = TextCompilation | BinaryCompilation;
@@ -44,8 +15,6 @@ export interface BaseCompilation {
 	id: string;
 	extension: string;
 }
-// TODO might need to be a union with a type, like `extension: '.svelte'` with additional properties.
-// Svelte compilation properties include `ast`, `warnings`, `vars`, and `stats`
 export interface TextCompilation extends BaseCompilation {
 	encoding: 'utf8';
 	contents: string;
@@ -70,170 +39,36 @@ export interface BinaryCompilationSource extends BaseCompilationSource {
 	contents: Buffer;
 }
 
-export interface Options {
-	dev: boolean;
-	log: Logger;
-	sourceMap: boolean;
-	tsconfig: TsConfig;
-	swcOptions: swc.Options;
-	svelteCompileOptions: CompileOptions;
-	sveltePreprocessor: PreprocessorGroup | PreprocessorGroup[] | null;
-	onwarn: typeof handleWarn; // TODO currently just used for Svelte.. hmm
-	onstats: typeof handleStats | null; // TODO currently just used for Svelte.. hmm
+export interface SelectCompiler {
+	(source: CompilationSource): Compiler | null;
 }
-export type RequiredOptions = 'dev' | 'log';
-export type InitialOptions = PartialExcept<Options, RequiredOptions>;
+
+export interface Options {
+	selectCompiler: SelectCompiler;
+}
+export type InitialOptions = Partial<Options>;
 export const initOptions = (opts: InitialOptions): Options => {
-	const tsconfig = opts.tsconfig || loadTsconfig(opts.log);
-	const target = toSwcCompilerTarget(tsconfig.compilerOptions?.target);
-	const sourceMap = opts.sourceMap ?? tsconfig.compilerOptions?.sourceMap ?? opts.dev;
-	const swcOptions = opts.swcOptions || getDefaultSwcOptions(target, sourceMap);
-	const svelteCompileOptions: CompileOptions = opts.svelteCompileOptions || {};
-	const sveltePreprocessor: PreprocessorGroup | PreprocessorGroup[] | null =
-		opts.sveltePreprocessor || sveltePreprocessSwc({swcOptions});
 	return {
-		onwarn: handleWarn,
-		onstats: null,
+		selectCompiler: selectNoopCompiler,
 		...omitUndefined(opts),
-		tsconfig,
-		swcOptions,
-		sourceMap,
-		svelteCompileOptions,
-		sveltePreprocessor,
 	};
 };
 
-export const createCompiler = (opts: InitialOptions): Compiler => {
-	const {
-		log,
-		dev,
-		sourceMap,
-		swcOptions,
-		svelteCompileOptions,
-		sveltePreprocessor,
-		onwarn,
-		onstats,
-	} = initOptions(opts);
+export const createCompiler = (opts: InitialOptions = {}): Compiler => {
+	const {selectCompiler} = initOptions(opts);
 
-	const compile: Compiler['compile'] = async (
-		source: CompilationSource,
-	): Promise<CompileResult> => {
-		const {id} = source;
-		switch (source.encoding) {
-			case 'utf8': {
-				switch (source.extension) {
-					case TS_EXTENSION: {
-						const finalSwcOptions = mergeSwcOptions(swcOptions, id);
-						const output = await swc.transform(source.contents, finalSwcOptions);
-						const buildId = toBuildId(id);
-						const sourceMapBuildId = buildId + SOURCE_MAP_EXTENSION;
-						const compilations: Compilation[] = [
-							{
-								id: buildId,
-								extension: JS_EXTENSION,
-								encoding: source.encoding,
-								contents: output.map
-									? addSourceMapFooter(output.code, sourceMapBuildId)
-									: output.code,
-								sourceMapOf: null,
-							},
-						];
-						if (output.map) {
-							compilations.push({
-								id: sourceMapBuildId,
-								extension: SOURCE_MAP_EXTENSION,
-								encoding: source.encoding,
-								contents: output.map,
-								sourceMapOf: buildId,
-							});
-						}
-						return {compilations};
-					}
-					case SVELTE_EXTENSION: {
-						let preprocessedCode: string;
+	const compile: Compiler['compile'] = (source: CompilationSource) => {
+		const compiler = selectCompiler(source) || noopCompiler;
+		return compiler.compile(source);
+	};
 
-						// TODO see rollup-plugin-svelte for how to track deps
-						// let dependencies = [];
-						if (sveltePreprocessor) {
-							const preprocessed = await svelte.preprocess(source.contents, sveltePreprocessor, {
-								filename: id,
-							});
-							preprocessedCode = preprocessed.code;
-							// dependencies = preprocessed.dependencies; // TODO
-						} else {
-							preprocessedCode = source.contents as string;
-						}
+	return {compile};
+};
 
-						const output: SvelteCompilation = svelte.compile(preprocessedCode, {
-							...baseSvelteCompileOptions,
-							dev,
-							...svelteCompileOptions,
-							filename: id,
-							// name: getPathStem(id), // TODO this causes warnings with Sapper routes
-						});
-						const {js, css, warnings, stats} = output;
-
-						for (const warning of warnings) {
-							onwarn(id, warning, handleWarn, log);
-						}
-						if (onstats) onstats(id, stats, handleStats, log);
-
-						const jsBuildId = toBuildId(id);
-						const cssBuildId = replaceExtension(jsBuildId, CSS_EXTENSION);
-
-						const compilations: Compilation[] = [
-							{
-								id: jsBuildId,
-								extension: JS_EXTENSION,
-								encoding: source.encoding as 'utf8',
-								contents: js.code,
-								sourceMapOf: null,
-							},
-						];
-						if (sourceMap && js.map) {
-							compilations.push({
-								id: jsBuildId + SOURCE_MAP_EXTENSION,
-								extension: SOURCE_MAP_EXTENSION,
-								encoding: source.encoding as 'utf8',
-								contents: JSON.stringify(js.map), // TODO do we want to also store the object version?
-								sourceMapOf: jsBuildId,
-							});
-						}
-						if (css.code) {
-							compilations.push({
-								id: cssBuildId,
-								extension: CSS_EXTENSION,
-								encoding: source.encoding as 'utf8',
-								contents: css.code,
-								sourceMapOf: null,
-							});
-							if (sourceMap && css.map) {
-								compilations.push({
-									id: cssBuildId + SOURCE_MAP_EXTENSION,
-									extension: SOURCE_MAP_EXTENSION,
-									encoding: source.encoding as 'utf8',
-									contents: JSON.stringify(css.map), // TODO do we want to also store the object version?
-									sourceMapOf: cssBuildId,
-								});
-							}
-						}
-						return {compilations};
-					}
-				}
-				break;
-			}
-			case null: {
-				// TODO make this pluggable (a good use case is generating image thumbnails)
-				break;
-			}
-			default:
-				throw new UnreachableError(source);
-		}
-
-		// No compiler found, so pass through the file without modification.
-		const buildId = toBuildId(id);
+const createNoopCompiler = (): Compiler => {
+	const compile: Compiler['compile'] = (source: CompilationSource) => {
+		const buildId = toBuildId(source.id);
 		let file: Compilation;
-		// TODO simplify this code if we add no additional proeprties - we may add stuff for source maps, though
 		switch (source.encoding) {
 			case 'utf8':
 				file = {
@@ -257,6 +92,7 @@ export const createCompiler = (opts: InitialOptions): Compiler => {
 		}
 		return {compilations: [file]};
 	};
-
 	return {compile};
 };
+export const noopCompiler = createNoopCompiler();
+export const selectNoopCompiler: SelectCompiler = () => noopCompiler;

--- a/src/compile/defaultCompiler.ts
+++ b/src/compile/defaultCompiler.ts
@@ -1,0 +1,51 @@
+import {SVELTE_EXTENSION, TS_EXTENSION} from '../paths.js';
+import {
+	CompilationSource,
+	Compiler,
+	createCompiler,
+	InitialOptions as CompilerInitialOptions,
+} from './compiler.js';
+import {createSwcCompiler, InitialOptions as SwcCompilerInitialOptions} from './swcCompiler.js';
+import {
+	createSvelteCompiler,
+	InitialOptions as SvelteCompilerInitialOptions,
+} from './svelteCompiler.js';
+import {cyan} from '../colors/terminal.js';
+import {SystemLogger} from '../utils/log.js';
+
+export const createDefaultCompiler = (
+	swcCompilerOptions?: SwcCompilerInitialOptions,
+	svelteCompilerOptions?: SvelteCompilerInitialOptions,
+	compilerOptions: CompilerInitialOptions = {},
+): Compiler => {
+	let log: SystemLogger | undefined;
+	const getLogger = () => log || (log = new SystemLogger([cyan('[compiler]')]));
+
+	if (!swcCompilerOptions) {
+		swcCompilerOptions = {dev: true, log: getLogger()};
+	}
+	const swcCompiler = createSwcCompiler(swcCompilerOptions);
+
+	if (!svelteCompilerOptions) {
+		svelteCompilerOptions = {dev: true, log: getLogger()};
+	}
+	const svelteCompiler = createSvelteCompiler(svelteCompilerOptions);
+
+	if (!compilerOptions.selectCompiler) {
+		compilerOptions = {
+			...compilerOptions,
+			selectCompiler: (source: CompilationSource) => {
+				switch (source.extension) {
+					case TS_EXTENSION:
+						return swcCompiler;
+					case SVELTE_EXTENSION:
+						return svelteCompiler;
+					default:
+						return null;
+				}
+			},
+		};
+	}
+
+	return createCompiler(compilerOptions);
+};

--- a/src/compile/svelteCompiler.ts
+++ b/src/compile/svelteCompiler.ts
@@ -1,0 +1,149 @@
+import swc from '@swc/core';
+import svelte from 'svelte/compiler.js';
+import {PreprocessorGroup} from 'svelte/types/compiler/preprocess';
+import {CompileOptions} from 'svelte/types/compiler/interfaces';
+
+import {loadTsconfig, TsConfig} from './tsHelpers.js';
+import {toSwcCompilerTarget, getDefaultSwcOptions} from './swcHelpers.js';
+import {
+	baseSvelteCompileOptions,
+	handleStats,
+	handleWarn,
+	SvelteCompilation,
+} from './svelteHelpers.js';
+import {Logger} from '../utils/log.js';
+import {
+	CSS_EXTENSION,
+	JS_EXTENSION,
+	SOURCE_MAP_EXTENSION,
+	SVELTE_EXTENSION,
+	toBuildId,
+} from '../paths.js';
+import {sveltePreprocessSwc} from '../project/svelte-preprocess-swc.js';
+import {replaceExtension} from '../utils/path.js';
+import {omitUndefined} from '../utils/object.js';
+import {Compiler, TextCompilation, TextCompilationSource} from './compiler.js';
+
+export interface Options {
+	dev: boolean;
+	log: Logger;
+	sourceMap: boolean;
+	tsconfig: TsConfig;
+	swcOptions: swc.Options;
+	svelteCompileOptions: CompileOptions;
+	sveltePreprocessor: PreprocessorGroup | PreprocessorGroup[] | null;
+	onwarn: typeof handleWarn;
+	onstats: typeof handleStats | null;
+}
+export type RequiredOptions = 'dev' | 'log';
+export type InitialOptions = PartialExcept<Options, RequiredOptions>;
+export const initOptions = (opts: InitialOptions): Options => {
+	const tsconfig = opts.tsconfig || loadTsconfig(opts.log);
+	const target = toSwcCompilerTarget(tsconfig.compilerOptions?.target);
+	const sourceMap = opts.sourceMap ?? tsconfig.compilerOptions?.sourceMap ?? opts.dev;
+	const swcOptions = opts.swcOptions || getDefaultSwcOptions(target, sourceMap);
+	const svelteCompileOptions: CompileOptions = opts.svelteCompileOptions || {};
+	const sveltePreprocessor: PreprocessorGroup | PreprocessorGroup[] | null =
+		opts.sveltePreprocessor || sveltePreprocessSwc({swcOptions});
+	return {
+		onwarn: handleWarn,
+		onstats: null,
+		...omitUndefined(opts),
+		tsconfig,
+		swcOptions,
+		sourceMap,
+		svelteCompileOptions,
+		sveltePreprocessor,
+	};
+};
+
+type SvelteCompiler = Compiler<TextCompilation>;
+
+export const createSvelteCompiler = (opts: InitialOptions): SvelteCompiler => {
+	const {
+		log,
+		dev,
+		sourceMap,
+		svelteCompileOptions,
+		sveltePreprocessor,
+		onwarn,
+		onstats,
+	} = initOptions(opts);
+
+	const compile: SvelteCompiler['compile'] = async (source: TextCompilationSource) => {
+		if (source.encoding !== 'utf8') throw Error('swc only handles utf8 encoding');
+		if (source.extension !== SVELTE_EXTENSION)
+			throw Error(`svelte only handles ${SVELTE_EXTENSION} files`);
+		const {id} = source;
+		let preprocessedCode: string;
+
+		// TODO see rollup-plugin-svelte for how to track deps
+		// let dependencies = [];
+		if (sveltePreprocessor) {
+			const preprocessed = await svelte.preprocess(source.contents, sveltePreprocessor, {
+				filename: id,
+			});
+			preprocessedCode = preprocessed.code;
+			// dependencies = preprocessed.dependencies; // TODO
+		} else {
+			preprocessedCode = source.contents as string;
+		}
+
+		const output: SvelteCompilation = svelte.compile(preprocessedCode, {
+			...baseSvelteCompileOptions,
+			dev,
+			...svelteCompileOptions,
+			filename: id,
+			// name: getPathStem(id), // TODO this causes warnings with Sapper routes
+		});
+		const {js, css, warnings, stats} = output;
+
+		for (const warning of warnings) {
+			onwarn(id, warning, handleWarn, log);
+		}
+		if (onstats) onstats(id, stats, handleStats, log);
+
+		const jsBuildId = toBuildId(id);
+		const cssBuildId = replaceExtension(jsBuildId, CSS_EXTENSION);
+
+		const compilations: TextCompilation[] = [
+			{
+				id: jsBuildId,
+				extension: JS_EXTENSION,
+				encoding: source.encoding as 'utf8',
+				contents: js.code,
+				sourceMapOf: null,
+			},
+		];
+		if (sourceMap && js.map) {
+			compilations.push({
+				id: jsBuildId + SOURCE_MAP_EXTENSION,
+				extension: SOURCE_MAP_EXTENSION,
+				encoding: source.encoding as 'utf8',
+				contents: JSON.stringify(js.map), // TODO do we want to also store the object version?
+				sourceMapOf: jsBuildId,
+			});
+		}
+		if (css.code) {
+			compilations.push({
+				id: cssBuildId,
+				extension: CSS_EXTENSION,
+				encoding: source.encoding as 'utf8',
+				contents: css.code,
+				sourceMapOf: null,
+			});
+			if (sourceMap && css.map) {
+				compilations.push({
+					id: cssBuildId + SOURCE_MAP_EXTENSION,
+					extension: SOURCE_MAP_EXTENSION,
+					encoding: source.encoding as 'utf8',
+					contents: JSON.stringify(css.map), // TODO do we want to also store the object version?
+					sourceMapOf: cssBuildId,
+				});
+			}
+		}
+		return {compilations};
+	};
+
+	return {compile};
+};

--- a/src/compile/swcCompiler.ts
+++ b/src/compile/swcCompiler.ts
@@ -1,0 +1,72 @@
+import swc from '@swc/core';
+
+import {loadTsconfig, TsConfig} from './tsHelpers.js';
+import {
+	toSwcCompilerTarget,
+	mergeSwcOptions,
+	getDefaultSwcOptions,
+	addSourceMapFooter,
+} from './swcHelpers.js';
+import {Logger} from '../utils/log.js';
+import {JS_EXTENSION, SOURCE_MAP_EXTENSION, toBuildId, TS_EXTENSION} from '../paths.js';
+import {omitUndefined} from '../utils/object.js';
+import {CompilationSource, Compiler, TextCompilation} from './compiler.js';
+
+export interface Options {
+	dev: boolean;
+	log: Logger;
+	sourceMap: boolean;
+	tsconfig: TsConfig;
+	swcOptions: swc.Options;
+}
+export type RequiredOptions = 'dev' | 'log';
+export type InitialOptions = PartialExcept<Options, RequiredOptions>;
+export const initOptions = (opts: InitialOptions): Options => {
+	const tsconfig = opts.tsconfig || loadTsconfig(opts.log);
+	const target = toSwcCompilerTarget(tsconfig.compilerOptions?.target);
+	const sourceMap = opts.sourceMap ?? tsconfig.compilerOptions?.sourceMap ?? opts.dev;
+	const swcOptions = opts.swcOptions || getDefaultSwcOptions(target, sourceMap);
+	return {
+		...omitUndefined(opts),
+		tsconfig,
+		swcOptions,
+		sourceMap,
+	};
+};
+
+type SwcCompiler = Compiler<TextCompilation>;
+
+export const createSwcCompiler = (opts: InitialOptions): SwcCompiler => {
+	const {swcOptions} = initOptions(opts);
+
+	const compile: SwcCompiler['compile'] = async (source: CompilationSource) => {
+		if (source.encoding !== 'utf8') throw Error('swc only handles utf8 encoding');
+		if (source.extension !== TS_EXTENSION) throw Error(`swc only handles ${TS_EXTENSION} files`);
+		const {id} = source;
+		const finalSwcOptions = mergeSwcOptions(swcOptions, id);
+		const output = await swc.transform(source.contents, finalSwcOptions);
+		const buildId = toBuildId(id);
+		const sourceMapBuildId = buildId + SOURCE_MAP_EXTENSION;
+		const compilations: TextCompilation[] = [
+			{
+				id: buildId,
+				extension: JS_EXTENSION,
+				encoding: source.encoding,
+				contents: output.map ? addSourceMapFooter(output.code, sourceMapBuildId) : output.code,
+				sourceMapOf: null,
+			},
+		];
+		if (output.map) {
+			compilations.push({
+				id: sourceMapBuildId,
+				extension: SOURCE_MAP_EXTENSION,
+				encoding: source.encoding,
+				contents: output.map,
+				sourceMapOf: buildId,
+			});
+		}
+		return {compilations};
+	};
+
+	return {compile};
+};

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -1,13 +1,13 @@
 import {Task} from './task/task.js';
 import {Filer} from './fs/Filer.js';
-import {createCompiler} from './compile/compiler.js';
 import {createDevServer} from './devServer/devServer.js';
 import {paths} from './paths.js';
+import {createDefaultCompiler} from './compile/defaultCompiler.js';
 
 export const task: Task = {
 	description: 'start development server',
-	run: async ({log}): Promise<void> => {
-		const filer = new Filer({compiler: createCompiler({dev: true, log})});
+	run: async (): Promise<void> => {
+		const filer = new Filer({compiler: createDefaultCompiler()});
 
 		const devServer = createDevServer({filer, dir: paths.build});
 

--- a/src/fs/Filer.ts
+++ b/src/fs/Filer.ts
@@ -318,7 +318,12 @@ export class Filer {
 		}
 
 		// Compile this one file, which may turn into one or many.
-		const result = await this.compiler.compile(id, newSourceContents, sourceFile.extension);
+		const result = await this.compiler.compile(
+			id,
+			newSourceContents,
+			sourceFile.extension,
+			sourceFile.encoding,
+		);
 
 		// Update the cache.
 		const oldFiles = sourceFile.compiledFiles;

--- a/src/project/dev.task.ts
+++ b/src/project/dev.task.ts
@@ -2,13 +2,13 @@ import {Task} from '../task/task.js';
 import {Filer} from '../fs/Filer.js';
 import {printTiming} from '../utils/print.js';
 import {Timings} from '../utils/time.js';
-import {createCompiler} from '../compile/compiler.js';
+import {createDefaultCompiler} from '../compile/defaultCompiler.js';
 
 export const task: Task = {
 	description: 'build typescript in watch mode for development',
 	run: async ({log}) => {
 		const timings = new Timings();
-		const filer = new Filer({compiler: createCompiler({dev: true, log})});
+		const filer = new Filer({compiler: createDefaultCompiler()});
 
 		const timingToInitFiler = timings.start('init filer');
 		await filer.init();

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -3,7 +3,7 @@ import {resolve} from 'path';
 import {Task} from './task/task.js';
 import {createDevServer} from './devServer/devServer.js';
 import {Filer} from './fs/Filer.js';
-import {createCompiler} from './compile/compiler.js';
+import {createDefaultCompiler} from './compile/defaultCompiler.js';
 
 export const task: Task = {
 	description: 'start static file server',
@@ -19,8 +19,7 @@ export const task: Task = {
 
 		// TODO this is inefficient for just serving files in a directory
 		// maybe we want a `lazy` flag?
-		const filer: Filer =
-			(args.filer as any) || new Filer({compiler: createCompiler({dev: true, log})});
+		const filer = new Filer({compiler: createDefaultCompiler()});
 		await filer.init();
 
 		const devServer = createDevServer({filer, host, port, dir});


### PR DESCRIPTION
This refactors `createCompiler` to allow users to select a compiler for each file. This makes it extensible in a very flexible way. The PR also adds the `defaultCompiler.ts` module which removes the boilerplate from the normal case. 