### PR TITLE
support svelte css

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,8 @@
   ([#63](https://github.com/feltcoop/gro/pull/63))
 - add Svelte compilation to the unbundled compilation strategies
   ([#52](https://github.com/feltcoop/gro/pull/52)),
-  ([#56](https://github.com/feltcoop/gro/pull/56))
+  ([#56](https://github.com/feltcoop/gro/pull/56)),
+  ([#64](https://github.com/feltcoop/gro/pull/64))
 - bundle external modules for the browser
   ([#61](https://github.com/feltcoop/gro/pull/61))
 - make `createCompiler` pluggable allowing users to provide a compiler for each file

--- a/src/build/ServedDir.ts
+++ b/src/build/ServedDir.ts
@@ -1,0 +1,41 @@
+import {resolve} from 'path';
+
+export interface ServedDir {
+	dir: string; // TODO rename? `source`, `sourceDir`, `path`
+	servedAt: string; // TODO rename?
+}
+
+export type ServedDirPartial = string | PartialExcept<ServedDir, 'dir'>;
+
+export const toServedDirs = (
+	partials: ServedDirPartial[],
+	externalsDir: string | null,
+	buildRootDir: string,
+): ServedDir[] => {
+	const dirs = partials.map((d) => toServedDir(d));
+	const uniqueDirs = new Set<string>();
+	for (const dir of dirs) {
+		// TODO instead of the error, should we allow multiple served paths for each input dir?
+		// This is mainly done to prevent duplicate work in watching the source directories.
+		if (uniqueDirs.has(dir.dir)) {
+			throw Error(`Duplicate servedDirs are not allowed: ${dir.dir}`);
+		}
+		uniqueDirs.add(dir.dir);
+	}
+	// Add the externals as a served directory, unless one is already found.
+	// This is mostly an ergonomic improvement, and the user can provide a custom one if needed.
+	// In the current design, externals should always be served.
+	if (externalsDir !== null && !dirs.find((d) => d.dir === externalsDir)) {
+		dirs.push(toServedDir({dir: externalsDir, servedAt: buildRootDir}));
+	}
+	return dirs;
+};
+
+export const toServedDir = (dir: ServedDirPartial): ServedDir => {
+	if (typeof dir === 'string') dir = {dir};
+	const resolvedDir = resolve(dir.dir);
+	return {
+		dir: resolvedDir,
+		servedAt: dir.servedAt ? resolve(dir.servedAt) : resolvedDir,
+	};
+};

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -69,8 +69,12 @@ export function postprocess(
 			}
 		}
 
-		// Support Svelte CSS for development.
-		if (source.extension === SVELTE_EXTENSION && compilation.extension === JS_EXTENSION) {
+		// Support Svelte CSS for development in the browser.
+		if (
+			source.extension === SVELTE_EXTENSION &&
+			compilation.extension === JS_EXTENSION &&
+			compilation.buildConfig.platform === 'browser'
+		) {
 			const cssCompilation = result.compilations.find((c) => c.extension === CSS_EXTENSION);
 			if (cssCompilation !== undefined) {
 				let importPath: string | undefined;

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -1,53 +1,109 @@
 // `lexer.init` is expected to be awaited elsewhere before `postprocess` is called
 import lexer from 'es-module-lexer';
 
-import {JS_EXTENSION, SVELTE_EXTENSION} from '../paths.js';
+import {CSS_EXTENSION, JS_EXTENSION, SVELTE_EXTENSION} from '../paths.js';
 import type {
 	TextCompilation,
 	BinaryCompilation,
 	Compilation,
 	CompileOptions,
+	CompileResult,
+	CompilationSource,
 } from '../compile/compiler.js';
 import {replaceExtension} from '../utils/path.js';
+import {stripStart} from '../utils/string.js';
 
 const INTERNAL_MODULE_MATCHER = /^\.?\.?\//;
 const isExternalModule = (moduleName: string): boolean => !INTERNAL_MODULE_MATCHER.test(moduleName);
 
-export function postprocess(compilation: TextCompilation, options: CompileOptions): string;
-export function postprocess(compilation: BinaryCompilation, options: CompileOptions): Buffer;
-export function postprocess(compilation: Compilation, {externalsDirBasePath}: CompileOptions) {
-	if (compilation.encoding === 'utf8' && compilation.extension === JS_EXTENSION) {
-		let result = '';
-		let index = 0;
-		const {contents} = compilation;
-		// TODO what should we pass as the second arg to parse? the id? nothing? `lexer.parse(code, id);`
-		const [imports] = lexer.parse(contents);
-		for (const {s, e, d} of imports) {
-			const start = d > -1 ? s + 1 : s;
-			const end = d > -1 ? e - 1 : e;
-			const moduleName = contents.substring(start, end);
-			if (moduleName === 'import.meta') continue;
-			let newModuleName = moduleName;
-			if (moduleName.endsWith(SVELTE_EXTENSION)) {
-				newModuleName = replaceExtension(moduleName, JS_EXTENSION);
+export function postprocess(
+	compilation: TextCompilation,
+	options: CompileOptions,
+	result: CompileResult<Compilation>,
+	source: CompilationSource,
+): string;
+export function postprocess(
+	compilation: BinaryCompilation,
+	options: CompileOptions,
+	result: CompileResult<Compilation>,
+	source: CompilationSource,
+): Buffer;
+export function postprocess(
+	compilation: Compilation,
+	{externalsDirBasePath, servedDirs}: CompileOptions,
+	result: CompileResult<Compilation>,
+	source: CompilationSource,
+) {
+	if (compilation.encoding === 'utf8') {
+		let {contents} = compilation;
+
+		// Map import paths to the compiled versions.
+		if (compilation.extension === JS_EXTENSION) {
+			let result = '';
+			let index = 0;
+			// TODO what should we pass as the second arg to parse? the id? nothing? `lexer.parse(code, id);`
+			const [imports] = lexer.parse(contents);
+			for (const {s, e, d} of imports) {
+				const start = d > -1 ? s + 1 : s;
+				const end = d > -1 ? e - 1 : e;
+				const moduleName = contents.substring(start, end);
+				if (moduleName === 'import.meta') continue;
+				let newModuleName = moduleName;
+				if (moduleName.endsWith(SVELTE_EXTENSION)) {
+					newModuleName = replaceExtension(moduleName, JS_EXTENSION);
+				}
+				if (
+					externalsDirBasePath !== null &&
+					compilation.buildConfig.platform === 'browser' &&
+					isExternalModule(moduleName)
+				) {
+					newModuleName = `/${externalsDirBasePath}/${newModuleName}${JS_EXTENSION}`;
+				}
+				if (newModuleName !== moduleName) {
+					result += contents.substring(index, start) + newModuleName;
+					index = end;
+				}
 			}
-			if (
-				externalsDirBasePath !== null &&
-				compilation.buildConfig.platform === 'browser' &&
-				isExternalModule(moduleName)
-			) {
-				newModuleName = `/${externalsDirBasePath}/${newModuleName}${JS_EXTENSION}`;
-			}
-			if (newModuleName !== moduleName) {
-				result += contents.substring(index, start) + newModuleName;
-				index = end;
+			if (index > 0) {
+				contents = result + contents.substring(index);
 			}
 		}
-		if (index > 0) {
-			return result + contents.substring(index);
-		} else {
-			return contents;
+
+		// Support Svelte CSS for development.
+		if (source.extension === SVELTE_EXTENSION && compilation.extension === JS_EXTENSION) {
+			const cssCompilation = result.compilations.find((c) => c.extension === CSS_EXTENSION);
+			if (cssCompilation !== undefined) {
+				let importPath: string | undefined;
+				for (const servedDir of servedDirs) {
+					if (cssCompilation.id.startsWith(servedDir.dir)) {
+						importPath = stripStart(cssCompilation.id, servedDir.servedAt);
+						break;
+					}
+				}
+				if (importPath !== undefined) {
+					contents = injectSvelteCssImport(contents, importPath);
+				}
+			}
+		}
+		return contents;
+	} else {
+		// Handle other encodings like binary.
+		return compilation.contents;
+	}
+}
+
+const injectSvelteCssImport = (contents: string, importPath: string): string => {
+	let newlineIndex = contents.length;
+	for (let i = 0; i < contents.length; i++) {
+		if (contents[i] === '\n') {
+			newlineIndex = i;
+			break;
 		}
 	}
-	return compilation.contents;
-}
+	const injectedCssLoaderScript = `;globalThis.gro.registerCss('${importPath}');`; // account for barbaric semicolonness code
+	const newContents = `${contents.substring(
+		0,
+		newlineIndex,
+	)}${injectedCssLoaderScript}${contents.substring(newlineIndex)}`;
+	return newContents;
+};

--- a/src/compile/compiler.ts
+++ b/src/compile/compiler.ts
@@ -3,6 +3,7 @@ import {UnreachableError} from '../utils/error.js';
 import {BuildConfig} from '../build/buildConfig.js';
 import {toBuildOutDir} from '../paths.js';
 import {EcmaScriptTarget} from './tsHelpers.js';
+import {ServedDir} from '../build/ServedDir.js';
 
 export interface Compiler<
 	TSource extends CompilationSource = CompilationSource,
@@ -24,6 +25,7 @@ export interface CompileOptions {
 	readonly buildRootDir: string;
 	readonly dev: boolean;
 	readonly externalsDirBasePath: string | null;
+	readonly servedDirs: readonly ServedDir[];
 }
 
 export type Compilation = TextCompilation | BinaryCompilation;

--- a/src/frontend/App.svelte
+++ b/src/frontend/App.svelte
@@ -1,5 +1,13 @@
 <script>
 	export let bar;
+	console.log('enter App.svelte');
 </script>
 
-bar: {bar}
+<main>bar!: {bar}</main>
+
+<style>
+	main {
+		background: black;
+		color: darkgoldenrod;
+	}
+</style>

--- a/src/frontend/GroDevtools.ts
+++ b/src/frontend/GroDevtools.ts
@@ -1,16 +1,17 @@
 // TODO maybe rename this to `FrontendDevtools`, `ClientDevtools`, or `BrowserDevtools`?
 export class GroDevtools {
 	head: HTMLHeadElement;
+	styleElementsByPath: Map<string, HTMLLinkElement> = new Map();
 
 	constructor() {
 		this.head = document.getElementsByTagName('head')[0];
 	}
 
-	styleElementsByPath: Map<string, HTMLLinkElement> = new Map();
-
 	registerCss(path: string) {
 		if (this.styleElementsByPath.has(path)) {
-			// TODO handle this properly
+			// TODO should this do reference counting and remove unused CSS?
+			// if so, we need to have components call `unregisterCss`,
+			// which could be a function returned from this method
 			return;
 		}
 		const styleEl = document.createElement('link');

--- a/src/frontend/GroDevtools.ts
+++ b/src/frontend/GroDevtools.ts
@@ -1,0 +1,22 @@
+// TODO maybe rename this to `FrontendDevtools`, `ClientDevtools`, or `BrowserDevtools`?
+export class GroDevtools {
+	head: HTMLHeadElement;
+
+	constructor() {
+		this.head = document.getElementsByTagName('head')[0];
+	}
+
+	styleElementsByPath: Map<string, HTMLLinkElement> = new Map();
+
+	registerCss(path: string) {
+		if (this.styleElementsByPath.has(path)) {
+			// TODO handle this properly
+			return;
+		}
+		const styleEl = document.createElement('link');
+		this.styleElementsByPath.set(path, styleEl);
+		styleEl.rel = 'stylesheet';
+		styleEl.href = path;
+		this.head.appendChild(styleEl);
+	}
+}

--- a/src/frontend/devtools.ts
+++ b/src/frontend/devtools.ts
@@ -1,0 +1,3 @@
+import {GroDevtools} from './GroDevtools.js';
+
+(globalThis as any).gro = new GroDevtools();

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -1,3 +1,4 @@
+import './devtools.js';
 import App from './App.svelte';
 import './foo.js';
 import {bar} from './bar.js';


### PR DESCRIPTION
This adds basic support for Svelte CSS in the browser during development. It's a half-baked design with the goal of supporting livereloading CSS, which I plan to work on next. When components are created, they register their associated CSS file path with a global devtools instance. To support livereloading, the devtools will then be responsible for keeping the CSS in sync when the server broadcasts changes.

CSS injection is accomplished by appending the devtools registration snippet before the first newline, and with no newlines of its own, to avoid breaking sourcemaps.