### PR TITLE
move the buildRootDir from source files to the Filer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,8 @@
 - add `Filer` to replace `CachingCompiler` with additional filesystem capabilities
   ([#54](https://github.com/feltcoop/gro/pull/54)),
   ([#55](https://github.com/feltcoop/gro/pull/55)),
-  ([#58](https://github.com/feltcoop/gro/pull/58))
+  ([#58](https://github.com/feltcoop/gro/pull/58)),
+  ([#60](https://github.com/feltcoop/gro/pull/60))
 - add Svelte compilation to the unbundled compilation strategies
   ([#52](https://github.com/feltcoop/gro/pull/52)),
   ([#56](https://github.com/feltcoop/gro/pull/56))

--- a/src/compile/compileSourceDirectory.ts
+++ b/src/compile/compileSourceDirectory.ts
@@ -35,7 +35,7 @@ export const compileSourceDirectory = async (
 	const timingToCreateFiler = timings.start('create filer');
 	const filer = new Filer({
 		compiler: createDefaultCompiler(),
-		compiledDirs: [{sourceDir: paths.source, outDir: paths.build}],
+		compiledDirs: [paths.source],
 		buildConfigs,
 		watch: false,
 		include,

--- a/src/compile/svelteCompiler.ts
+++ b/src/compile/svelteCompiler.ts
@@ -17,7 +17,7 @@ import {
 	JS_EXTENSION,
 	SOURCE_MAP_EXTENSION,
 	SVELTE_EXTENSION,
-	toBuildDir,
+	toBuildOutDir,
 } from '../paths.js';
 import {sveltePreprocessSwc} from '../project/svelte-preprocess-swc.js';
 import {replaceExtension} from '../utils/path.js';
@@ -70,6 +70,7 @@ export const createSvelteCompiler = (opts: InitialOptions = {}): SvelteCompiler 
 	const compile: SvelteCompiler['compile'] = async (
 		source: TextCompilationSource,
 		buildConfig: BuildConfig,
+		buildRootDir: string,
 		dev: boolean,
 	) => {
 		if (source.encoding !== 'utf8') {
@@ -79,7 +80,7 @@ export const createSvelteCompiler = (opts: InitialOptions = {}): SvelteCompiler 
 			throw Error(`svelte only handles ${SVELTE_EXTENSION} files, not ${source.extension}`);
 		}
 		const {id, encoding, contents} = source;
-		const outDir = toBuildDir(dev, buildConfig.name, source.dirBasePath, source.sourceDir.outDir);
+		const outDir = toBuildOutDir(dev, buildConfig.name, source.dirBasePath, buildRootDir);
 		let preprocessedCode: string;
 
 		// TODO see rollup-plugin-svelte for how to track deps

--- a/src/compile/swcCompiler.ts
+++ b/src/compile/swcCompiler.ts
@@ -4,7 +4,7 @@ import {relative} from 'path';
 import {loadTsconfig, TsConfig} from './tsHelpers.js';
 import {toSwcCompilerTarget, getDefaultSwcOptions, addSourceMapFooter} from './swcHelpers.js';
 import {Logger, SystemLogger} from '../utils/log.js';
-import {JS_EXTENSION, SOURCE_MAP_EXTENSION, toBuildDir, TS_EXTENSION} from '../paths.js';
+import {JS_EXTENSION, SOURCE_MAP_EXTENSION, toBuildOutDir, TS_EXTENSION} from '../paths.js';
 import {omitUndefined} from '../utils/object.js';
 import {CompilationSource, Compiler, TextCompilation} from './compiler.js';
 import {replaceExtension} from '../utils/path.js';
@@ -41,6 +41,7 @@ export const createSwcCompiler = (opts: InitialOptions = {}): SwcCompiler => {
 	const compile: SwcCompiler['compile'] = async (
 		source: CompilationSource,
 		buildConfig: BuildConfig,
+		buildRootDir: string,
 		dev: boolean,
 	) => {
 		if (source.encoding !== 'utf8') {
@@ -50,7 +51,7 @@ export const createSwcCompiler = (opts: InitialOptions = {}): SwcCompiler => {
 			throw Error(`swc only handles ${TS_EXTENSION} files, not ${source.extension}`);
 		}
 		const {id, encoding, contents} = source;
-		const outDir = toBuildDir(dev, buildConfig.name, source.dirBasePath, source.sourceDir.outDir);
+		const outDir = toBuildOutDir(dev, buildConfig.name, source.dirBasePath, buildRootDir);
 		const finalSwcOptions = {...swcOptions, filename: relative(outDir, id)};
 		const output = await swc.transform(contents, finalSwcOptions);
 		const jsFilename = replaceExtension(source.filename, JS_EXTENSION);

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -10,7 +10,7 @@ export const task: Task = {
 	run: async (): Promise<void> => {
 		const filer = new Filer({
 			compiler: createDefaultCompiler(),
-			compiledDirs: [{sourceDir: paths.source, outDir: paths.build}],
+			compiledDirs: [paths.source],
 			buildConfigs: await loadBuildConfigs(),
 		});
 

--- a/src/dist.task.ts
+++ b/src/dist.task.ts
@@ -1,6 +1,6 @@
 import {copy} from './fs/nodeFs.js';
 import {Task} from './task/task.js';
-import {paths, toBuildDir} from './paths.js';
+import {paths, toBuildOutDir} from './paths.js';
 import {isTestBuildFile, isTestBuildArtifact} from './oki/testModule.js';
 import {printPath} from './utils/print.js';
 import {cleanDist} from './project/clean.js';
@@ -23,11 +23,11 @@ export const task: Task = {
 			: buildConfigs;
 		await Promise.all(
 			buildConfigsForDist.map((buildConfig) => {
-				const buildDir = toBuildDir(dev, buildConfig.name);
-				const destDir =
+				const buildOutDir = toBuildOutDir(dev, buildConfig.name);
+				const distOutDir =
 					buildConfigsForDist.length === 1 ? paths.dist : `${paths.dist}${buildConfig.name}`;
-				log.info(`copying ${printPath(buildDir)} to ${printPath(destDir)}`);
-				return copy(buildDir, destDir, {filter: (id) => isDistFile(id)});
+				log.info(`copying ${printPath(buildOutDir)} to ${printPath(distOutDir)}`);
+				return copy(buildOutDir, distOutDir, {filter: (id) => isDistFile(id)});
 			}),
 		);
 	},

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -70,18 +70,18 @@ export const sourceIdToBasePath = (sourceId: string, p = paths): string =>
 // 'foo/bar/baz.ts' -> '/home/me/app/src/foo/bar/baz.ts'
 export const basePathToSourceId = (basePath: string, p = paths): string => join(p.source, basePath);
 
-export const toBuildsDir = (dev: boolean, buildDir = paths.build): string =>
-	`${ensureTrailingSlash(buildDir)}${dev ? 'dev' : 'prod'}`;
+export const toBuildsOutDir = (dev: boolean, buildRootDir = paths.build): string =>
+	`${ensureTrailingSlash(buildRootDir)}${dev ? 'dev' : 'prod'}`;
 // TODO this is only needed because of how we added `/` to all directories above
 // fix those and remove this!
 const ensureTrailingSlash = (s: string): string => (s[s.length - 1] === '/' ? s : s + '/');
 
-export const toBuildDir = (
+export const toBuildOutDir = (
 	dev: boolean,
 	buildConfigName: string,
 	dirBasePath = '',
-	buildDir = paths.build,
-): string => `${toBuildsDir(dev, buildDir)}/${buildConfigName}/${dirBasePath}`;
+	buildRootDir = paths.build,
+): string => `${toBuildsOutDir(dev, buildRootDir)}/${buildConfigName}/${dirBasePath}`;
 
 export const JS_EXTENSION = '.js';
 export const TS_EXTENSION = '.ts';
@@ -124,5 +124,5 @@ export const replaceRootDir = (id: string, rootDir: string, p = paths): string =
 export const toImportId = (id: string, dev: boolean, buildConfigName: string): string => {
 	const p = pathsFromId(id);
 	const dirBasePath = replaceExtension(stripStart(id, p.source), JS_EXTENSION);
-	return toBuildDir(dev, buildConfigName, dirBasePath, p.build);
+	return toBuildOutDir(dev, buildConfigName, dirBasePath, p.build);
 };

--- a/src/project/clean.ts
+++ b/src/project/clean.ts
@@ -1,5 +1,5 @@
 import {pathExists, remove} from '../fs/nodeFs.js';
-import {paths, toBuildsDir} from '../paths.js';
+import {paths, toBuildsOutDir} from '../paths.js';
 import {SystemLogger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 
@@ -17,7 +17,7 @@ export const cleanBuild = async (log: SystemLogger) => {
 };
 
 export const cleanProductionBuild = async (log: SystemLogger) => {
-	const path = toBuildsDir(false);
+	const path = toBuildsOutDir(false);
 	if (await pathExists(path)) {
 		log.info('removing', printPath(path));
 		await remove(path);

--- a/src/project/dev.task.ts
+++ b/src/project/dev.task.ts
@@ -12,7 +12,7 @@ export const task: Task = {
 		const timings = new Timings();
 		const filer = new Filer({
 			compiler: createDefaultCompiler(),
-			compiledDirs: [{sourceDir: paths.source, outDir: paths.build}],
+			compiledDirs: [paths.source],
 			buildConfigs: await loadBuildConfigs(),
 		});
 


### PR DESCRIPTION
This is a minor change that clarifies the concepts of the `Filer`. It now takes an optional `buildRootDir` that defaults to `paths.build`, the `.gro` directory. Previously each source directory stored its own build root directory, which is more flexible, but it's complex and unnecessary with current use cases. We may want the flexibility back in the future, but I am guessing that there's a better design to accomplish that. This change simplify interfaces at multiple levels.