### PR TITLE
cache build options and invalidate builds when options change

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,8 @@
   ([#54](https://github.com/feltcoop/gro/pull/54)),
   ([#55](https://github.com/feltcoop/gro/pull/55)),
   ([#58](https://github.com/feltcoop/gro/pull/58)),
-  ([#60](https://github.com/feltcoop/gro/pull/60))
+  ([#60](https://github.com/feltcoop/gro/pull/60)),
+  ([#62](https://github.com/feltcoop/gro/pull/62))
 - add Svelte compilation to the unbundled compilation strategies
   ([#52](https://github.com/feltcoop/gro/pull/52)),
   ([#56](https://github.com/feltcoop/gro/pull/56))

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -3,8 +3,8 @@ import {resolve} from 'path';
 import {pathExists} from './fs/nodeFs.js';
 import {Task} from './task/task.js';
 import {createBuild} from './project/build.js';
-import {getDefaultSwcOptions, toSwcCompilerTarget} from './compile/swcHelpers.js';
-import {loadTsconfig} from './compile/tsHelpers.js';
+import {getDefaultSwcOptions} from './compile/swcHelpers.js';
+import {loadTsconfig, toEcmaScriptTarget} from './compile/tsHelpers.js';
 
 // TODO how should this be done? do we want to allow development builds with Rollup?
 process.env.NODE_ENV = 'production';
@@ -29,7 +29,7 @@ export const task: Task = {
 		const tsconfigPath = undefined; // TODO parameterized options?
 		const basePath = undefined; // TODO parameterized options?
 		const tsconfig = loadTsconfig(log, tsconfigPath, basePath);
-		const target = toSwcCompilerTarget(tsconfig.compilerOptions?.target);
+		const target = toEcmaScriptTarget(tsconfig.compilerOptions?.target);
 		const sourceMap = tsconfig.compilerOptions?.sourceMap ?? process.env.NODE_ENV === 'development';
 		const swcOptions = getDefaultSwcOptions(target, sourceMap);
 

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -397,7 +397,7 @@ export class Filer {
 	}
 
 	// If changes are detected in the build options, clear the cache and rebuild everything.
-	async initBuildOptions(): Promise<void> {
+	private async initBuildOptions(): Promise<void> {
 		const currentBuildOptions: CachedBuildOptions = {
 			sourceMap: this.sourceMap,
 			target: this.target,

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -1,0 +1,53 @@
+// `lexer.init` is expected to be awaited elsewhere before `postprocess` is called
+import lexer from 'es-module-lexer';
+
+import {JS_EXTENSION, SVELTE_EXTENSION} from '../paths.js';
+import type {
+	TextCompilation,
+	BinaryCompilation,
+	Compilation,
+	CompileOptions,
+} from '../compile/compiler.js';
+import {replaceExtension} from '../utils/path.js';
+
+const INTERNAL_MODULE_MATCHER = /^\.?\.?\//;
+const isExternalModule = (moduleName: string): boolean => !INTERNAL_MODULE_MATCHER.test(moduleName);
+
+export function postprocess(compilation: TextCompilation, options: CompileOptions): string;
+export function postprocess(compilation: BinaryCompilation, options: CompileOptions): Buffer;
+export function postprocess(compilation: Compilation, {externalsDirBasePath}: CompileOptions) {
+	if (compilation.encoding === 'utf8' && compilation.extension === JS_EXTENSION) {
+		let result = '';
+		let index = 0;
+		const {contents} = compilation;
+		// TODO what should we pass as the second arg to parse? the id? nothing? `lexer.parse(code, id);`
+		const [imports] = lexer.parse(contents);
+		for (const {s, e, d} of imports) {
+			const start = d > -1 ? s + 1 : s;
+			const end = d > -1 ? e - 1 : e;
+			const moduleName = contents.substring(start, end);
+			if (moduleName === 'import.meta') continue;
+			let newModuleName = moduleName;
+			if (moduleName.endsWith(SVELTE_EXTENSION)) {
+				newModuleName = replaceExtension(moduleName, JS_EXTENSION);
+			}
+			if (
+				externalsDirBasePath !== null &&
+				compilation.buildConfig.platform === 'browser' &&
+				isExternalModule(moduleName)
+			) {
+				newModuleName = `/${externalsDirBasePath}/${newModuleName}${JS_EXTENSION}`;
+			}
+			if (newModuleName !== moduleName) {
+				result += contents.substring(index, start) + newModuleName;
+				index = end;
+			}
+		}
+		if (index > 0) {
+			return result + contents.substring(index);
+		} else {
+			return contents;
+		}
+	}
+	return compilation.contents;
+}

--- a/src/compile/compiler.ts
+++ b/src/compile/compiler.ts
@@ -2,7 +2,6 @@ import {omitUndefined} from '../utils/object.js';
 import {UnreachableError} from '../utils/error.js';
 import {BuildConfig} from '../build/buildConfig.js';
 import {toBuildOutDir} from '../paths.js';
-import type {Filer} from '../build/Filer.js';
 
 export interface Compiler<
 	TSource extends CompilationSource = CompilationSource,
@@ -11,12 +10,18 @@ export interface Compiler<
 	compile(
 		source: TSource,
 		buildConfig: BuildConfig,
-		filer: Filer,
+		options: CompileOptions,
 	): CompileResult<TResult> | Promise<CompileResult<TResult>>;
 }
 
 export interface CompileResult<T extends Compilation = Compilation> {
 	compilations: T[];
+}
+export interface CompileOptions {
+	// TODO add source map, right? need to use it in the compilers
+	readonly buildRootDir: string;
+	readonly dev: boolean;
+	readonly externalsDirBasePath: string | null;
 }
 
 export type Compilation = TextCompilation | BinaryCompilation;
@@ -85,10 +90,10 @@ export const createCompiler = (opts: InitialOptions = {}): Compiler => {
 	const compile: Compiler['compile'] = (
 		source: CompilationSource,
 		buildConfig: BuildConfig,
-		filer: Filer,
+		options: CompileOptions,
 	) => {
 		const compiler = getCompiler(source, buildConfig) || noopCompiler;
-		return compiler.compile(source, buildConfig, filer);
+		return compiler.compile(source, buildConfig, options);
 	};
 
 	return {compile};

--- a/src/compile/compiler.ts
+++ b/src/compile/compiler.ts
@@ -2,6 +2,7 @@ import {omitUndefined} from '../utils/object.js';
 import {UnreachableError} from '../utils/error.js';
 import {BuildConfig} from '../build/buildConfig.js';
 import {toBuildOutDir} from '../paths.js';
+import {EcmaScriptTarget} from './tsHelpers.js';
 
 export interface Compiler<
 	TSource extends CompilationSource = CompilationSource,
@@ -18,7 +19,8 @@ export interface CompileResult<T extends Compilation = Compilation> {
 	compilations: T[];
 }
 export interface CompileOptions {
-	// TODO add source map, right? need to use it in the compilers
+	readonly sourceMap: boolean;
+	readonly target: EcmaScriptTarget;
 	readonly buildRootDir: string;
 	readonly dev: boolean;
 	readonly externalsDirBasePath: string | null;
@@ -99,8 +101,8 @@ export const createCompiler = (opts: InitialOptions = {}): Compiler => {
 	return {compile};
 };
 
-const createNoopCompiler = (): Compiler => {
-	const compile: Compiler['compile'] = (source, buildConfig, {buildRootDir, dev}) => {
+const noopCompiler: Compiler = {
+	compile: (source, buildConfig, {buildRootDir, dev}) => {
 		const {filename, extension} = source;
 		const outDir = toBuildOutDir(dev, buildConfig.name, source.dirBasePath, buildRootDir);
 		const id = `${outDir}${filename}`;
@@ -133,8 +135,6 @@ const createNoopCompiler = (): Compiler => {
 				throw new UnreachableError(source);
 		}
 		return {compilations: [file]};
-	};
-	return {compile};
+	},
 };
-export const noopCompiler = createNoopCompiler();
-export const getNoopCompiler: GetCompiler = () => noopCompiler;
+const getNoopCompiler: GetCompiler = () => noopCompiler;

--- a/src/compile/externalsCompiler.ts
+++ b/src/compile/externalsCompiler.ts
@@ -9,14 +9,12 @@ import {buildExternalModule} from '../build/buildExternalModule.js';
 import {printPath} from '../utils/print.js';
 
 export interface Options {
-	sourceMap: boolean;
 	log: Logger;
 }
 export type InitialOptions = Partial<Options>;
 export const initOptions = (opts: InitialOptions): Options => {
 	const log = opts.log || new SystemLogger([cyan('[externalsCompiler]')]);
 	return {
-		sourceMap: false,
 		...omitUndefined(opts),
 		log,
 	};
@@ -25,17 +23,16 @@ export const initOptions = (opts: InitialOptions): Options => {
 type ExternalsCompiler = Compiler<ExternalsCompilationSource, TextCompilation>;
 
 export const createExternalsCompiler = (opts: InitialOptions = {}): ExternalsCompiler => {
-	const {sourceMap, log} = initOptions(opts);
-
-	if (sourceMap) {
-		log.warn('Source maps are not yet supported by the externals compiler.');
-	}
+	const {log} = initOptions(opts);
 
 	const compile: ExternalsCompiler['compile'] = async (
 		source,
 		buildConfig,
-		{buildRootDir, dev, externalsDirBasePath},
+		{buildRootDir, dev, externalsDirBasePath /*, sourceMap */},
 	) => {
+		// if (sourceMap) {
+		// 	log.warn('Source maps are not yet supported by the externals compiler.');
+		// }
 		if (!dev) {
 			throw Error('The externals compiler is currently not designed for production usage.');
 		}

--- a/src/compile/swcHelpers.ts
+++ b/src/compile/swcHelpers.ts
@@ -1,36 +1,10 @@
 import swc from '@swc/core';
-import type {ScriptTarget} from 'typescript';
 import {basename} from 'path';
 
-const DEFAULT_TARGET = 'es2019'; // TODO?
-
-export const toSwcCompilerTarget = (target: ScriptTarget | undefined): swc.JscTarget => {
-	switch (target) {
-		case 0: // ES3 = 0,
-			return 'es3';
-		case 1: // ES5 = 1,
-			return 'es5';
-		case 2: // ES2015 = 2,
-			return 'es2015';
-		case 3: // ES2016 = 3,
-			return 'es2016';
-		case 4: // ES2017 = 4,
-			return 'es2017';
-		case 5: // ES2018 = 5,
-			return 'es2018';
-		case 6: // ES2019 = 6,
-			return 'es2019';
-		// ES2020 = 7,
-		// ESNext = 99,
-		// JSON = 100,
-		// Latest = 99
-		default:
-			return DEFAULT_TARGET;
-	}
-};
+import {DEFAULT_ECMA_SCRIPT_TARGET, EcmaScriptTarget} from './tsHelpers.js';
 
 export const getDefaultSwcOptions = (
-	target: swc.JscTarget = DEFAULT_TARGET,
+	target: EcmaScriptTarget = DEFAULT_ECMA_SCRIPT_TARGET,
 	sourceMap = true, // sticking with the naming convention of TypeScript and some other libs
 ): swc.Options => ({
 	sourceMaps: sourceMap,

--- a/src/compile/tsHelpers.ts
+++ b/src/compile/tsHelpers.ts
@@ -1,8 +1,38 @@
 import ts from 'typescript';
+import type {JscTarget} from '@swc/core';
 import {join, dirname, resolve} from 'path';
 
 import {black, bgRed} from '../colors/terminal.js';
 import {Logger} from '../utils/log.js';
+
+export type EcmaScriptTarget = JscTarget;
+
+export const DEFAULT_ECMA_SCRIPT_TARGET: EcmaScriptTarget = 'es2019';
+
+export const toEcmaScriptTarget = (target: ts.ScriptTarget | undefined): EcmaScriptTarget => {
+	switch (target) {
+		case 0: // ES3 = 0,
+			return 'es3';
+		case 1: // ES5 = 1,
+			return 'es5';
+		case 2: // ES2015 = 2,
+			return 'es2015';
+		case 3: // ES2016 = 3,
+			return 'es2016';
+		case 4: // ES2017 = 4,
+			return 'es2017';
+		case 5: // ES2018 = 5,
+			return 'es2018';
+		case 6: // ES2019 = 6,
+			return 'es2019';
+		// ES2020 = 7,
+		// ESNext = 99,
+		// JSON = 100,
+		// Latest = 99
+		default:
+			return DEFAULT_ECMA_SCRIPT_TARGET;
+	}
+};
 
 // confusingly, TypeScript doesn't seem to be a good type for this
 export interface TsConfig {

--- a/src/project/dev.task.ts
+++ b/src/project/dev.task.ts
@@ -6,6 +6,7 @@ import {createDefaultCompiler} from '../compile/defaultCompiler.js';
 import {paths, toBuildOutDir} from '../paths.js';
 import {loadBuildConfigs} from '../build/buildConfig.js';
 import {createDevServer} from '../devServer/devServer.js';
+import {loadTsconfig, toEcmaScriptTarget} from '../compile/tsHelpers.js';
 
 export const task: Task = {
 	description: 'build typescript in watch mode for development',
@@ -15,6 +16,12 @@ export const task: Task = {
 		const timingToLoadConfig = timings.start('load build configs');
 		const buildConfigs = await loadBuildConfigs();
 		timingToLoadConfig();
+
+		const timingToLoadTsconfig = timings.start('load tsconfig');
+		const tsconfig = loadTsconfig(log);
+		const target = toEcmaScriptTarget(tsconfig.compilerOptions?.target);
+		const sourceMap = tsconfig.compilerOptions?.sourceMap ?? true;
+		timingToLoadTsconfig();
 
 		const timingToCreateFiler = timings.start('create filer');
 		const buildOutDir = toBuildOutDir(
@@ -27,6 +34,8 @@ export const task: Task = {
 			compiledDirs: [paths.source],
 			servedDirs: [`${buildOutDir}/frontend`],
 			buildConfigs,
+			sourceMap,
+			target,
 		});
 		timingToCreateFiler();
 


### PR DESCRIPTION
This adds simple caching to the `Filer`'s build options. When the `Filer` initializes, it tries to load any previously cached build options, and if it either can't find them or they've changed, it clears all existing builds. This means that if you toggle source maps, modify the `BuildConfig`s, or change other `CachedBuildOptions`, we're sure to have clean and correct builds. Its cache invalidation is fairly aggressive, opting for simplicity and correctness over optimal preservation of valid build artifacts. Basically, if the developer changes any of the `CachedBuildOptions`, they'll need to re-run `gro dev` and wait for the cold cache to warm up as it performs a complete rebuild.

To make this work, build options are hoisted out of the `Compiler` implementations into the `Filer` and passed to the compilers as arguments. There are some corner cases where changes to compilers or their configurations will cause stale builds. I want to figure out a better solution there. For now, if the developer changes the code underneath the build process, they should probably clear the cache manually via `gro clean`.