### PR TITLE
add docs for unbundled development

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,17 @@
 Gro is an opinionated monotool for making webapps.
 It includes:
 
+- [unbundled development](src/docs/unbundled-development.md)
+  for Node modules and [Svelte](https://github.com/sveltejs/svelte) UIs
+  inspired by [Snowpack](https://github.com/pikapkg/snowpack)
+- production bundling via [Rollup](https://github.com/rollup/rollup)
 - [task runner](src/task) that uses the filesystem convention `*.task.ts`
   (docs at [`src/task`](src/task))
 - testing library called `oki` (docs at [`src/oki`](src/oki))
 - codegen by convention called `gen` (docs at [`src/gen`](src/gen))
-- dev server
-- integrated UI development with
-  [Svelte](https://github.com/sveltejs/svelte) (particularly rough right now)
+- dev server with efficient caching and pluggable compilation
 - fully integrated [TypeScript](https://github.com/microsoft/typescript)
-  using [swc](https://github.com/swc-project/swc) in dev mode
-- bundling via [Rollup](https://github.com/rollup/rollup)
+  using the superfast [swc](https://github.com/swc-project/swc) in dev mode
 - formatting via [Prettier](https://github.com/prettier/prettier)
 - more to come, exploring what deeply integrated tools enable
   in the realms of developer power and ergonomics and end user experience

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 ## docs
 
+- [unbundled development](/src/docs/unbundledDevelopment.md) with TypeScript and Svelte,
+  and Rollup for bundling in production
 - [`task`](/src/task) runner
 - [`oki`](/src/oki) testing library
 - [`gen`](/src/gen) code generation

--- a/README.md
+++ b/README.md
@@ -15,28 +15,28 @@
 
 ## docs
 
-- [`task`](src/task) runner
-- [`oki`](src/oki) testing library
-- [`gen`](src/gen) code generation
-- other [docs](src/docs)
-  - [tasks](src/docs/tasks.md)
-  - [build config](src/docs/buildConfig.md)
-  - [publish](src/docs/publish.md)
-  - [options](src/docs/options.md)
+- [`task`](/src/task) runner
+- [`oki`](/src/oki) testing library
+- [`gen`](/src/gen) code generation
+- other [docs](/src/docs)
+  - [tasks](/src/docs/tasks.md)
+  - [build config](/src/docs/buildConfig.md)
+  - [publish](/src/docs/publish.md)
+  - [options](/src/docs/options.md)
 
 ## about
 
 Gro is an opinionated monotool for making webapps.
 It includes:
 
-- [unbundled development](src/docs/unbundledDevelopment.md)
+- [unbundled development](/src/docs/unbundledDevelopment.md)
   for Node modules and [Svelte](https://github.com/sveltejs/svelte) UIs
   inspired by [Snowpack](https://github.com/pikapkg/snowpack)
 - production bundling via [Rollup](https://github.com/rollup/rollup)
-- [task runner](src/task) that uses the filesystem convention `*.task.ts`
-  (docs at [`src/task`](src/task))
-- testing library called `oki` (docs at [`src/oki`](src/oki))
-- codegen by convention called `gen` (docs at [`src/gen`](src/gen))
+- [task runner](/src/task) that uses the filesystem convention `*.task.ts`
+  (docs at [`src/task`](/src/task))
+- testing library called `oki` (docs at [`src/oki`](/src/oki))
+- codegen by convention called `gen` (docs at [`src/gen`](/src/gen))
 - dev server with efficient caching and pluggable compilation
 - fully integrated [TypeScript](https://github.com/microsoft/typescript)
   using the superfast [swc](https://github.com/swc-project/swc) in dev mode
@@ -75,8 +75,8 @@ gro test # run one of Gro's tasks or `src/test.task.ts` if it exists
 ```
 
 Gro has a number of builtin tasks.
-To learn more [see the task docs](src/task)
-and [the generated task index](src/docs/tasks.md).
+To learn more [see the task docs](/src/task)
+and [the generated task index](/src/docs/tasks.md).
 
 ```bash
 gro dev # starts the dev server in watch mode
@@ -86,13 +86,13 @@ gro dev # starts the dev server in watch mode
 gro build # builds everything for production
 ```
 
-Testing with `oki` (docs at [`src/oki`](src/oki))
+Testing with `oki` (docs at [`src/oki`](/src/oki))
 
 ```bash
 gro test # run all tests for `*.test.ts` files
 ```
 
-Codegen with `gen` (docs at [`src/gen`](src/gen))
+Codegen with `gen` (docs at [`src/gen`](/src/gen))
 
 ```bash
 gro gen # runs codegen for all `*.gen.*` files

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 Gro is an opinionated monotool for making webapps.
 It includes:
 
-- [unbundled development](src/docs/unbundled-development.md)
+- [unbundled development](src/docs/unbundledDevelopment.md)
   for Node modules and [Svelte](https://github.com/sveltejs/svelte) UIs
   inspired by [Snowpack](https://github.com/pikapkg/snowpack)
 - production bundling via [Rollup](https://github.com/rollup/rollup)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@
 
 ## docs
 
-- [unbundled development](/src/docs/unbundledDevelopment.md) with TypeScript and Svelte,
-  and Rollup for bundling in production
+- [unbundled development](/src/docs/unbundledDevelopment.md) for frontends, servers, and libraries
 - [`task`](/src/task) runner
 - [`oki`](/src/oki) testing library
 - [`gen`](/src/gen) code generation

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -6,6 +6,7 @@
 - [options](options.md)
 - [publish](publish.md)
 - [tasks](tasks.md)
+- [unbundledDevelopment](unbundledDevelopment.md)
 
 > <sub>[gro](/../..) / docs / README.md</sub>
 

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -52,11 +52,16 @@ Gro differs in some significant ways:
   There are plans for Gro to support lazy compilation and other scale-friendly features,
   and some of Gro's design decisions may change before it reaches 1.0.
 - Gro does not yet support hot module reloading, though work is in progress.
-- Gro does not have a plugin system for things like PostCSS/SASS and UI frameworks besides Svelte.
+- Gro does not yet have a plugin system for things like PostCSS/SASS and UI frameworks besides Svelte.
   It has a pluggable compiler architecture that can probably support most of the ecosystem,
   but it's all a work in progress right now.
   Adventurous developers can [define their own tasks](src/dev.task.ts)
   to extend Gro's development system. By default Gro supports TypeScript and Svelte.
+  We're not fans of plugin ecosystems that primarily wrap other libraries,
+  and instead we try to support the direct usage of Node APIs and libraries,
+  like with [tasks](/src/task).
+  Snowpack emphasizes composing tools via the CLI; we prefer TypeScript for most things,
+  but we'll probably do more to support CLI integrations.
 - Gro uses [swc](https://github.com/swc-project/swc)
   instead of [esbuild](https://github.com/evanw/esbuild)
   because the former allows preserving unused imports, which is helpful for Svelte.

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -20,7 +20,7 @@ but today these are low priority.
 We recommend using [Sapper](https://github.com/sveltejs/sapper) for most websites.
 Gro is primarily intended for SPAs and Node projects,
 and it won't reach a stable 1.0 for quite a while.
-SPAs are a niche use case - they're usually not what you want on the web!
+SPAs are a niche use case - they're usually **not** what you want on the web!
 But sometimes they're _exactly_ what you want, and Gro was purpose-built to support them.
 
 Gro tries to provide good defaults and full control when you need it.

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -48,7 +48,7 @@ Gro differs in some significant ways:
   In contrast, Gro compiles files on startup
   and bundles external modules when the browser requests them.
   This is a complex set of tradeoffs - for very large projects, Snowpack has a significant edge,
-  but Gro's strategy has advantages.
+  but Gro's strategy has advantages. We'll plan to do a more detailed analysis eventually.
   There are plans for Gro to support lazy compilation and other scale-friendly features,
   and some of Gro's design decisions may change before it reaches 1.0.
 - Gro does not yet support hot module reloading, though work is in progress.

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -30,7 +30,7 @@ Gro tries to provide good defaults and full control when you need it.
 Its philosophy is to offer sharp tools
 that prioritize efficiency and minimize dependencies.
 Sharp tools have a drawback, and aren't the best experience for all developers -
-they can hurt when held in certain ways!
+they can hurt when held in certain ways! Try not to get cut! :O
 
 Gro's development is still a work in progress, and production usage is discouraged,
 but please feel free to try it and share your feedback!

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -61,4 +61,6 @@ Gro differs in some significant ways:
   instead of [esbuild](https://github.com/evanw/esbuild)
   because the former allows preserving unused imports, which is helpful for Svelte.
 
-<img src="/src/frontend/favicon.png" align="center" width="512" height="512">
+<p align="center">
+  <img src="/src/frontend/favicon.png" width="512" height="512">
+</p>

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -3,7 +3,8 @@
 Gro is designed to be a most-in-one development tool for both Node projects and
 [Svelte](https://github.com/sveltejs/svelte) user inferfaces.
 Inspired by [Snowpack](https://github.com/pikapkg/snowpack),
-Gro leverages ES modules during development to avoid the overhead and complexity of bundling.
+Gro leverages ES modules during development
+to avoid the unnecessary overhead and complexity of bundling.
 For production, it uses Rollup to produce efficient bundles.
 The result is the best of both worlds:
 fast iteration with straightforward builds during development,

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -16,6 +16,8 @@ Today, Gro is aimed at three primary use cases:
 - single page Svelte appliations that also have a server
 - Node modules, like libraries and standalone servers
 
+> Gro is not yet 1.0! Some use cases are particularly rough right now.
+
 In the long run, Gro plans to add support for server side rendering and static site generation,
 but today these are low priority.
 We recommend using [Sapper](https://github.com/sveltejs/sapper) for most websites.

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -60,3 +60,5 @@ Gro differs in some significant ways:
 - Gro uses [swc](https://github.com/swc-project/swc)
   instead of [esbuild](https://github.com/evanw/esbuild)
   because the former allows preserving unused imports, which is helpful for Svelte.
+
+<img src="src/frontend/favicon.png" align="center" width="512" height="512">

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -61,4 +61,4 @@ Gro differs in some significant ways:
   instead of [esbuild](https://github.com/evanw/esbuild)
   because the former allows preserving unused imports, which is helpful for Svelte.
 
-<img src="src/frontend/favicon.png" align="center" width="512" height="512">
+<img src="/src/frontend/favicon.png" align="center" width="512" height="512">

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -1,0 +1,56 @@
+# unbundled development
+
+Gro is designed to support development of both Node projects and
+[Svelte](https://github.com/sveltejs/svelte) user inferfaces.
+Inspired by [Snowpack](https://github.com/pikapkg/snowpack),
+Gro leverages ES modules during development to avoid the overhead and complexity of bundling.
+For production, it uses Rollup to produce efficient bundles.
+The result is the best of both worlds:
+fast iteration with straightforward builds during development,
+and uncompromising efficiency for production.
+
+Today, Gro is aimed at two primary use cases:
+
+- single page applications with Svelte
+- Node modules
+
+In the long run, Gro plans to add support for server side rendering and static site generation,
+but today these are low priority.
+We recommend using [Sapper](https://github.com/sveltejs/sapper) for most websites.
+Gro is primarily intended for SPAs and Node projects,
+and it won't reach a stable 1.0 for quite a while.
+
+Gro tries to provide good defaults and full control when you need it.
+Its philosophy is to offer sharp tools
+that prioritize efficiency and minimize dependencies.
+Sharp tools have a drawback, and aren't the best experience for all developers -
+they can hurt when held in certain ways!
+
+Gro's development is still a work in progress, and production usage is discouraged,
+but please feel free to try it and share your feedback!
+
+## comparison to Snowpack
+
+Gro's unbundled development is heavily inspired by [Snowpack](https://github.com/pikapkg/snowpack),
+which pioneered using ES modules to avoid the unnecessary overhead of bundling during development.
+Gro differs in some significant ways:
+
+- Snowpack is focused on frontend websites,
+  and Gro is designed to support both frontend and Node projects
+- Snowpack compiles files on demand when requested by the browser
+  and bundles external modules during a separate `snowpack install` step.
+  In contrast, Gro compiles files on startup
+  and bundles external modules when the browser requests them.
+  This is a complex set of tradeoffs - for very large projects, Snowpack has a significant edge,
+  but Gro's strategy has advantages.
+  There are plans for Gro to support lazy compilation and other scale-friendly features,
+  and some of Gro's design decisions may change before it reaches 1.0.
+- Gro does not yet support hot module reloading, though work is in progress.
+- Gro does not have a plugin system for things like PostCSS/SASS and UI frameworks besides Svelte.
+  It has a pluggable compiler architecture that can probably support most of the ecosystem,
+  but it's all a work in progress right now.
+  Adventurous developers can [define their own tasks](src/dev.task.ts)
+  to extend Gro's development system. By default Gro supports TypeScript and Svelte.
+- Gro uses [swc](https://github.com/swc-project/swc)
+  instead of [esbuild](https://github.com/evanw/esbuild)
+  because the former allows preserving unused imports, which is helpful for Svelte.

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -42,7 +42,7 @@ which pioneered using ES modules to avoid the unnecessary overhead of bundling d
 Gro differs in some significant ways:
 
 - Snowpack is focused on frontend websites,
-  and Gro is designed to support both frontend and Node projects
+  and Gro is designed to support both frontend and Node projects.
 - Snowpack compiles files on demand when requested by the browser
   and bundles external modules during a separate `snowpack install` step.
   In contrast, Gro compiles files on startup

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -62,5 +62,7 @@ Gro differs in some significant ways:
   because the former allows preserving unused imports, which is helpful for Svelte.
 
 <p align="center">
-  [<img src="/src/frontend/favicon.png" width="512" height="512">](https://github.com/feltcoop/gro)
+  <a href="https://github.com/feltcoop/gro">
+    <img src="/src/frontend/favicon.png" width="512" height="512">
+  </a>
 </p>

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -63,6 +63,6 @@ Gro differs in some significant ways:
 
 <p align="center">
   <a href="https://github.com/feltcoop/gro">
-    <img src="/src/frontend/favicon.png" width="512" height="512">
+    <img src="/src/frontend/favicon.png" width="192" height="192">
   </a>
 </p>

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -12,7 +12,7 @@ and uncompromising efficiency for production.
 
 Today, Gro is aimed at two primary use cases:
 
-- single page applications with Svelte
+- single page applications with Svelte that may or may not have a server
 - Node modules
 
 In the long run, Gro plans to add support for server side rendering and static site generation,

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -1,6 +1,6 @@
 # unbundled development
 
-Gro is designed to support development of both Node projects and
+Gro is designed to be a most-in-one development tool for both Node projects and
 [Svelte](https://github.com/sveltejs/svelte) user inferfaces.
 Inspired by [Snowpack](https://github.com/pikapkg/snowpack),
 Gro leverages ES modules during development to avoid the overhead and complexity of bundling.

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -12,7 +12,7 @@ and uncompromising efficiency for production.
 
 Today, Gro is aimed at three primary use cases:
 
-- single page applications with Svelte
+- single page applications (SPAs) with Svelte
 - single page Svelte appliations that also have a server
 - Node modules, like libraries and standalone servers
 

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -10,10 +10,11 @@ The result is the best of both worlds:
 fast iteration with straightforward builds during development,
 and uncompromising efficiency for production.
 
-Today, Gro is aimed at two primary use cases:
+Today, Gro is aimed at three primary use cases:
 
-- single page applications with Svelte that may or may not have a server
-- Node modules
+- single page applications with Svelte
+- single page Svelte appliations that also have a server
+- Node modules, like libraries and standalone servers
 
 In the long run, Gro plans to add support for server side rendering and static site generation,
 but today these are low priority.

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -55,7 +55,7 @@ Gro differs in some significant ways:
 - Gro does not yet have a plugin system for things like PostCSS/SASS and UI frameworks besides Svelte.
   It has a pluggable compiler architecture that can probably support most of the ecosystem,
   but it's all a work in progress right now.
-  Adventurous developers can [define their own tasks](src/dev.task.ts)
+  Adventurous developers can [define their own tasks](/src/dev.task.ts)
   to extend Gro's development system. By default Gro supports TypeScript and Svelte.
   We're not fans of plugin ecosystems that primarily wrap other libraries,
   and instead we try to support the direct usage of Node APIs and libraries,

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -62,5 +62,5 @@ Gro differs in some significant ways:
   because the former allows preserving unused imports, which is helpful for Svelte.
 
 <p align="center">
-  <img src="/src/frontend/favicon.png" width="512" height="512">
+  [<img src="/src/frontend/favicon.png" width="512" height="512">](https://github.com/feltcoop/gro)
 </p>

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -48,7 +48,7 @@ Gro differs in some significant ways:
   In contrast, Gro compiles files on startup
   and bundles external modules when the browser requests them.
   This is a complex set of tradeoffs - for very large projects, Snowpack has a significant edge,
-  but Gro's strategy has advantages. We'll a more detailed analysis eventually, hopefully.
+  but Gro's strategy has advantages. We'll do a more detailed analysis eventually, hopefully.
   There are plans for Gro to support lazy compilation and other scale-friendly features,
   and some of Gro's design decisions may change before it reaches 1.0.
 - Gro does not yet support hot module reloading, though work is in progress.

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -48,7 +48,7 @@ Gro differs in some significant ways:
   In contrast, Gro compiles files on startup
   and bundles external modules when the browser requests them.
   This is a complex set of tradeoffs - for very large projects, Snowpack has a significant edge,
-  but Gro's strategy has advantages. We'll plan to do a more detailed analysis eventually.
+  but Gro's strategy has advantages. We'll a more detailed analysis eventually, hopefully.
   There are plans for Gro to support lazy compilation and other scale-friendly features,
   and some of Gro's design decisions may change before it reaches 1.0.
 - Gro does not yet support hot module reloading, though work is in progress.

--- a/src/docs/unbundledDevelopment.md
+++ b/src/docs/unbundledDevelopment.md
@@ -20,6 +20,8 @@ but today these are low priority.
 We recommend using [Sapper](https://github.com/sveltejs/sapper) for most websites.
 Gro is primarily intended for SPAs and Node projects,
 and it won't reach a stable 1.0 for quite a while.
+SPAs are a niche use case - they're usually not what you want on the web!
+But sometimes they're _exactly_ what you want, and Gro was purpose-built to support them.
 
 Gro tries to provide good defaults and full control when you need it.
 Its philosophy is to offer sharp tools


### PR DESCRIPTION
This documents the unbundled development features added for v0.5.0. There's an emphasis on comparing Gro's dev system to [Snowpack](https://github.com/pikapkg/snowpack), which heavily inspired it.