### PR TITLE
config input

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "request": "launch",
       "name": "gro",
       "program": "${workspaceFolder}/dist/cli/gro.js",
-      "args": [],
+      "args": ["project/dev"],
       "runtimeArgs": [],
       "outFiles": ["${workspaceRoot}/dist/**/*.js"], // enables breakpoints in TS source
       "env": {

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ gro clean # deletes all build artifacts from the filesystem
 ```
 
 ```bash
-gro serve # staticly serves the current directory
-gro serve some/dir and/another/dir # staticly serves some directories
+gro serve # serves the current directory
+gro serve some/dir and/another/dir # serves some directories
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ gro # lists all available tasks with the pattern `*.task.ts`
 gro some/dir # lists all tasks inside `src/some/dir`
 gro some/file # runs `src/some/file.task.ts`
 gro some/file.task.ts # same as above
-gro test # run one of Gro's tasks or `src/test.task.ts` if it exists
+gro test # run `src/test.task.ts` if it exists, falling back to Gro's builtin
 ```
 
 Gro has a number of builtin tasks.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Normally you'll want to install Gro as a dev dependency:
 npm i -D @feltcoop/gro
 ```
 
-You'll also want to install Gro globally to add its CLI to your system PATH:
+It's handy to install globally too:
 
 ```bash
 npm i -g @feltcoop/gro

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Gro's strategy of pairing unbundled ES modules during development
 with optimized bundles for production
 was inspired by [Snowpack](https://github.com/pikapkg/snowpack).
 
+Gro's buildtime antics were inspired by [Svelte](https://github.com/sveltejs/svelte).
+
 ## license :bird:
 
 [MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "gro",
     "test": "gro test",
     "bootstrap": "rm -rf .gro/prod/node dist/ && tsc; cp -r .gro/prod/node/ dist/ && npm link",
+    "dev": "clear && rm -rf .gro && npm run bootstrap && gro project/dev",
     "preversion": "npm run bootstrap && gro check && npm run bootstrap && gro project/build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "start": "gro",
     "test": "gro test",
-    "bootstrap": "rm -rf .gro/prod/node dist/ && tsc && cp -r .gro/prod/node/ dist/ && npm link",
+    "bootstrap": "rm -rf .gro/prod/node dist/ && tsc; cp -r .gro/prod/node/ dist/ && npm link",
     "preversion": "npm run bootstrap && gro check && npm run bootstrap && gro project/build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "gro",
     "test": "gro test",
     "bootstrap": "rm -rf .gro/prod/node dist/ && tsc; cp -r .gro/prod/node/ dist/ && npm link",
-    "dev": "clear && rm -rf .gro && npm run bootstrap && gro project/dev",
+    "dev": "clear && rm -rf .gro && gro project/dev",
+    "redev": "clear && rm -rf .gro && npm run bootstrap && gro project/dev",
     "preversion": "npm run bootstrap && gro check && npm run bootstrap && gro project/build"
   },
   "repository": {

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -470,6 +470,7 @@ export class Filer {
 	}
 
 	// Remove the build config. The caller is expected to check to avoid duplicates.
+	// aka `removeSourceFileFromBuild`
 	private async removeBuildConfigFromSourceFile(
 		sourceFile: BuildableSourceFile,
 		buildConfig: BuildConfig,
@@ -693,17 +694,6 @@ export class Filer {
 		return filerDir.buildable;
 	}
 
-	// Updates the build files in the memory cache and writes to disk.
-	private async updateBuildFiles(
-		sourceFile: BuildableSourceFile,
-		newBuildFiles: readonly BuildFile[], // TODO should these be nullable?
-	): Promise<void> {
-		const oldBuildFiles = sourceFile.buildFiles;
-		sourceFile.buildFiles = newBuildFiles;
-		syncBuildFilesToMemoryCache(this.files, newBuildFiles, oldBuildFiles, this.log);
-		return syncFilesToDisk(newBuildFiles, oldBuildFiles, this.log);
-	}
-
 	// These are used to avoid concurrent compilations for any given source file.
 	private pendingCompilations = new Set<string>(); // value is `buildConfigName + sourceFileId`
 	private enqueuedCompilations = new Set<string>(); // value is `buildConfigName + sourceFileId`
@@ -892,6 +882,17 @@ export class Filer {
 			}
 		}
 		if (promises !== null) await Promise.all(promises);
+	}
+
+	// Updates the build files in the memory cache and writes to disk.
+	private async updateBuildFiles(
+		sourceFile: BuildableSourceFile,
+		newBuildFiles: readonly BuildFile[], // TODO should these be nullable?
+	): Promise<void> {
+		const oldBuildFiles = sourceFile.buildFiles;
+		sourceFile.buildFiles = newBuildFiles;
+		syncBuildFilesToMemoryCache(this.files, newBuildFiles, oldBuildFiles, this.log);
+		return syncFilesToDisk(newBuildFiles, oldBuildFiles, this.log);
 	}
 
 	private async destroySourceId(id: string): Promise<void> {

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -483,46 +483,29 @@ export class Filer {
 		const newBuildFiles: BuildFile[] = oldBuildFiles.filter((f) => f.buildConfig !== buildConfig);
 
 		// TODO remove from dependents
+		// TODO remove all dependencies if they have none
 
 		await Promise.all([
 			this.updateBuildFiles(sourceFile, newBuildFiles, oldBuildFiles),
 			this.updateCachedSourceInfo(sourceFile),
 		]);
 
-		// OLD CODE FROM `addBuildConfigToSourceFile`
-		// Add the build config as an input if appropriate, initializing the set if needed.
-		// We need to determine `isInputToBuildConfig` independently of the caller,
-		// because the caller may not
-
-		// if (isInputToBuildConfig(sourceFile, buildConfig)) {
-		// 	if (sourceFile.isInputToBuildConfigs === null) {
-		// 		// Cast to keep the `readonly` modifier outside of initialization.
-		// 		(sourceFile as Writable<
-		// 			BuildableSourceFile,
-		// 			'isInputToBuildConfigs'
-		// 		>).isInputToBuildConfigs = new Set();
-		// 	}
-		// 	sourceFile.isInputToBuildConfigs!.add(buildConfig);
-		// }
-
-		// await this.buildSourceFile(sourceFile, buildConfig);
-
 		// const promises: Promise<void>[] = [];
 
-		// // At this point, we need to compile the dependencies of the compiled files.
-		// // Then, each of those needs to compile its dependencies, and so forth.
-		// for (const compiledFile of sourceFile.buildFiles) {
-		// 	// console.log('\n\ncompiledFile.id', compiledFile.id);
-		// 	if (buildConfig.platform === 'browser' && compiledFile.externalDependencies !== null) {
-		// 		for (const externalDependency of compiledFile.externalDependencies) {
-		// 			console.log('add external', externalDependency, compiledFile.id);
+		// // At this point, we need to check dependencies (remove it from them? uhhhhhhhhhhhhhhh) TODO
+		// // Then, each of those needs to check its dependencies, and so forth.
+		// for (const buildFile of sourceFile.buildFiles) {
+		// 	// console.log('\n\nbuildFile.id', buildFile.id);
+		// 	if (buildConfig.platform === 'browser' && buildFile.externalDependencies !== null) {
+		// 		for (const externalDependency of buildFile.externalDependencies) {
+		// 			console.log('add external', externalDependency, buildFile.id);
 		// 			this.externalDependencies.add(externalDependency);
 		// 		}
 		// 	}
 		// 	// TODO wait so we need to map the imported dependencies back from the compiled files to the source files? hmm
 		// 	// do we expect these to always be relative paths, so we need to resolve them against the compiled file dir?
-		// 	if (compiledFile.localDependencies !== null) {
-		// 		for (const localDependencyId of compiledFile.localDependencies) {
+		// 	if (buildFile.localDependencies !== null) {
+		// 		for (const localDependencyId of buildFile.localDependencies) {
 		// 			// TODO this should short circuit if the source has already been added to the input set
 		// 			// console.log('localDependencyId', localDependencyId);
 		// 			const dependencySourceId = this.mapBuildIdToSourceId(localDependencyId);

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -482,10 +482,13 @@ export class Filer {
 		const oldBuildFiles = sourceFile.buildFiles;
 		const newBuildFiles: BuildFile[] = oldBuildFiles.filter((f) => f.buildConfig !== buildConfig);
 
+		// TODO remove from dependents
+
 		await Promise.all([
 			this.updateBuildFiles(sourceFile, newBuildFiles, oldBuildFiles),
-			this.deleteCachedSourceInfo(sourceFile),
+			this.updateCachedSourceInfo(sourceFile),
 		]);
+
 		// OLD CODE FROM `addBuildConfigToSourceFile`
 		// Add the build config as an input if appropriate, initializing the set if needed.
 		// We need to determine `isInputToBuildConfig` independently of the caller,
@@ -761,6 +764,7 @@ export class Filer {
 			this.updateCachedSourceInfo(sourceFile),
 		]);
 
+		// TODO parallelize with the above? after `updateCachedSourceInfo`? race conditions?
 		// After building the source file, we need to handle any dependency changes for each build file.
 		// Dependencies may be added or removed,
 		// and their source files need to be updated with any build config changes.
@@ -884,6 +888,7 @@ export class Filer {
 	}
 
 	private async updateCachedSourceInfo(file: BuildableSourceFile): Promise<void> {
+		if (file.buildConfigs.size === 0) return this.deleteCachedSourceInfo(file);
 		const cachedSourceInfoId = toCachedSourceInfoId(
 			file,
 			this.buildRootDir,

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -348,7 +348,7 @@ export class Filer {
 		const filters: ((id: string) => boolean)[] = [];
 		const filterBuildConfigs: BuildConfig[] = [];
 
-		// Iterate through the build config inputs and look for their files.
+		// Iterate through the build config inputs and initialize their files.
 		for (const buildConfig of this.buildConfigs) {
 			for (const buildConfigInput of buildConfig.input) {
 				if (typeof buildConfigInput === 'function') {
@@ -425,11 +425,10 @@ export class Filer {
 			}
 			// TODO wait so we need to map the imported dependencies back from the compiled files to the source files? hmm
 			// do we expect these to always be relative paths, so we need to resolve them against the compiled file dir?
-			for (const localDependency of compiledFile.locals) {
+			for (const localDependencyId of compiledFile.locals) {
 				// TODO this should short circuit if the source has already been added to the input set
-				const dependencyId = join(compiledFile.dir, localDependency);
-				// console.log('dependencyId', dependencyId);
-				const dependencySourceId = this.mapBuildIdToSourceId(dependencyId);
+				// console.log('localDependencyId', localDependencyId);
+				const dependencySourceId = this.mapBuildIdToSourceId(localDependencyId);
 				// console.log('dependencySourceId', dependencySourceId);
 				const dependencySourceFile = this.files.get(dependencySourceId);
 				// TODO these 2 checks are copy/pasted in 3 places - we can probably remove them and just cast

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -427,7 +427,10 @@ export class Filer {
 			sourceFile.isInputToBuildConfigs!.add(buildConfig);
 		}
 
-		await this.buildSourceFile(sourceFile, buildConfig);
+		// Build only if needed - build files may be hydrated from the cache.
+		if (sourceFile.buildFiles.find((f) => f.buildConfig === buildConfig) === undefined) {
+			await this.buildSourceFile(sourceFile, buildConfig);
+		}
 
 		const promises: Promise<void>[] = [];
 

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -474,24 +474,19 @@ export class Filer {
 		buildConfig: BuildConfig,
 	): Promise<void> {
 		// TODO I think this check should be unnecessary, but might catch weird bugs while developing
-		if (isInputToBuildConfig(sourceFile, buildConfig)) throw Error('TODO removeme');
+		if (isInputToBuildConfig(sourceFile, buildConfig)) throw Error('TODO needed?');
 
 		const deleted = sourceFile.buildConfigs.delete(buildConfig);
 		if (!deleted) {
 			throw Error(`Expected to delete buildConfig '${buildConfig}' from ${sourceFile.id}`);
 		}
 
-		// TODO wait what? if it's an input to the build config,
-		// when would you ever remove it?
-		// we're expecting build configs and source file paths to be immutable!
-		// (so "moving" a file, which may change if it's selected to be an input,
-		// is actually modeled as the destruction of the old and creation of the new)
-		// Remove the build config as an input if it's there.
-		// sourceFile.isInputToBuildConfigs?.delete(buildConfig);
-
 		// TODO remove from dependents ????????
 		// if (sourceFile.dependents.size === 0) {
 		// }
+
+		await this.updateBuildFiles(sourceFile, [], buildConfig);
+		await this.updateCachedSourceInfo(sourceFile);
 
 		// TODO parallelize this with the above?
 		// doesn't this overlap with `updateBuildFiles`?
@@ -749,6 +744,7 @@ export class Filer {
 		newBuildFiles: readonly BuildFile[], // TODO should these be nullable?
 		buildConfig: BuildConfig,
 	): Promise<void> {
+		// TODO extract into a helper?
 		const diffResult = this.diffDependencies(sourceFile, newBuildFiles, buildConfig);
 		const addedDependencySourceFiles = diffResult && diffResult[0];
 		const removedDependencySourceFiles = diffResult && diffResult[1];

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -431,18 +431,18 @@ export class Filer {
 
 		// At this point, we need to compile the dependencies of the compiled files.
 		// Then, each of those needs to compile its dependencies, and so forth.
-		for (const compiledFile of sourceFile.buildFiles) {
-			// console.log('\n\ncompiledFile.id', compiledFile.id);
-			if (buildConfig.platform === 'browser' && compiledFile.externalDependencies !== null) {
-				for (const externalDependency of compiledFile.externalDependencies) {
-					console.log('add external', externalDependency, compiledFile.id);
+		for (const buildFile of sourceFile.buildFiles) {
+			// console.log('\n\nbuildFile.id', buildFile.id);
+			if (buildConfig.platform === 'browser' && buildFile.externalDependencies !== null) {
+				for (const externalDependency of buildFile.externalDependencies) {
+					console.log('add external', externalDependency, buildFile.id);
 					this.externalDependencies.add(externalDependency);
 				}
 			}
 			// TODO wait so we need to map the imported dependencies back from the compiled files to the source files? hmm
 			// do we expect these to always be relative paths, so we need to resolve them against the compiled file dir?
-			if (compiledFile.localDependencies !== null) {
-				for (const localDependencyId of compiledFile.localDependencies) {
+			if (buildFile.localDependencies !== null) {
+				for (const localDependencyId of buildFile.localDependencies) {
 					// TODO this should short circuit if the source has already been added to the input set
 					// console.log('localDependencyId', localDependencyId);
 					const dependencySourceId = this.mapBuildIdToSourceId(localDependencyId);

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -352,9 +352,6 @@ export class Filer {
 		if (this.cleanOutputDirs && buildConfigs !== null) {
 			// Clean the dev output directories,
 			// removing any files that can't be mapped back to source files.
-			// For now, this does not handle production output.
-			// See the comments where `dev` is declared for more.
-			// (more accurately, it could handle prod, but not simultaneous to dev)
 			const buildOutDirs: string[] = buildConfigs.map((buildConfig) =>
 				toBuildOutPath(this.dev, buildConfig.name, '', this.buildRootDir),
 			);
@@ -602,7 +599,6 @@ export class Filer {
 		}
 
 		// Compile the source file.
-		// TODO support production builds
 		// The Filer is designed to be able to be a long-lived process
 		// that can output builds for both development and production,
 		// but for now it's hardcoded to development, and production is entirely done by Rollup.
@@ -891,8 +887,6 @@ const validateDirs = (
 	}
 };
 
-// This code could be shortened a lot by collapsing the object declarations,
-// but as is it doesn't play nicely with the types, and it might be harder to reason about.
 const createSourceFile = async (
 	id: string,
 	encoding: Encoding,

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -773,13 +773,6 @@ export class Filer {
 		const addedDependencies = diffResult && diffResult[0];
 		const removedDependencies = diffResult && diffResult[1];
 		if (addedDependencies !== null) {
-			// TODO handle adding during initialization vs after a real compilation
-			// The added dependency might not exist!
-			// TODO I think there's a weird race condition here.
-			// What if it sees no build file, but there's a pending compilation?
-			// We could infer the source file id to check for its existence,
-			// but is that bulletproof?
-			// TODO but how can we retroactively initialize its source file build config then?
 			for (const addedDependency of addedDependencies) {
 				if (addedDependency.external) {
 					if (buildConfig.platform === 'node') {
@@ -799,7 +792,6 @@ export class Filer {
 			}
 		}
 		if (removedDependencies !== null) {
-			// TODO review all of these conditions, and race conditions with pending compilations (see above)
 			for (const removedDependency of removedDependencies) {
 				if (removedDependency.external) {
 					if (buildConfig.platform === 'node') {
@@ -848,6 +840,8 @@ export class Filer {
 		}
 	}
 
+	// TODO as an optimization, this should be debounced per file,
+	// because we're writing per build config.
 	private async updateCachedSourceInfo(file: BuildableSourceFile): Promise<void> {
 		if (file.buildConfigs.size === 0) return this.deleteCachedSourceInfo(file);
 		const cachedSourceInfoId = toCachedSourceInfoId(

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -269,7 +269,7 @@ export class Filer {
 		await Promise.all(this.dirs.map((dir) => dir.init()));
 		// This performs initial source file compilation, traces deps,
 		// and populates the `buildConfigs` property of all source files.
-		await this.initBuildConfigs();
+		await this.initBuilds();
 		console.log('buildConfigs', this.buildConfigs);
 
 		// TODO this needs to perform matching for each buildConfig against the file,
@@ -341,7 +341,7 @@ export class Filer {
 	// It traces the dependencies starting from each `buildConfig.input`,
 	// compiling each input source file and populating its `buildConfigs`,
 	// recursively until all dependencies have been handled.
-	private async initBuildConfigs(): Promise<void> {
+	private async initBuilds(): Promise<void> {
 		if (this.buildConfigs === null) return;
 
 		const promises: Promise<void>[] = [];
@@ -559,7 +559,7 @@ export class Filer {
 					const shouldCompile = await this.updateSourceFile(id, filerDir);
 					if (
 						shouldCompile &&
-						// When initializing, compilation is deferred to `initBuildConfigs`
+						// When initializing, compilation is deferred to `initBuilds`
 						// so that deps are determined in the correct order.
 						change.type !== 'init' &&
 						filerDir.buildable // only needed for types, doing this instead of casting for type safety

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -899,8 +899,7 @@ export class Filer {
 					}
 				}
 				const addedSourceFile = this.findSourceFile(addedDependency.id);
-				if (addedSourceFile === undefined) throw Error('TODO error or continue?');
-				// if (addedSourceFile === undefined) continue;
+				if (addedSourceFile === undefined) continue; // import might point to a nonexistent file
 				if (!addedSourceFile.buildable) {
 					throw Error(`Expected source file to be buildable: ${addedSourceFile.id}`);
 				}
@@ -920,8 +919,7 @@ export class Filer {
 					}
 				}
 				const removedSourceFile = this.findSourceFile(removedDependency.id);
-				if (removedSourceFile === undefined) throw Error('TODO error or continue?');
-				// if (removedSourceFile === undefined) continue;
+				if (removedSourceFile === undefined) continue; // import might point to a nonexistent file
 				if (!removedSourceFile.buildable) {
 					throw Error(`Expected dependency source file to be buildable: ${removedSourceFile.id}`);
 				}

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -154,7 +154,7 @@ export class Filer {
 	private readonly externalsDir: ExternalsFilerDir | null;
 	private readonly externalsServedDir: ServedDir | null;
 	private readonly buildConfigs: BuildConfig[] | null;
-	private readonly externalsBuildConfig: BuildConfig | null;
+	// private readonly externalsBuildConfig: BuildConfig | null;
 	private readonly mapBuildIdToSourceId: typeof defaultMapBuildIdToSourceId;
 	private readonly cleanOutputDirs: boolean;
 	private readonly log: Logger;
@@ -172,7 +172,7 @@ export class Filer {
 			dev,
 			compiler,
 			buildConfigs,
-			externalsBuildConfig,
+			// externalsBuildConfig,
 			buildRootDir,
 			mapBuildIdToSourceId,
 			compiledDirs,
@@ -187,7 +187,7 @@ export class Filer {
 		} = initOptions(opts);
 		this.dev = dev;
 		this.buildConfigs = buildConfigs;
-		this.externalsBuildConfig = externalsBuildConfig;
+		// this.externalsBuildConfig = externalsBuildConfig;
 		this.buildRootDir = buildRootDir;
 		this.mapBuildIdToSourceId = mapBuildIdToSourceId;
 		this.sourceMap = sourceMap;

--- a/src/build/FilerDir.ts
+++ b/src/build/FilerDir.ts
@@ -6,24 +6,24 @@ import {UnreachableError} from '../utils/error.js';
 import {PathStats} from '../fs/pathData.js';
 
 // Compiled filer dirs are watched, compiled, and written to disk.
-// For non-compilable dirs, the `dir` is only watched and nothing is written to the filesystem.
+// For non-buildable dirs, the `dir` is only watched and nothing is written to the filesystem.
 // Externals dirs require special handling - see the `Filer` for more.
-export type FilerDir = CompilableFilerDir | NonCompilableInternalsFilerDir;
-export type CompilableFilerDir = CompilableInternalsFilerDir | ExternalsFilerDir;
+export type FilerDir = BuildableFilerDir | NonBuildableInternalsFilerDir;
+export type BuildableFilerDir = BuildableInternalsFilerDir | ExternalsFilerDir;
 export type FilerDirType = 'files' | 'externals';
-export interface CompilableInternalsFilerDir extends BaseFilerDir {
+export interface BuildableInternalsFilerDir extends BaseFilerDir {
 	readonly type: 'files';
-	readonly compilable: true;
+	readonly buildable: true;
 	readonly compiler: Compiler;
 }
-export interface NonCompilableInternalsFilerDir extends BaseFilerDir {
+export interface NonBuildableInternalsFilerDir extends BaseFilerDir {
 	readonly type: 'files';
-	readonly compilable: false;
+	readonly buildable: false;
 	readonly compiler: null;
 }
 export interface ExternalsFilerDir extends BaseFilerDir {
 	readonly type: 'externals';
-	readonly compilable: true;
+	readonly buildable: true;
 	readonly compiler: Compiler;
 }
 
@@ -75,7 +75,7 @@ export const createFilerDir = (
 			if (compiler === null) {
 				filerDir = {
 					type: 'files',
-					compilable: false,
+					buildable: false,
 					compiler: null,
 					dir,
 					onChange,
@@ -86,7 +86,7 @@ export const createFilerDir = (
 			} else {
 				filerDir = {
 					type: 'files',
-					compilable: true,
+					buildable: true,
 					compiler,
 					dir,
 					onChange,
@@ -103,7 +103,7 @@ export const createFilerDir = (
 			} else {
 				filerDir = {
 					type: 'externals',
-					compilable: true,
+					buildable: true,
 					compiler,
 					dir,
 					onChange,

--- a/src/build/baseFilerFile.ts
+++ b/src/build/baseFilerFile.ts
@@ -1,0 +1,49 @@
+import {createHash} from 'crypto';
+
+import {stat, Stats} from '../fs/nodeFs.js';
+import {Encoding} from '../fs/encoding.js';
+import {getMimeTypeByExtension} from '../fs/mime.js';
+
+// TODO rename this module? or move this code elsewhere?
+
+export interface BaseFilerFile {
+	readonly id: string;
+	readonly filename: string;
+	readonly dir: string;
+	readonly extension: string;
+	readonly encoding: Encoding;
+	readonly contents: string | Buffer;
+	contentsBuffer: Buffer | undefined; // `undefined` and mutable for lazy loading
+	contentsHash: string | undefined; // `undefined` and mutable for lazy loading
+	stats: Stats | undefined; // `undefined` and mutable for lazy loading
+	mimeType: string | null | undefined; // `null` means unknown, `undefined` and mutable for lazy loading
+}
+
+export const getFileMimeType = (file: BaseFilerFile): string | null =>
+	file.mimeType !== undefined
+		? file.mimeType
+		: (file.mimeType = getMimeTypeByExtension(file.extension.substring(1)));
+
+export const getFileContentsBuffer = (file: BaseFilerFile): Buffer =>
+	file.contentsBuffer !== undefined
+		? file.contentsBuffer
+		: (file.contentsBuffer = Buffer.from(file.contents));
+
+// Stats are currently lazily loaded. Should they be?
+export const getFileStats = (file: BaseFilerFile): Stats | Promise<Stats> =>
+	file.stats !== undefined
+		? file.stats
+		: stat(file.id).then((stats) => {
+				file.stats = stats;
+				return stats;
+		  });
+
+export const getFileContentsHash = (file: BaseFilerFile): string =>
+	file.contentsHash !== undefined
+		? file.contentsHash
+		: (file.contentsHash = toHash(getFileContentsBuffer(file)));
+
+// Note that this uses md5 and therefore is not cryptographically secure.
+// It's fine for now, but some use cases may need security.
+export const toHash = (buf: Buffer): string =>
+	createHash('md5').update(buf).digest().toString('hex');

--- a/src/build/baseFilerFile.ts
+++ b/src/build/baseFilerFile.ts
@@ -1,8 +1,7 @@
-import {createHash} from 'crypto';
-
 import {stat, Stats} from '../fs/nodeFs.js';
 import {Encoding} from '../fs/encoding.js';
 import {getMimeTypeByExtension} from '../fs/mime.js';
+import {toHash} from './utils.js';
 
 // TODO rename this module? or move this code elsewhere?
 
@@ -42,8 +41,3 @@ export const getFileContentsHash = (file: BaseFilerFile): string =>
 	file.contentsHash !== undefined
 		? file.contentsHash
 		: (file.contentsHash = toHash(getFileContentsBuffer(file)));
-
-// Note that this uses md5 and therefore is not cryptographically secure.
-// It's fine for now, but some use cases may need security.
-export const toHash = (buf: Buffer): string =>
-	createHash('md5').update(buf).digest().toString('hex');

--- a/src/build/buildFile.ts
+++ b/src/build/buildFile.ts
@@ -2,7 +2,7 @@ import {Compilation, CompileOptions, CompileResult} from '../compile/compiler.js
 import {UnreachableError} from '../utils/error.js';
 import {BaseFilerFile} from './baseFilerFile.js';
 import {CachedSourceInfo} from './Filer.js';
-import {SOURCE_MAP_EXTENSION} from '../paths.js';
+import {SOURCEMAP_EXTENSION} from '../paths.js';
 import {postprocess} from './postprocess.js';
 import {basename, dirname, extname} from 'path';
 import {loadContents} from './load.js';
@@ -118,8 +118,8 @@ export const reconstructBuildFiles = (
 							extension,
 							encoding,
 							contents: contents as string,
-							sourceMapOf: id.endsWith(SOURCE_MAP_EXTENSION)
-								? stripEnd(id, SOURCE_MAP_EXTENSION)
+							sourceMapOf: id.endsWith(SOURCEMAP_EXTENSION)
+								? stripEnd(id, SOURCEMAP_EXTENSION)
 								: null,
 							contentsBuffer: undefined,
 							contentsHash: undefined,

--- a/src/build/buildFile.ts
+++ b/src/build/buildFile.ts
@@ -1,0 +1,135 @@
+import {Compilation, CompileOptions, CompileResult} from '../compile/compiler.js';
+import {UnreachableError} from '../utils/error.js';
+import {BaseFilerFile} from './baseFilerFile.js';
+import {CachedSourceInfo} from './Filer.js';
+import {SOURCE_MAP_EXTENSION} from '../paths.js';
+import {postprocess} from './postprocess.js';
+import {basename, dirname, extname} from 'path';
+import {loadContents} from './load.js';
+import {BuildableSourceFile} from './sourceFile.js';
+import {stripEnd} from '../utils/string.js';
+
+export type BuildFile = TextBuildFile | BinaryBuildFile;
+export interface TextBuildFile extends BaseBuildFile {
+	readonly encoding: 'utf8';
+	readonly contents: string;
+	readonly sourceMapOf: string | null; // TODO maybe prefer a union with an `isSourceMap` boolean flag?
+}
+export interface BinaryBuildFile extends BaseBuildFile {
+	readonly encoding: null;
+	readonly contents: Buffer;
+	readonly contentsBuffer: Buffer;
+}
+interface BaseBuildFile extends BaseFilerFile {
+	readonly type: 'build';
+	readonly sourceFileId: string;
+	readonly locals: string[]; // TODO is this right? or maybe a set?
+	readonly externals: string[]; // TODO is this right? or maybe a set?
+}
+
+export const createBuildFile = (
+	compilation: Compilation,
+	compileOptions: CompileOptions,
+	result: CompileResult<Compilation>,
+	sourceFile: BuildableSourceFile,
+): BuildFile => {
+	const [contents, locals, externals] = postprocess(
+		compilation,
+		compileOptions,
+		result,
+		sourceFile,
+	);
+	switch (compilation.encoding) {
+		case 'utf8':
+			return {
+				type: 'build',
+				sourceFileId: sourceFile.id,
+				locals,
+				externals,
+				id: compilation.id,
+				filename: compilation.filename,
+				dir: compilation.dir,
+				extension: compilation.extension,
+				encoding: compilation.encoding,
+				contents: contents as string,
+				sourceMapOf: compilation.sourceMapOf,
+				contentsBuffer: undefined,
+				contentsHash: undefined,
+				stats: undefined,
+				mimeType: undefined,
+			};
+		case null:
+			return {
+				type: 'build',
+				sourceFileId: sourceFile.id,
+				locals,
+				externals,
+				id: compilation.id,
+				filename: compilation.filename,
+				dir: compilation.dir,
+				extension: compilation.extension,
+				encoding: compilation.encoding,
+				contents: contents as Buffer,
+				contentsBuffer: compilation.contents,
+				contentsHash: undefined,
+				stats: undefined,
+				mimeType: undefined,
+			};
+		default:
+			throw new UnreachableError(compilation);
+	}
+};
+
+export const reconstructBuildFiles = (cachedSourceInfo: CachedSourceInfo): Promise<BuildFile[]> =>
+	Promise.all(
+		cachedSourceInfo.compilations.map(
+			async (compilation): Promise<BuildFile> => {
+				const {id} = compilation;
+				const filename = basename(id);
+				const dir = dirname(id) + '/'; // TODO the slash is currently needed because paths.sourceId and the rest have a trailing slash, but this may cause other problems
+				const extension = extname(id);
+				const contents = await loadContents(compilation.encoding, id);
+				switch (compilation.encoding) {
+					case 'utf8':
+						return {
+							type: 'build',
+							sourceFileId: cachedSourceInfo.sourceId,
+							locals: compilation.locals,
+							externals: compilation.externals,
+							id,
+							filename,
+							dir,
+							extension,
+							encoding: compilation.encoding,
+							contents: contents as string,
+							sourceMapOf: id.endsWith(SOURCE_MAP_EXTENSION)
+								? stripEnd(id, SOURCE_MAP_EXTENSION)
+								: null,
+							contentsBuffer: undefined,
+							contentsHash: undefined,
+							stats: undefined,
+							mimeType: undefined,
+						};
+					case null:
+						return {
+							type: 'build',
+							sourceFileId: cachedSourceInfo.sourceId,
+							locals: compilation.locals,
+							externals: compilation.externals,
+							id,
+							filename,
+							dir,
+							extension,
+							encoding: compilation.encoding,
+							contents: contents as Buffer,
+							contentsBuffer: contents as Buffer,
+							contentsHash: undefined,
+							stats: undefined,
+							mimeType: undefined,
+						};
+					default:
+						throw new UnreachableError(compilation.encoding);
+				}
+			},
+		),
+	);

--- a/src/build/buildFile.ts
+++ b/src/build/buildFile.ts
@@ -157,8 +157,10 @@ interface DependencyInfo {
 	external: boolean;
 }
 
+// TODO maybe this should take in cached aggregated data from the source file, not `oldBuildFiles`?
+
 // Returns the dependency changes between two sets of build files.
-// Lazily instantiate the collections as an optimization -
+// Lazily instantiate the collections as a small optimization -
 // this function is expected to return `null` most of the time.
 export const diffDependencies = (
 	newFiles: readonly BuildFile[],
@@ -177,28 +179,24 @@ export const diffDependencies = (
 	for (const newFile of newFiles) {
 		if (newFile.localDependencies !== null) {
 			for (const localDependency of newFile.localDependencies) {
-				(newLocalDependencies || (newLocalDependencies = new Set<string>())).add(localDependency);
+				(newLocalDependencies || (newLocalDependencies = new Set())).add(localDependency);
 			}
 		}
 		if (newFile.externalDependencies !== null) {
 			for (const externalDependency of newFile.externalDependencies) {
-				(newExternalDependencies || (newExternalDependencies = new Set<string>())).add(
-					externalDependency,
-				);
+				(newExternalDependencies || (newExternalDependencies = new Set())).add(externalDependency);
 			}
 		}
 	}
 	for (const oldFile of oldFiles) {
 		if (oldFile.localDependencies !== null) {
 			for (const localDependency of oldFile.localDependencies) {
-				(oldLocalDependencies || (oldLocalDependencies = new Set<string>())).add(localDependency);
+				(oldLocalDependencies || (oldLocalDependencies = new Set())).add(localDependency);
 			}
 		}
 		if (oldFile.externalDependencies !== null) {
 			for (const externalDependency of oldFile.externalDependencies) {
-				(oldExternalDependencies || (oldExternalDependencies = new Set<string>())).add(
-					externalDependency,
-				);
+				(oldExternalDependencies || (oldExternalDependencies = new Set())).add(externalDependency);
 			}
 		}
 	}

--- a/src/build/buildFile.ts
+++ b/src/build/buildFile.ts
@@ -21,7 +21,7 @@ export interface BinaryBuildFile extends BaseBuildFile {
 	readonly contents: Buffer;
 	readonly contentsBuffer: Buffer;
 }
-interface BaseBuildFile extends BaseFilerFile {
+export interface BaseBuildFile extends BaseFilerFile {
 	readonly type: 'build';
 	readonly sourceFileId: string;
 	readonly buildConfig: BuildConfig;

--- a/src/build/load.ts
+++ b/src/build/load.ts
@@ -1,0 +1,5 @@
+import {readFile} from '../fs/nodeFs.js';
+import {Encoding} from '../fs/encoding.js';
+
+export const loadContents = (encoding: Encoding, id: string): Promise<string | Buffer> =>
+	encoding === null ? readFile(id) : readFile(id, encoding);

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -1,3 +1,4 @@
+import {join} from 'path';
 // `lexer.init` is expected to be awaited elsewhere before `postprocess` is called
 import lexer from 'es-module-lexer';
 
@@ -50,7 +51,7 @@ export const postprocess = (
 				if (isExternal) {
 					(externals || (externals = [])).push(newModuleName);
 				} else {
-					(locals || (locals = [])).push(newModuleName);
+					(locals || (locals = [])).push(join(compilation.dir, newModuleName));
 				}
 				if (newModuleName !== moduleName) {
 					transformedContents += contents.substring(index, start) + newModuleName;

--- a/src/build/sourceFile.ts
+++ b/src/build/sourceFile.ts
@@ -1,0 +1,210 @@
+import {basename, dirname} from 'path';
+
+import {
+	NonBuildableInternalsFilerDir,
+	BuildableInternalsFilerDir,
+	ExternalsFilerDir,
+	FilerDir,
+} from '../build/FilerDir.js';
+import {BuildFile, reconstructBuildFiles} from './buildFile.js';
+import {BaseFilerFile, toHash} from './baseFilerFile.js';
+import {BuildConfig} from '../config/buildConfig.js';
+import {Encoding} from '../fs/encoding.js';
+import {CachedSourceInfo} from './Filer.js';
+import {UnreachableError} from '../utils/error.js';
+import {stripStart} from '../utils/string.js';
+
+export type SourceFile = BuildableSourceFile | NonBuildableSourceFile;
+export type BuildableSourceFile =
+	| BuildableTextSourceFile
+	| BuildableBinarySourceFile
+	| BuildableExternalsSourceFile;
+export type NonBuildableSourceFile = NonBuildableTextSourceFile | NonBuildableBinarySourceFile;
+export interface TextSourceFile extends BaseSourceFile {
+	readonly sourceType: 'text';
+	readonly encoding: 'utf8';
+	readonly contents: string;
+}
+export interface BinarySourceFile extends BaseSourceFile {
+	readonly sourceType: 'binary';
+	readonly encoding: null;
+	readonly contents: Buffer;
+	readonly contentsBuffer: Buffer;
+}
+export interface ExternalsSourceFile extends BaseSourceFile {
+	readonly sourceType: 'externals';
+	readonly encoding: 'utf8';
+	readonly contents: string;
+}
+interface BaseSourceFile extends BaseFilerFile {
+	readonly type: 'source';
+	readonly dirBasePath: string; // TODO is this the best design? if so should it also go on the `BaseFilerFile`? what about `basePath` too?
+}
+export interface BuildableTextSourceFile extends TextSourceFile {
+	readonly buildable: true;
+	readonly filerDir: BuildableInternalsFilerDir;
+	readonly compiledFiles: BuildFile[];
+	readonly buildConfigs: BuildConfig[];
+}
+export interface BuildableBinarySourceFile extends BinarySourceFile {
+	readonly buildable: true;
+	readonly filerDir: BuildableInternalsFilerDir;
+	readonly compiledFiles: BuildFile[];
+	readonly buildConfigs: BuildConfig[];
+}
+export interface BuildableExternalsSourceFile extends ExternalsSourceFile {
+	readonly buildable: true;
+	readonly filerDir: ExternalsFilerDir;
+	readonly compiledFiles: BuildFile[];
+	readonly buildConfigs: BuildConfig[];
+}
+export interface NonBuildableTextSourceFile extends TextSourceFile {
+	readonly buildable: false;
+	readonly filerDir: NonBuildableInternalsFilerDir;
+	readonly compiledFiles: null;
+	readonly buildConfigs: null;
+}
+export interface NonBuildableBinarySourceFile extends BinarySourceFile {
+	readonly buildable: false;
+	readonly filerDir: NonBuildableInternalsFilerDir;
+	readonly compiledFiles: null;
+	readonly buildConfigs: null;
+}
+
+export const createSourceFile = async (
+	id: string,
+	encoding: Encoding,
+	extension: string,
+	contents: string | Buffer,
+	filerDir: FilerDir,
+	cachedSourceInfo: CachedSourceInfo | undefined,
+): Promise<SourceFile> => {
+	let contentsBuffer: Buffer | undefined = encoding === null ? (contents as Buffer) : undefined;
+	let contentsHash: string | undefined = undefined;
+	let compiledFiles: BuildFile[] = [];
+	if (filerDir.buildable && cachedSourceInfo !== undefined) {
+		if (encoding === 'utf8') {
+			contentsBuffer = Buffer.from(contents);
+		} else if (encoding !== null) {
+			throw new UnreachableError(encoding);
+		}
+		contentsHash = toHash(contentsBuffer!);
+		if (contentsHash === cachedSourceInfo.contentsHash) {
+			compiledFiles = await reconstructBuildFiles(cachedSourceInfo);
+		}
+	}
+	if (filerDir.type === 'externals') {
+		if (encoding !== 'utf8') {
+			throw Error(`Externals sources must have utf8 encoding, not '${encoding}': ${id}`);
+		}
+		let filename = basename(id) + (id.endsWith(extension) ? '' : extension);
+		const dir = `${filerDir.dir}/${dirname(id)}/`; // TODO the slash is currently needed because paths.sourceId and the rest have a trailing slash, but this may cause other problems
+		const dirBasePath = stripStart(dir, filerDir.dir + '/'); // TODO see above comment about `+ '/'`
+		return {
+			type: 'source',
+			sourceType: 'externals',
+			buildable: true,
+			buildConfigs: [],
+			id,
+			filename,
+			dir,
+			dirBasePath,
+			extension,
+			encoding,
+			contents: contents as string,
+			contentsBuffer,
+			contentsHash,
+			filerDir,
+			compiledFiles,
+			stats: undefined,
+			mimeType: undefined,
+		};
+	}
+	const filename = basename(id);
+	const dir = dirname(id) + '/'; // TODO the slash is currently needed because paths.sourceId and the rest have a trailing slash, but this may cause other problems
+	const dirBasePath = stripStart(dir, filerDir.dir + '/'); // TODO see above comment about `+ '/'`
+	switch (encoding) {
+		case 'utf8':
+			return filerDir.buildable
+				? {
+						type: 'source',
+						sourceType: 'text',
+						buildConfigs: [],
+						buildable: true,
+						id,
+						filename,
+						dir,
+						dirBasePath,
+						extension,
+						encoding,
+						contents: contents as string,
+						contentsBuffer,
+						contentsHash,
+						filerDir,
+						compiledFiles,
+						stats: undefined,
+						mimeType: undefined,
+				  }
+				: {
+						type: 'source',
+						sourceType: 'text',
+						buildConfigs: null,
+						buildable: false,
+						id,
+						filename,
+						dir,
+						dirBasePath,
+						extension,
+						encoding,
+						contents: contents as string,
+						contentsBuffer,
+						contentsHash,
+						filerDir,
+						compiledFiles: null,
+						stats: undefined,
+						mimeType: undefined,
+				  };
+		case null:
+			return filerDir.buildable
+				? {
+						type: 'source',
+						sourceType: 'binary',
+						buildConfigs: [],
+						buildable: true,
+						id,
+						filename,
+						dir,
+						dirBasePath,
+						extension,
+						encoding,
+						contents: contents as Buffer,
+						contentsBuffer: contentsBuffer as Buffer,
+						contentsHash,
+						filerDir,
+						compiledFiles,
+						stats: undefined,
+						mimeType: undefined,
+				  }
+				: {
+						type: 'source',
+						sourceType: 'binary',
+						buildConfigs: null,
+						buildable: false,
+						id,
+						filename,
+						dir,
+						dirBasePath,
+						extension,
+						encoding,
+						contents: contents as Buffer,
+						contentsBuffer: contentsBuffer as Buffer,
+						contentsHash,
+						filerDir,
+						compiledFiles: null,
+						stats: undefined,
+						mimeType: undefined,
+				  };
+		default:
+			throw new UnreachableError(encoding);
+	}
+};

--- a/src/build/sourceFile.ts
+++ b/src/build/sourceFile.ts
@@ -56,6 +56,7 @@ export interface BaseBuildableFile {
 	buildFiles: readonly BuildFile[];
 	readonly buildConfigs: Set<BuildConfig>;
 	readonly isInputToBuildConfigs: null | Set<BuildConfig>;
+	readonly dependents: Map<BuildConfig, Set<BuildableSourceFile>>; // `dependents` are other buildable source files that import or otherwise depend on this one
 }
 export interface NonBuildableTextSourceFile extends TextSourceFile, BaseNonBuildableFile {}
 export interface NonBuildableBinarySourceFile extends BinarySourceFile, BaseNonBuildableFile {}
@@ -65,6 +66,7 @@ export interface BaseNonBuildableFile {
 	readonly buildFiles: null;
 	readonly buildConfigs: null;
 	readonly isInputToBuildConfigs: null;
+	readonly dependents: null;
 }
 
 export const createSourceFile = async (
@@ -103,6 +105,7 @@ export const createSourceFile = async (
 			buildable: true,
 			buildConfigs: new Set(),
 			isInputToBuildConfigs: null,
+			dependents: new Map(),
 			id,
 			filename,
 			dir,
@@ -129,6 +132,7 @@ export const createSourceFile = async (
 						sourceType: 'text',
 						buildConfigs: new Set(),
 						isInputToBuildConfigs: null,
+						dependents: new Map(),
 						buildable: true,
 						id,
 						filename,
@@ -149,6 +153,7 @@ export const createSourceFile = async (
 						sourceType: 'text',
 						buildConfigs: null,
 						isInputToBuildConfigs: null,
+						dependents: null,
 						buildable: false,
 						id,
 						filename,
@@ -171,6 +176,7 @@ export const createSourceFile = async (
 						sourceType: 'binary',
 						buildConfigs: new Set(),
 						isInputToBuildConfigs: null,
+						dependents: new Map(),
 						buildable: true,
 						id,
 						filename,
@@ -191,6 +197,7 @@ export const createSourceFile = async (
 						sourceType: 'binary',
 						buildConfigs: null,
 						isInputToBuildConfigs: null,
+						dependents: null,
 						buildable: false,
 						id,
 						filename,

--- a/src/build/sourceFile.ts
+++ b/src/build/sourceFile.ts
@@ -37,45 +37,35 @@ export interface ExternalsSourceFile extends BaseSourceFile {
 	readonly encoding: 'utf8';
 	contents: string;
 }
-interface BaseSourceFile extends BaseFilerFile {
+export interface BaseSourceFile extends BaseFilerFile {
 	readonly type: 'source';
 	readonly dirBasePath: string; // TODO is this the best design? if so should it also go on the `BaseFilerFile`? what about `basePath` too?
 }
-export interface BuildableTextSourceFile extends TextSourceFile {
+export interface BaseBuildableFile {
 	readonly buildable: true;
-	readonly filerDir: BuildableInternalsFilerDir;
+	readonly filerDir: FilerDir;
 	buildFiles: readonly BuildFile[];
 	readonly buildConfigs: Set<BuildConfig>;
 	readonly isInputToBuildConfigs: null | Set<BuildConfig>;
 }
-export interface BuildableBinarySourceFile extends BinarySourceFile {
-	readonly buildable: true;
+export interface BuildableTextSourceFile extends BaseBuildableFile, TextSourceFile {
 	readonly filerDir: BuildableInternalsFilerDir;
-	buildFiles: readonly BuildFile[];
-	readonly buildConfigs: Set<BuildConfig>;
-	readonly isInputToBuildConfigs: null | Set<BuildConfig>;
 }
-export interface BuildableExternalsSourceFile extends ExternalsSourceFile {
-	readonly buildable: true;
+export interface BuildableBinarySourceFile extends BaseBuildableFile, BinarySourceFile {
+	readonly filerDir: BuildableInternalsFilerDir;
+}
+export interface BuildableExternalsSourceFile extends BaseBuildableFile, ExternalsSourceFile {
 	readonly filerDir: ExternalsFilerDir;
-	buildFiles: readonly BuildFile[];
-	readonly buildConfigs: Set<BuildConfig>;
-	readonly isInputToBuildConfigs: null | Set<BuildConfig>;
 }
-export interface NonBuildableTextSourceFile extends TextSourceFile {
+export interface BaseNonBuildableFile {
 	readonly buildable: false;
 	readonly filerDir: NonBuildableInternalsFilerDir;
 	readonly buildFiles: null;
 	readonly buildConfigs: null;
 	readonly isInputToBuildConfigs: null;
 }
-export interface NonBuildableBinarySourceFile extends BinarySourceFile {
-	readonly buildable: false;
-	readonly filerDir: NonBuildableInternalsFilerDir;
-	readonly buildFiles: null;
-	readonly buildConfigs: null;
-	readonly isInputToBuildConfigs: null;
-}
+export interface NonBuildableTextSourceFile extends BaseNonBuildableFile, TextSourceFile {}
+export interface NonBuildableBinarySourceFile extends BaseNonBuildableFile, BinarySourceFile {}
 
 export const createSourceFile = async (
 	id: string,

--- a/src/build/sourceFile.ts
+++ b/src/build/sourceFile.ts
@@ -41,6 +41,15 @@ export interface BaseSourceFile extends BaseFilerFile {
 	readonly type: 'source';
 	readonly dirBasePath: string; // TODO is this the best design? if so should it also go on the `BaseFilerFile`? what about `basePath` too?
 }
+export interface BuildableTextSourceFile extends TextSourceFile, BaseBuildableFile {
+	readonly filerDir: BuildableInternalsFilerDir;
+}
+export interface BuildableBinarySourceFile extends BinarySourceFile, BaseBuildableFile {
+	readonly filerDir: BuildableInternalsFilerDir;
+}
+export interface BuildableExternalsSourceFile extends ExternalsSourceFile, BaseBuildableFile {
+	readonly filerDir: ExternalsFilerDir;
+}
 export interface BaseBuildableFile {
 	readonly buildable: true;
 	readonly filerDir: FilerDir;
@@ -48,15 +57,8 @@ export interface BaseBuildableFile {
 	readonly buildConfigs: Set<BuildConfig>;
 	readonly isInputToBuildConfigs: null | Set<BuildConfig>;
 }
-export interface BuildableTextSourceFile extends BaseBuildableFile, TextSourceFile {
-	readonly filerDir: BuildableInternalsFilerDir;
-}
-export interface BuildableBinarySourceFile extends BaseBuildableFile, BinarySourceFile {
-	readonly filerDir: BuildableInternalsFilerDir;
-}
-export interface BuildableExternalsSourceFile extends BaseBuildableFile, ExternalsSourceFile {
-	readonly filerDir: ExternalsFilerDir;
-}
+export interface NonBuildableTextSourceFile extends TextSourceFile, BaseNonBuildableFile {}
+export interface NonBuildableBinarySourceFile extends BinarySourceFile, BaseNonBuildableFile {}
 export interface BaseNonBuildableFile {
 	readonly buildable: false;
 	readonly filerDir: NonBuildableInternalsFilerDir;
@@ -64,8 +66,6 @@ export interface BaseNonBuildableFile {
 	readonly buildConfigs: null;
 	readonly isInputToBuildConfigs: null;
 }
-export interface NonBuildableTextSourceFile extends BaseNonBuildableFile, TextSourceFile {}
-export interface NonBuildableBinarySourceFile extends BaseNonBuildableFile, BinarySourceFile {}
 
 export const createSourceFile = async (
 	id: string,

--- a/src/build/sourceFile.ts
+++ b/src/build/sourceFile.ts
@@ -7,7 +7,8 @@ import {
 	FilerDir,
 } from '../build/FilerDir.js';
 import {BuildFile, reconstructBuildFiles} from './buildFile.js';
-import {BaseFilerFile, toHash} from './baseFilerFile.js';
+import {BaseFilerFile} from './baseFilerFile.js';
+import {toHash} from './utils.js';
 import {BuildConfig} from '../config/buildConfig.js';
 import {Encoding} from '../fs/encoding.js';
 import {CachedSourceInfo} from './Filer.js';

--- a/src/build/sourceFile.ts
+++ b/src/build/sourceFile.ts
@@ -23,18 +23,18 @@ export type NonBuildableSourceFile = NonBuildableTextSourceFile | NonBuildableBi
 export interface TextSourceFile extends BaseSourceFile {
 	readonly sourceType: 'text';
 	readonly encoding: 'utf8';
-	readonly contents: string;
+	contents: string;
 }
 export interface BinarySourceFile extends BaseSourceFile {
 	readonly sourceType: 'binary';
 	readonly encoding: null;
-	readonly contents: Buffer;
-	readonly contentsBuffer: Buffer;
+	contents: Buffer;
+	contentsBuffer: Buffer;
 }
 export interface ExternalsSourceFile extends BaseSourceFile {
 	readonly sourceType: 'externals';
 	readonly encoding: 'utf8';
-	readonly contents: string;
+	contents: string;
 }
 interface BaseSourceFile extends BaseFilerFile {
 	readonly type: 'source';
@@ -43,31 +43,31 @@ interface BaseSourceFile extends BaseFilerFile {
 export interface BuildableTextSourceFile extends TextSourceFile {
 	readonly buildable: true;
 	readonly filerDir: BuildableInternalsFilerDir;
-	readonly compiledFiles: BuildFile[];
+	buildFiles: readonly BuildFile[];
 	readonly buildConfigs: BuildConfig[];
 }
 export interface BuildableBinarySourceFile extends BinarySourceFile {
 	readonly buildable: true;
 	readonly filerDir: BuildableInternalsFilerDir;
-	readonly compiledFiles: BuildFile[];
+	buildFiles: readonly BuildFile[];
 	readonly buildConfigs: BuildConfig[];
 }
 export interface BuildableExternalsSourceFile extends ExternalsSourceFile {
 	readonly buildable: true;
 	readonly filerDir: ExternalsFilerDir;
-	readonly compiledFiles: BuildFile[];
+	buildFiles: readonly BuildFile[];
 	readonly buildConfigs: BuildConfig[];
 }
 export interface NonBuildableTextSourceFile extends TextSourceFile {
 	readonly buildable: false;
 	readonly filerDir: NonBuildableInternalsFilerDir;
-	readonly compiledFiles: null;
+	readonly buildFiles: null;
 	readonly buildConfigs: null;
 }
 export interface NonBuildableBinarySourceFile extends BinarySourceFile {
 	readonly buildable: false;
 	readonly filerDir: NonBuildableInternalsFilerDir;
-	readonly compiledFiles: null;
+	readonly buildFiles: null;
 	readonly buildConfigs: null;
 }
 
@@ -78,10 +78,11 @@ export const createSourceFile = async (
 	contents: string | Buffer,
 	filerDir: FilerDir,
 	cachedSourceInfo: CachedSourceInfo | undefined,
+	buildConfigs: BuildConfig[] | null,
 ): Promise<SourceFile> => {
 	let contentsBuffer: Buffer | undefined = encoding === null ? (contents as Buffer) : undefined;
 	let contentsHash: string | undefined = undefined;
-	let compiledFiles: BuildFile[] = [];
+	let buildFiles: BuildFile[] = [];
 	if (filerDir.buildable && cachedSourceInfo !== undefined) {
 		if (encoding === 'utf8') {
 			contentsBuffer = Buffer.from(contents);
@@ -90,7 +91,7 @@ export const createSourceFile = async (
 		}
 		contentsHash = toHash(contentsBuffer!);
 		if (contentsHash === cachedSourceInfo.contentsHash) {
-			compiledFiles = await reconstructBuildFiles(cachedSourceInfo);
+			buildFiles = await reconstructBuildFiles(cachedSourceInfo, buildConfigs!);
 		}
 	}
 	if (filerDir.type === 'externals') {
@@ -115,7 +116,7 @@ export const createSourceFile = async (
 			contentsBuffer,
 			contentsHash,
 			filerDir,
-			compiledFiles,
+			buildFiles,
 			stats: undefined,
 			mimeType: undefined,
 		};
@@ -141,7 +142,7 @@ export const createSourceFile = async (
 						contentsBuffer,
 						contentsHash,
 						filerDir,
-						compiledFiles,
+						buildFiles: buildFiles,
 						stats: undefined,
 						mimeType: undefined,
 				  }
@@ -160,7 +161,7 @@ export const createSourceFile = async (
 						contentsBuffer,
 						contentsHash,
 						filerDir,
-						compiledFiles: null,
+						buildFiles: null,
 						stats: undefined,
 						mimeType: undefined,
 				  };
@@ -181,7 +182,7 @@ export const createSourceFile = async (
 						contentsBuffer: contentsBuffer as Buffer,
 						contentsHash,
 						filerDir,
-						compiledFiles,
+						buildFiles,
 						stats: undefined,
 						mimeType: undefined,
 				  }
@@ -200,7 +201,7 @@ export const createSourceFile = async (
 						contentsBuffer: contentsBuffer as Buffer,
 						contentsHash,
 						filerDir,
-						compiledFiles: null,
+						buildFiles: null,
 						stats: undefined,
 						mimeType: undefined,
 				  };

--- a/src/build/sourceFile.ts
+++ b/src/build/sourceFile.ts
@@ -45,31 +45,36 @@ export interface BuildableTextSourceFile extends TextSourceFile {
 	readonly buildable: true;
 	readonly filerDir: BuildableInternalsFilerDir;
 	buildFiles: readonly BuildFile[];
-	readonly buildConfigs: BuildConfig[];
+	readonly buildConfigs: Set<BuildConfig>;
+	readonly isInputToBuildConfigs: null | Set<BuildConfig>;
 }
 export interface BuildableBinarySourceFile extends BinarySourceFile {
 	readonly buildable: true;
 	readonly filerDir: BuildableInternalsFilerDir;
 	buildFiles: readonly BuildFile[];
-	readonly buildConfigs: BuildConfig[];
+	readonly buildConfigs: Set<BuildConfig>;
+	readonly isInputToBuildConfigs: null | Set<BuildConfig>;
 }
 export interface BuildableExternalsSourceFile extends ExternalsSourceFile {
 	readonly buildable: true;
 	readonly filerDir: ExternalsFilerDir;
 	buildFiles: readonly BuildFile[];
-	readonly buildConfigs: BuildConfig[];
+	readonly buildConfigs: Set<BuildConfig>;
+	readonly isInputToBuildConfigs: null | Set<BuildConfig>;
 }
 export interface NonBuildableTextSourceFile extends TextSourceFile {
 	readonly buildable: false;
 	readonly filerDir: NonBuildableInternalsFilerDir;
 	readonly buildFiles: null;
 	readonly buildConfigs: null;
+	readonly isInputToBuildConfigs: null;
 }
 export interface NonBuildableBinarySourceFile extends BinarySourceFile {
 	readonly buildable: false;
 	readonly filerDir: NonBuildableInternalsFilerDir;
 	readonly buildFiles: null;
 	readonly buildConfigs: null;
+	readonly isInputToBuildConfigs: null;
 }
 
 export const createSourceFile = async (
@@ -106,7 +111,8 @@ export const createSourceFile = async (
 			type: 'source',
 			sourceType: 'externals',
 			buildable: true,
-			buildConfigs: [],
+			buildConfigs: new Set(),
+			isInputToBuildConfigs: null,
 			id,
 			filename,
 			dir,
@@ -131,7 +137,8 @@ export const createSourceFile = async (
 				? {
 						type: 'source',
 						sourceType: 'text',
-						buildConfigs: [],
+						buildConfigs: new Set(),
+						isInputToBuildConfigs: null,
 						buildable: true,
 						id,
 						filename,
@@ -143,7 +150,7 @@ export const createSourceFile = async (
 						contentsBuffer,
 						contentsHash,
 						filerDir,
-						buildFiles: buildFiles,
+						buildFiles,
 						stats: undefined,
 						mimeType: undefined,
 				  }
@@ -151,6 +158,7 @@ export const createSourceFile = async (
 						type: 'source',
 						sourceType: 'text',
 						buildConfigs: null,
+						isInputToBuildConfigs: null,
 						buildable: false,
 						id,
 						filename,
@@ -171,7 +179,8 @@ export const createSourceFile = async (
 				? {
 						type: 'source',
 						sourceType: 'binary',
-						buildConfigs: [],
+						buildConfigs: new Set(),
+						isInputToBuildConfigs: null,
 						buildable: true,
 						id,
 						filename,
@@ -191,6 +200,7 @@ export const createSourceFile = async (
 						type: 'source',
 						sourceType: 'binary',
 						buildConfigs: null,
+						isInputToBuildConfigs: null,
 						buildable: false,
 						id,
 						filename,

--- a/src/build/utils.test.ts
+++ b/src/build/utils.test.ts
@@ -1,0 +1,42 @@
+import {resolve, join} from 'path';
+
+import {test, t} from '../oki/oki.js';
+import {paths} from '../paths.js';
+import {toHash, createDirectoryFilter} from './utils.js';
+
+test('toHash()', () => {
+	t.is(typeof toHash(Buffer.from('hey')), 'string');
+	t.is(toHash(Buffer.from('hey')), toHash(Buffer.from('hey')));
+});
+
+test('createDirectoryFilter()', () => {
+	const rootDir = resolve('bar');
+	test('relative source path', () => {
+		const filter = createDirectoryFilter('foo');
+		t.ok(filter(join(paths.source, 'foo')));
+		t.ok(filter(join(paths.source, 'foo/')));
+		t.ok(!filter(join(paths.source, 'fo')));
+		t.ok(!filter(join(paths.source, 'fo/')));
+	});
+	test('absolute source path', () => {
+		const filter = createDirectoryFilter(join(paths.source, 'foo'));
+		t.ok(filter(join(paths.source, 'foo')));
+		t.ok(filter(join(paths.source, 'foo/')));
+		t.ok(!filter(join(paths.source, 'fo')));
+		t.ok(!filter(join(paths.source, 'fo/')));
+	});
+	test('relative path with custom root', () => {
+		const filter = createDirectoryFilter('foo', rootDir);
+		t.ok(filter(join(rootDir, 'foo')));
+		t.ok(filter(join(rootDir, 'foo/')));
+		t.ok(!filter(join(rootDir, 'fo')));
+		t.ok(!filter(join(rootDir, 'fo/')));
+	});
+	test('absolute path with custom root', () => {
+		const filter = createDirectoryFilter(join(rootDir, 'foo'), rootDir);
+		t.ok(filter(join(rootDir, 'foo')));
+		t.ok(filter(join(rootDir, 'foo/')));
+		t.ok(!filter(join(rootDir, 'fo')));
+		t.ok(!filter(join(rootDir, 'fo/')));
+	});
+});

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -8,11 +8,14 @@ import {paths} from '../paths.js';
 export const toHash = (buf: Buffer): string =>
 	createHash('md5').update(buf).digest().toString('hex');
 
-export const createDirectoryFilter = (
-	dir: string,
-	rootDir = paths.source,
-): ((id: string) => boolean) => {
+interface FilterDirectory {
+	(id: string): boolean;
+}
+
+export const createDirectoryFilter = (dir: string, rootDir = paths.source): FilterDirectory => {
 	dir = resolve(rootDir, dir);
 	const dirWithTrailingSlash = dir + '/';
-	return (id) => id === dir || id.startsWith(dirWithTrailingSlash);
+	const filterDirectory: FilterDirectory = (id) =>
+		id === dir || id.startsWith(dirWithTrailingSlash);
+	return filterDirectory;
 };

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -1,0 +1,6 @@
+import {createHash} from 'crypto';
+
+// Note that this uses md5 and therefore is not cryptographically secure.
+// It's fine for now, but some use cases may need security.
+export const toHash = (buf: Buffer): string =>
+	createHash('md5').update(buf).digest().toString('hex');

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -1,6 +1,18 @@
 import {createHash} from 'crypto';
+import {resolve} from 'path';
+
+import {paths} from '../paths.js';
 
 // Note that this uses md5 and therefore is not cryptographically secure.
 // It's fine for now, but some use cases may need security.
 export const toHash = (buf: Buffer): string =>
 	createHash('md5').update(buf).digest().toString('hex');
+
+export const createDirectoryFilter = (
+	dir: string,
+	rootDir = paths.source,
+): ((id: string) => boolean) => {
+	dir = resolve(rootDir, dir);
+	const dirWithTrailingSlash = dir + '/';
+	return (id) => id === dir || id.startsWith(dirWithTrailingSlash);
+};

--- a/src/compile/compiler.ts
+++ b/src/compile/compiler.ts
@@ -7,17 +7,17 @@ import {ServedDir} from '../build/ServedDir.js';
 
 export interface Compiler<
 	TSource extends CompilationSource = CompilationSource,
-	TResult extends Compilation = Compilation
+	TCompilation extends Compilation = Compilation
 > {
 	compile(
 		source: TSource,
 		buildConfig: BuildConfig,
 		options: CompileOptions,
-	): CompileResult<TResult> | Promise<CompileResult<TResult>>;
+	): CompileResult<TCompilation> | Promise<CompileResult<TCompilation>>;
 }
 
-export interface CompileResult<T extends Compilation = Compilation> {
-	compilations: T[];
+export interface CompileResult<TCompilation extends Compilation = Compilation> {
+	compilations: TCompilation[];
 }
 export interface CompileOptions {
 	readonly sourceMap: boolean;

--- a/src/compile/svelteCompiler.ts
+++ b/src/compile/svelteCompiler.ts
@@ -107,7 +107,7 @@ export const createSvelteCompiler = (opts: InitialOptions = {}): SvelteCompiler 
 		if (onstats) onstats(id, stats, handleStats, log);
 
 		const jsFilename = `${source.filename}${JS_EXTENSION}`;
-		const cssFilename = `${jsFilename}${CSS_EXTENSION}`;
+		const cssFilename = `${source.filename}${CSS_EXTENSION}`;
 		const jsId = `${outDir}${jsFilename}`;
 		const cssId = `${outDir}${cssFilename}`;
 		const hasJsSourceMap = sourceMap && js.map !== undefined;

--- a/src/compile/svelteCompiler.ts
+++ b/src/compile/svelteCompiler.ts
@@ -14,7 +14,7 @@ import {Logger, SystemLogger} from '../utils/log.js';
 import {
 	CSS_EXTENSION,
 	JS_EXTENSION,
-	SOURCE_MAP_EXTENSION,
+	SOURCEMAP_EXTENSION,
 	SVELTE_EXTENSION,
 	toBuildOutPath,
 } from '../paths.js';
@@ -121,7 +121,7 @@ export const createSvelteCompiler = (opts: InitialOptions = {}): SvelteCompiler 
 				extension: JS_EXTENSION,
 				encoding,
 				contents: hasJsSourceMap
-					? addJsSourceMapFooter(js.code, jsFilename + SOURCE_MAP_EXTENSION)
+					? addJsSourceMapFooter(js.code, jsFilename + SOURCEMAP_EXTENSION)
 					: js.code,
 				sourceMapOf: null,
 				buildConfig,
@@ -129,10 +129,10 @@ export const createSvelteCompiler = (opts: InitialOptions = {}): SvelteCompiler 
 		];
 		if (hasJsSourceMap) {
 			compilations.push({
-				id: jsId + SOURCE_MAP_EXTENSION,
-				filename: jsFilename + SOURCE_MAP_EXTENSION,
+				id: jsId + SOURCEMAP_EXTENSION,
+				filename: jsFilename + SOURCEMAP_EXTENSION,
 				dir: outDir,
-				extension: SOURCE_MAP_EXTENSION,
+				extension: SOURCEMAP_EXTENSION,
 				encoding,
 				contents: JSON.stringify(js.map), // TODO do we want to also store the object version?
 				sourceMapOf: jsId,
@@ -147,17 +147,17 @@ export const createSvelteCompiler = (opts: InitialOptions = {}): SvelteCompiler 
 				extension: CSS_EXTENSION,
 				encoding,
 				contents: hasCssSourceMap
-					? addCssSourceMapFooter(css.code, cssFilename + SOURCE_MAP_EXTENSION)
+					? addCssSourceMapFooter(css.code, cssFilename + SOURCEMAP_EXTENSION)
 					: css.code,
 				sourceMapOf: null,
 				buildConfig,
 			});
 			if (hasCssSourceMap) {
 				compilations.push({
-					id: cssId + SOURCE_MAP_EXTENSION,
-					filename: cssFilename + SOURCE_MAP_EXTENSION,
+					id: cssId + SOURCEMAP_EXTENSION,
+					filename: cssFilename + SOURCEMAP_EXTENSION,
 					dir: outDir,
-					extension: SOURCE_MAP_EXTENSION,
+					extension: SOURCEMAP_EXTENSION,
 					encoding,
 					contents: JSON.stringify(css.map), // TODO do we want to also store the object version?
 					sourceMapOf: cssId,

--- a/src/compile/svelteCompiler.ts
+++ b/src/compile/svelteCompiler.ts
@@ -77,9 +77,6 @@ export const createSvelteCompiler = (opts: InitialOptions = {}): SvelteCompiler 
 		if (source.extension !== SVELTE_EXTENSION) {
 			throw Error(`svelte only handles ${SVELTE_EXTENSION} files, not ${source.extension}`);
 		}
-		if (buildConfig.platform !== 'browser') {
-			return {compilations: []}; // TODO support SSR! and make this configurable
-		}
 		const {id, encoding, contents} = source;
 		const outDir = toBuildOutPath(dev, buildConfig.name, source.dirBasePath, buildRootDir);
 		let preprocessedCode: string;

--- a/src/compile/svelteCompiler.ts
+++ b/src/compile/svelteCompiler.ts
@@ -19,7 +19,6 @@ import {
 	toBuildOutPath,
 } from '../paths.js';
 import {sveltePreprocessSwc} from '../project/svelte-preprocess-swc.js';
-import {replaceExtension} from '../utils/path.js';
 import {omitUndefined} from '../utils/object.js';
 import {Compiler, TextCompilation, TextCompilationSource} from './compiler.js';
 import {BuildConfig} from '../config/buildConfig.js';
@@ -110,10 +109,10 @@ export const createSvelteCompiler = (opts: InitialOptions = {}): SvelteCompiler 
 		}
 		if (onstats) onstats(id, stats, handleStats, log);
 
-		const jsFilename = replaceExtension(source.filename, JS_EXTENSION);
-		const cssFilename = replaceExtension(jsFilename, CSS_EXTENSION);
+		const jsFilename = `${source.filename}${JS_EXTENSION}`;
+		const cssFilename = `${jsFilename}${CSS_EXTENSION}`;
 		const jsId = `${outDir}${jsFilename}`;
-		const cssId = replaceExtension(jsId, CSS_EXTENSION);
+		const cssId = `${outDir}${cssFilename}`;
 		const hasJsSourceMap = sourceMap && js.map !== undefined;
 		const hasCssSourceMap = sourceMap && css.map !== undefined;
 

--- a/src/compile/swcCompiler.ts
+++ b/src/compile/swcCompiler.ts
@@ -4,7 +4,7 @@ import {relative} from 'path';
 import {EcmaScriptTarget} from './tsHelpers.js';
 import {getDefaultSwcOptions} from './swcHelpers.js';
 import {Logger, SystemLogger} from '../utils/log.js';
-import {JS_EXTENSION, SOURCE_MAP_EXTENSION, toBuildOutPath, TS_EXTENSION} from '../paths.js';
+import {JS_EXTENSION, SOURCEMAP_EXTENSION, toBuildOutPath, TS_EXTENSION} from '../paths.js';
 import {omitUndefined} from '../utils/object.js';
 import {Compiler, TextCompilation, TextCompilationSource} from './compiler.js';
 import {replaceExtension} from '../utils/path.js';
@@ -66,7 +66,7 @@ export const createSwcCompiler = (opts: InitialOptions = {}): SwcCompiler => {
 				extension: JS_EXTENSION,
 				encoding,
 				contents: output.map
-					? addJsSourceMapFooter(output.code, jsFilename + SOURCE_MAP_EXTENSION)
+					? addJsSourceMapFooter(output.code, jsFilename + SOURCEMAP_EXTENSION)
 					: output.code,
 				sourceMapOf: null,
 				buildConfig,
@@ -74,10 +74,10 @@ export const createSwcCompiler = (opts: InitialOptions = {}): SwcCompiler => {
 		];
 		if (output.map) {
 			compilations.push({
-				id: jsId + SOURCE_MAP_EXTENSION,
-				filename: jsFilename + SOURCE_MAP_EXTENSION,
+				id: jsId + SOURCEMAP_EXTENSION,
+				filename: jsFilename + SOURCEMAP_EXTENSION,
 				dir: outDir,
-				extension: SOURCE_MAP_EXTENSION,
+				extension: SOURCEMAP_EXTENSION,
 				encoding,
 				contents: output.map,
 				sourceMapOf: jsId,

--- a/src/config/buildConfig.test.ts
+++ b/src/config/buildConfig.test.ts
@@ -9,9 +9,7 @@ const input = [paths.source.substring(0, paths.source.length - 1)]; // TODO fix 
 test('normalizeBuildConfigs()', async () => {
 	test('normalizes a plain config', () => {
 		const buildConfig = normalizeBuildConfigs([{name: 'node', platform: 'node', input: '.'}]);
-		t.equal(buildConfig, [
-			{name: 'node', platform: 'node', input, primary: true, dist: true, include: null},
-		]);
+		t.equal(buildConfig, [{name: 'node', platform: 'node', input, primary: true, dist: true}]);
 	});
 
 	test('normalizes inputs', () => {
@@ -27,16 +25,15 @@ test('normalizeBuildConfigs()', async () => {
 			{name: 'node7', platform: 'node', input: [inputPath, inputFilter]},
 		]);
 		t.equal(buildConfig, [
-			{name: 'node', platform: 'node', input, primary: true, dist: true, include: null},
-			{name: 'node2', platform: 'node', input, primary: false, dist: true, include: null},
-			{name: 'node3', platform: 'node', input, primary: false, dist: true, include: null},
+			{name: 'node', platform: 'node', input, primary: true, dist: true},
+			{name: 'node2', platform: 'node', input, primary: false, dist: true},
+			{name: 'node3', platform: 'node', input, primary: false, dist: true},
 			{
 				name: 'node4',
 				platform: 'node',
 				input: [inputPath],
 				primary: false,
 				dist: true,
-				include: null,
 			},
 			{
 				name: 'node5',
@@ -44,7 +41,6 @@ test('normalizeBuildConfigs()', async () => {
 				input: [inputPath],
 				primary: false,
 				dist: true,
-				include: null,
 			},
 			{
 				name: 'node6',
@@ -52,7 +48,6 @@ test('normalizeBuildConfigs()', async () => {
 				input: [inputFilter],
 				primary: false,
 				dist: true,
-				include: null,
 			},
 			{
 				name: 'node7',
@@ -60,7 +55,6 @@ test('normalizeBuildConfigs()', async () => {
 				input: [inputPath, inputFilter],
 				primary: false,
 				dist: true,
-				include: null,
 			},
 		]);
 	});
@@ -72,9 +66,9 @@ test('normalizeBuildConfigs()', async () => {
 			{name: 'node3', platform: 'node', input, primary: true},
 		]);
 		t.equal(buildConfig, [
-			{name: 'node1', platform: 'node', input, primary: false, dist: false, include: null},
-			{name: 'node2', platform: 'node', input, primary: false, dist: true, include: null},
-			{name: 'node3', platform: 'node', input, primary: true, dist: false, include: null},
+			{name: 'node1', platform: 'node', input, primary: false, dist: false},
+			{name: 'node2', platform: 'node', input, primary: false, dist: true},
+			{name: 'node3', platform: 'node', input, primary: true, dist: false},
 		]);
 	});
 
@@ -87,11 +81,11 @@ test('normalizeBuildConfigs()', async () => {
 			{name: 'browser3', platform: 'browser', input, primary: false},
 		]);
 		t.equal(buildConfig, [
-			{name: 'node1', platform: 'node', input, primary: true, dist: true, include: null},
-			{name: 'node2', platform: 'node', input, primary: false, dist: false, include: null},
-			{name: 'browser1', platform: 'browser', input, primary: true, dist: false, include: null},
-			{name: 'browser2', platform: 'browser', input, primary: false, dist: false, include: null},
-			{name: 'browser3', platform: 'browser', input, primary: false, dist: false, include: null},
+			{name: 'node1', platform: 'node', input, primary: true, dist: true},
+			{name: 'node2', platform: 'node', input, primary: false, dist: false},
+			{name: 'browser1', platform: 'browser', input, primary: true, dist: false},
+			{name: 'browser2', platform: 'browser', input, primary: false, dist: false},
+			{name: 'browser3', platform: 'browser', input, primary: false, dist: false},
 		]);
 	});
 
@@ -104,11 +98,11 @@ test('normalizeBuildConfigs()', async () => {
 			{name: 'browser2', platform: 'browser', input},
 		]);
 		t.equal(buildConfig, [
-			{name: 'node1', platform: 'node', input, primary: true, dist: true, include: null},
-			{name: 'node2', platform: 'node', input, primary: false, dist: true, include: null},
-			{name: 'node3', platform: 'node', input, primary: false, dist: true, include: null},
-			{name: 'browser1', platform: 'browser', input, primary: true, dist: true, include: null},
-			{name: 'browser2', platform: 'browser', input, primary: false, dist: true, include: null},
+			{name: 'node1', platform: 'node', input, primary: true, dist: true},
+			{name: 'node2', platform: 'node', input, primary: false, dist: true},
+			{name: 'node3', platform: 'node', input, primary: false, dist: true},
+			{name: 'browser1', platform: 'browser', input, primary: true, dist: true},
+			{name: 'browser2', platform: 'browser', input, primary: false, dist: true},
 		]);
 	});
 

--- a/src/config/buildConfig.test.ts
+++ b/src/config/buildConfig.test.ts
@@ -1,82 +1,128 @@
+import {join} from 'path';
+
 import {test, t} from '../oki/oki.js';
 import {normalizeBuildConfigs, validateBuildConfigs} from './buildConfig.js';
+import {paths} from '../paths.js';
+
+const input = [paths.source.substring(0, paths.source.length - 1)]; // TODO fix when trailing slash is removed
 
 test('normalizeBuildConfigs()', async () => {
 	test('normalizes undefined to a default config', () => {
 		const buildConfig = normalizeBuildConfigs(undefined);
 		t.equal(buildConfig, [
-			{name: 'node', platform: 'node', primary: true, dist: true, include: null},
+			{name: 'node', platform: 'node', input, primary: true, dist: true, include: null},
 		]);
 	});
 
 	test('normalizes an empty array to a default config', () => {
 		const buildConfig = normalizeBuildConfigs([]);
 		t.equal(buildConfig, [
-			{name: 'node', platform: 'node', primary: true, dist: true, include: null},
+			{name: 'node', platform: 'node', input, primary: true, dist: true, include: null},
 		]);
 	});
 
 	test('normalizes a plain config', () => {
-		const buildConfig = normalizeBuildConfigs([{name: 'node', platform: 'node'}]);
+		const buildConfig = normalizeBuildConfigs([{name: 'node', platform: 'node', input: '.'}]);
 		t.equal(buildConfig, [
-			{name: 'node', platform: 'node', primary: true, dist: true, include: null},
+			{name: 'node', platform: 'node', input, primary: true, dist: true, include: null},
+		]);
+	});
+
+	test('normalizes inputs', () => {
+		const fooInput = join(paths.source, 'foo');
+		const buildConfig = normalizeBuildConfigs([
+			{name: 'node', platform: 'node', input: '.'},
+			{name: 'node2', platform: 'node', input: paths.source},
+			{name: 'node3', platform: 'node', input},
+			{name: 'node4', platform: 'node', input: 'foo'},
+			{name: 'node5', platform: 'node', input: fooInput},
+			{name: 'node6', platform: 'node', input: [fooInput]},
+		]);
+		t.equal(buildConfig, [
+			{name: 'node', platform: 'node', input, primary: true, dist: true, include: null},
+			{name: 'node2', platform: 'node', input, primary: false, dist: true, include: null},
+			{name: 'node3', platform: 'node', input, primary: false, dist: true, include: null},
+			{
+				name: 'node4',
+				platform: 'node',
+				input: [fooInput],
+				primary: false,
+				dist: true,
+				include: null,
+			},
+			{
+				name: 'node5',
+				platform: 'node',
+				input: [fooInput],
+				primary: false,
+				dist: true,
+				include: null,
+			},
+			{
+				name: 'node6',
+				platform: 'node',
+				input: [fooInput],
+				primary: false,
+				dist: true,
+				include: null,
+			},
 		]);
 	});
 
 	test('ensures a node config', () => {
 		const buildConfig = normalizeBuildConfigs([
-			{name: 'browser', platform: 'browser', primary: true, dist: true},
+			{name: 'browser', platform: 'browser', input, primary: true, dist: true},
 		]);
 		t.equal(buildConfig, [
-			{name: 'browser', platform: 'browser', primary: true, dist: true, include: null},
-			{name: 'node', platform: 'node', primary: true, dist: false, include: null},
+			{name: 'browser', platform: 'browser', input, primary: true, dist: true, include: null},
+			{name: 'node', platform: 'node', input, primary: true, dist: false, include: null},
 		]);
 	});
 
 	test('declares a single dist', () => {
 		const buildConfig = normalizeBuildConfigs([
-			{name: 'node1', platform: 'node'},
-			{name: 'node2', platform: 'node', dist: true},
-			{name: 'node3', platform: 'node', primary: true},
+			{name: 'node1', platform: 'node', input},
+			{name: 'node2', platform: 'node', input, dist: true},
+			{name: 'node3', platform: 'node', input, primary: true},
 		]);
 		t.equal(buildConfig, [
-			{name: 'node1', platform: 'node', primary: false, dist: false, include: null},
-			{name: 'node2', platform: 'node', primary: false, dist: true, include: null},
-			{name: 'node3', platform: 'node', primary: true, dist: false, include: null},
+			{name: 'node1', platform: 'node', input, primary: false, dist: false, include: null},
+			{name: 'node2', platform: 'node', input, primary: false, dist: true, include: null},
+			{name: 'node3', platform: 'node', input, primary: true, dist: false, include: null},
 		]);
 	});
 
 	test('ensures a primary config for each platform', () => {
 		const buildConfig = normalizeBuildConfigs([
-			{name: 'node1', platform: 'node', primary: false, dist: true},
-			{name: 'node2', platform: 'node', primary: false},
-			{name: 'browser1', platform: 'browser', primary: false},
-			{name: 'browser2', platform: 'browser', primary: false},
-			{name: 'browser3', platform: 'browser', primary: false},
+			{name: 'node1', platform: 'node', input, primary: false, dist: true},
+			{name: 'node2', platform: 'node', input, primary: false},
+			{name: 'browser1', platform: 'browser', input, primary: false},
+			{name: 'browser2', platform: 'browser', input, primary: false},
+			{name: 'browser3', platform: 'browser', input, primary: false},
 		]);
 		t.equal(buildConfig, [
-			{name: 'node1', platform: 'node', primary: true, dist: true, include: null},
-			{name: 'node2', platform: 'node', primary: false, dist: false, include: null},
-			{name: 'browser1', platform: 'browser', primary: true, dist: false, include: null},
-			{name: 'browser2', platform: 'browser', primary: false, dist: false, include: null},
-			{name: 'browser3', platform: 'browser', primary: false, dist: false, include: null},
+			{name: 'node1', platform: 'node', input, primary: true, dist: true, include: null},
+			{name: 'node2', platform: 'node', input, primary: false, dist: false, include: null},
+			{name: 'browser1', platform: 'browser', input, primary: true, dist: false, include: null},
+			{name: 'browser2', platform: 'browser', input, primary: false, dist: false, include: null},
+			{name: 'browser3', platform: 'browser', input, primary: false, dist: false, include: null},
 		]);
 	});
 
 	test('makes all dist when none is', () => {
 		const buildConfig = normalizeBuildConfigs([
-			{name: 'node1', platform: 'node', dist: false},
-			{name: 'node2', platform: 'node', dist: false},
-			{name: 'node3', platform: 'node'},
-			{name: 'browser1', platform: 'browser', dist: false},
-			{name: 'browser2', platform: 'browser'},
+			{name: 'node1', platform: 'node', input, dist: false},
+			{name: 'node2', platform: 'node', input, dist: false},
+			{name: 'node3', platform: 'node', input},
+			{name: 'browser1', platform: 'browser', input, dist: false},
+			{name: 'browser2', platform: 'browser', input},
 		]);
 		t.equal(buildConfig, [
-			{name: 'node1', platform: 'node', primary: true, dist: true, include: null},
-			{name: 'node2', platform: 'node', primary: false, dist: true, include: null},
-			{name: 'node3', platform: 'node', primary: false, dist: true, include: null},
-			{name: 'browser1', platform: 'browser', primary: true, dist: true, include: null},
-			{name: 'browser2', platform: 'browser', primary: false, dist: true, include: null},
+			{name: 'node1', platform: 'node', input, primary: true, dist: true, include: null},
+			{name: 'node2', platform: 'node', input, primary: false, dist: true, include: null},
+			{name: 'node3', platform: 'node', input, primary: false, dist: true, include: null},
+			{name: 'browser1', platform: 'browser', input, primary: true, dist: true, include: null},
+			{name: 'browser2', platform: 'browser', input, primary: false, dist: true, include: null},
 		]);
 	});
 
@@ -86,45 +132,45 @@ test('normalizeBuildConfigs()', async () => {
 });
 
 test('validateBuildConfigs', () => {
-	validateBuildConfigs(normalizeBuildConfigs([{name: 'node', platform: 'node'}]));
+	validateBuildConfigs(normalizeBuildConfigs([{name: 'node', platform: 'node', input}]));
 	validateBuildConfigs(
 		normalizeBuildConfigs([
-			{name: 'node', platform: 'node', dist: true},
-			{name: 'node2', platform: 'node', primary: true},
-			{name: 'browser', platform: 'browser'},
-			{name: 'browser2', platform: 'browser'},
+			{name: 'node', platform: 'node', input, dist: true},
+			{name: 'node2', platform: 'node', input, primary: true},
+			{name: 'browser', platform: 'browser', input},
+			{name: 'browser2', platform: 'browser', input},
 		]),
 	);
 	validateBuildConfigs(
 		normalizeBuildConfigs([
-			{name: 'node', platform: 'node'},
-			{name: 'node2', platform: 'node', primary: true},
-			{name: 'browser', platform: 'browser'},
-			{name: 'browser2', platform: 'browser', primary: true},
+			{name: 'node', platform: 'node', input},
+			{name: 'node2', platform: 'node', input, primary: true},
+			{name: 'browser', platform: 'browser', input},
+			{name: 'browser2', platform: 'browser', input, primary: true},
 		]),
 	);
 
 	test('fails with undefined', () => {
 		t.ok(!validateBuildConfigs(undefined as any).ok);
-		t.ok(!validateBuildConfigs({name: 'node', platform: 'node'} as any).ok);
+		t.ok(!validateBuildConfigs({name: 'node', platform: 'node', input} as any).ok);
 	});
 
 	test('fails with an invalid name', () => {
-		t.ok(!validateBuildConfigs(normalizeBuildConfigs([{platform: 'node'} as any])).ok);
-		t.ok(!validateBuildConfigs(normalizeBuildConfigs([{name: '', platform: 'node'}])).ok);
+		t.ok(!validateBuildConfigs(normalizeBuildConfigs([{platform: 'node', input} as any])).ok);
+		t.ok(!validateBuildConfigs(normalizeBuildConfigs([{name: '', platform: 'node', input}])).ok);
 	});
 
 	test('fails with a primary Node name that does not match the enforced default', () => {
 		t.ok(
 			!validateBuildConfigs(
-				normalizeBuildConfigs([{name: 'failing_custom_name', platform: 'node'}]),
+				normalizeBuildConfigs([{name: 'failing_custom_name', platform: 'node', input}]),
 			).ok,
 		);
 		t.ok(
 			!validateBuildConfigs(
 				normalizeBuildConfigs([
-					{name: 'node', platform: 'node'},
-					{name: 'failing_custom_name', platform: 'node', primary: true},
+					{name: 'node', platform: 'node', input},
+					{name: 'failing_custom_name', platform: 'node', input, primary: true},
 				]),
 			).ok,
 		);
@@ -134,16 +180,16 @@ test('validateBuildConfigs', () => {
 		t.ok(
 			!validateBuildConfigs(
 				normalizeBuildConfigs([
-					{name: 'node', platform: 'node'},
-					{name: 'node', platform: 'node'},
+					{name: 'node', platform: 'node', input},
+					{name: 'node', platform: 'node', input},
 				]),
 			).ok,
 		);
 		t.ok(
 			!validateBuildConfigs(
 				normalizeBuildConfigs([
-					{name: 'node', platform: 'node'},
-					{name: 'node', platform: 'browser'},
+					{name: 'node', platform: 'node', input},
+					{name: 'node', platform: 'browser', input},
 				]),
 			).ok,
 		);
@@ -153,29 +199,30 @@ test('validateBuildConfigs', () => {
 		t.ok(
 			!validateBuildConfigs(
 				normalizeBuildConfigs([
-					{name: 'node', platform: 'node'},
-					{name: 'node2', platform: 'node', primary: true},
-					{name: 'browser', platform: 'browser', primary: true},
-					{name: 'node3', platform: 'node', primary: true},
+					{name: 'node', platform: 'node', input},
+					{name: 'node2', platform: 'node', input, primary: true},
+					{name: 'browser', platform: 'browser', input, primary: true},
+					{name: 'node3', platform: 'node', input, primary: true},
 				]),
 			).ok,
 		);
 		t.ok(
 			!validateBuildConfigs(
 				normalizeBuildConfigs([
-					{name: 'node', platform: 'node'},
-					{name: 'browser1', platform: 'browser', primary: true},
-					{name: 'browser2', platform: 'browser'},
-					{name: 'browser3', platform: 'browser', primary: true},
+					{name: 'node', platform: 'node', input},
+					{name: 'browser1', platform: 'browser', input, primary: true},
+					{name: 'browser2', platform: 'browser', input},
+					{name: 'browser3', platform: 'browser', input, primary: true},
 				]),
 			).ok,
 		);
 	});
 
 	test('fails with an invalid platform', () => {
-		t.ok(!validateBuildConfigs(normalizeBuildConfigs([{name: 'node'} as any])).ok);
+		t.ok(!validateBuildConfigs(normalizeBuildConfigs([{name: 'node', input} as any])).ok);
 		t.ok(
-			!validateBuildConfigs(normalizeBuildConfigs([{name: 'node', platform: 'deno'} as any])).ok,
+			!validateBuildConfigs(normalizeBuildConfigs([{name: 'node', platform: 'deno', input} as any]))
+				.ok,
 		);
 	});
 });

--- a/src/config/buildConfig.test.ts
+++ b/src/config/buildConfig.test.ts
@@ -15,14 +15,16 @@ test('normalizeBuildConfigs()', async () => {
 	});
 
 	test('normalizes inputs', () => {
-		const fooInput = join(paths.source, 'foo');
+		const inputPath = join(paths.source, 'foo');
+		const inputFilter = () => true;
 		const buildConfig = normalizeBuildConfigs([
 			{name: 'node', platform: 'node', input: '.'},
 			{name: 'node2', platform: 'node', input: paths.source},
 			{name: 'node3', platform: 'node', input},
 			{name: 'node4', platform: 'node', input: 'foo'},
-			{name: 'node5', platform: 'node', input: fooInput},
-			{name: 'node6', platform: 'node', input: [fooInput]},
+			{name: 'node5', platform: 'node', input: inputPath},
+			{name: 'node6', platform: 'node', input: inputFilter},
+			{name: 'node7', platform: 'node', input: [inputPath, inputFilter]},
 		]);
 		t.equal(buildConfig, [
 			{name: 'node', platform: 'node', input, primary: true, dist: true, include: null},
@@ -31,7 +33,7 @@ test('normalizeBuildConfigs()', async () => {
 			{
 				name: 'node4',
 				platform: 'node',
-				input: [fooInput],
+				input: [inputPath],
 				primary: false,
 				dist: true,
 				include: null,
@@ -39,7 +41,7 @@ test('normalizeBuildConfigs()', async () => {
 			{
 				name: 'node5',
 				platform: 'node',
-				input: [fooInput],
+				input: [inputPath],
 				primary: false,
 				dist: true,
 				include: null,
@@ -47,7 +49,15 @@ test('normalizeBuildConfigs()', async () => {
 			{
 				name: 'node6',
 				platform: 'node',
-				input: [fooInput],
+				input: [inputFilter],
+				primary: false,
+				dist: true,
+				include: null,
+			},
+			{
+				name: 'node7',
+				platform: 'node',
+				input: [inputPath, inputFilter],
 				primary: false,
 				dist: true,
 				include: null,

--- a/src/config/buildConfig.test.ts
+++ b/src/config/buildConfig.test.ts
@@ -7,20 +7,6 @@ import {paths} from '../paths.js';
 const input = [paths.source.substring(0, paths.source.length - 1)]; // TODO fix when trailing slash is removed
 
 test('normalizeBuildConfigs()', async () => {
-	test('normalizes undefined to a default config', () => {
-		const buildConfig = normalizeBuildConfigs(undefined);
-		t.equal(buildConfig, [
-			{name: 'node', platform: 'node', input, primary: true, dist: true, include: null},
-		]);
-	});
-
-	test('normalizes an empty array to a default config', () => {
-		const buildConfig = normalizeBuildConfigs([]);
-		t.equal(buildConfig, [
-			{name: 'node', platform: 'node', input, primary: true, dist: true, include: null},
-		]);
-	});
-
 	test('normalizes a plain config', () => {
 		const buildConfig = normalizeBuildConfigs([{name: 'node', platform: 'node', input: '.'}]);
 		t.equal(buildConfig, [
@@ -66,16 +52,6 @@ test('normalizeBuildConfigs()', async () => {
 				dist: true,
 				include: null,
 			},
-		]);
-	});
-
-	test('ensures a node config', () => {
-		const buildConfig = normalizeBuildConfigs([
-			{name: 'browser', platform: 'browser', input, primary: true, dist: true},
-		]);
-		t.equal(buildConfig, [
-			{name: 'browser', platform: 'browser', input, primary: true, dist: true, include: null},
-			{name: 'node', platform: 'node', input, primary: true, dist: false, include: null},
 		]);
 	});
 

--- a/src/config/buildConfig.ts
+++ b/src/config/buildConfig.ts
@@ -1,7 +1,7 @@
 import {resolve} from 'path';
 
 import {ensureArray} from '../utils/array.js';
-import {DEFAULT_BUILD_CONFIG, DEFAULT_BUILD_CONFIG_NAME} from './defaultBuildConfig.js';
+import {DEFAULT_BUILD_CONFIG_NAME} from './defaultBuildConfig.js';
 import {paths} from '../paths.js';
 
 // See `../docs/config.md` for documentation.
@@ -31,17 +31,9 @@ export interface PartialBuildConfig {
 
 export type PlatformTarget = 'node' | 'browser';
 
-export const normalizeBuildConfigs = (
-	partials: PartialBuildConfig[] | undefined,
-): BuildConfig[] => {
-	if (partials === undefined) partials = [];
+export const normalizeBuildConfigs = (partials: PartialBuildConfig[]): BuildConfig[] => {
 	const platforms: Set<string> = new Set();
 	const primaryPlatforms: Set<string> = new Set();
-
-	// If there is no Node config, add one.
-	if (!partials.some((p) => p.platform === 'node')) {
-		partials.push(DEFAULT_BUILD_CONFIG);
-	}
 
 	const hasDist = partials.some((b) => b.dist);
 

--- a/src/config/buildConfig.ts
+++ b/src/config/buildConfig.ts
@@ -9,7 +9,7 @@ import {paths} from '../paths.js';
 export interface BuildConfig {
 	readonly name: string;
 	readonly platform: PlatformTarget;
-	readonly input: BuildConfigInput[];
+	readonly input: readonly BuildConfigInput[];
 	readonly dist: boolean;
 	readonly primary: boolean;
 }

--- a/src/config/buildConfig.ts
+++ b/src/config/buildConfig.ts
@@ -9,13 +9,15 @@ import {paths} from '../paths.js';
 export interface BuildConfig {
 	readonly name: string;
 	readonly platform: PlatformTarget;
-	readonly input: string[];
+	readonly input: BuildConfigInput[];
 	readonly dist: boolean;
 	readonly primary: boolean;
 	readonly include: null | ((id: string) => boolean); // `null` means include everything
 }
 
-// TODO choose one of these
+type BuildConfigInput = string | ((id: string) => boolean);
+
+// The partial was originally this calculated type, but it's a lot less readable.
 // export type PartialBuildConfig = PartialExcept<
 // 	OmitStrict<BuildConfig, 'input'> & {readonly input: string | string[]},
 // 	'name' | 'platform'
@@ -23,7 +25,7 @@ export interface BuildConfig {
 export interface PartialBuildConfig {
 	readonly name: string;
 	readonly platform: PlatformTarget;
-	readonly input: string | string[];
+	readonly input: BuildConfigInput | BuildConfigInput[];
 	readonly dist?: boolean;
 	readonly primary?: boolean;
 	readonly include?: null | ((id: string) => boolean); // `null` means include everything
@@ -64,7 +66,7 @@ export const normalizeBuildConfigs = (partials: PartialBuildConfig[]): BuildConf
 };
 
 const normalizeBuildConfigInput = (input: PartialBuildConfig['input']): BuildConfig['input'] =>
-	ensureArray(input).map((v) => resolve(paths.source, v));
+	ensureArray(input).map((v) => (typeof v === 'string' ? resolve(paths.source, v) : v));
 
 // TODO replace this with JSON schema validation (or most of it at least)
 export const validateBuildConfigs = (buildConfigs: BuildConfig[]): Result<{}, {reason: string}> => {

--- a/src/config/buildConfig.ts
+++ b/src/config/buildConfig.ts
@@ -12,7 +12,6 @@ export interface BuildConfig {
 	readonly input: BuildConfigInput[];
 	readonly dist: boolean;
 	readonly primary: boolean;
-	readonly include: null | ((id: string) => boolean); // `null` means include everything
 }
 
 type BuildConfigInput = string | ((id: string) => boolean);
@@ -28,7 +27,6 @@ export interface PartialBuildConfig {
 	readonly input: BuildConfigInput | BuildConfigInput[];
 	readonly dist?: boolean;
 	readonly primary?: boolean;
-	readonly include?: null | ((id: string) => boolean); // `null` means include everything
 }
 
 export type PlatformTarget = 'node' | 'browser';
@@ -46,7 +44,6 @@ export const normalizeBuildConfigs = (partials: PartialBuildConfig[]): BuildConf
 		input: normalizeBuildConfigInput(buildConfig.input),
 		dist: hasDist ? buildConfig.dist ?? false : true, // If no config is marked as `dist`, assume they all are.
 		primary: buildConfig.primary ?? false,
-		include: buildConfig.include ?? null,
 	}));
 
 	for (const buildConfig of buildConfigs) {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -40,7 +40,7 @@ export interface GroConfig {
 }
 
 export interface PartialGroConfig {
-	readonly builds?: PartialBuildConfig[];
+	readonly builds: PartialBuildConfig[];
 }
 
 export interface GroConfigModule {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -26,7 +26,7 @@ This choice keeps things simple and flexible because:
 - a project's Gro config may share any amount of code and types bidirectionally
 	with the project's source code
 - the config itself is defined in TypeScript
-- isolating all compilable source code in `src/` avoids a lot of tooling complexity
+- isolating all buildable source code in `src/` avoids a lot of tooling complexity
 
 */
 

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -13,5 +13,4 @@ export const DEFAULT_BUILD_CONFIG: BuildConfig = {
 	primary: true,
 	dist: false,
 	input: [paths.source],
-	include: null,
 };

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -11,7 +11,7 @@ export const DEFAULT_BUILD_CONFIG: BuildConfig = {
 	name: DEFAULT_BUILD_CONFIG_NAME,
 	platform: 'node',
 	primary: true,
-	dist: false, // gets set to `true` along with all others if none are `true`
+	dist: false,
 	input: [paths.source],
 	include: null,
 };

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -1,4 +1,5 @@
 import {BuildConfig} from './buildConfig.js';
+import {paths} from '../paths.js';
 
 // Gro currently enforces that the primary build config
 // for the Node platform has this value as its name.
@@ -11,5 +12,6 @@ export const DEFAULT_BUILD_CONFIG: BuildConfig = {
 	platform: 'node',
 	primary: true,
 	dist: false, // gets set to `true` along with all others if none are `true`
+	input: [paths.source],
 	include: null,
 };

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -1,7 +1,7 @@
 import {createFilter} from '@rollup/pluginutils';
 
-import {basePathToSourceId} from '../paths.js';
 import {GroConfigCreator, PartialGroConfig} from './config.js';
+import {basePathToSourceId} from '../paths.js';
 
 // This is the default config that's used if the current project does not define one.
 
@@ -10,10 +10,19 @@ const createConfig: GroConfigCreator = async () => {
 		// TODO include only tasks and such in the Node build,
 		// and follow imports from entry points in the browser build so things like tasks aren't included
 		builds: [
-			{name: 'browser', platform: 'browser', dist: true},
+			{
+				name: 'browser',
+				platform: 'browser',
+				input: 'index.ts',
+				dist: true,
+			},
 			{
 				name: 'node',
 				platform: 'node',
+				// TODO should this be a pattern/filter for all tasks? add in other subexts like `gen` and `test` too?
+				// input: ['**/*.task.ts'],
+				// input: [createFilter('**/*.task.ts')],
+				input: '.',
 				include: createFilter(undefined, basePathToSourceId('**/*.svelte')),
 			},
 		],

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -1,14 +1,11 @@
 import {createFilter} from '@rollup/pluginutils';
 
 import {GroConfigCreator, PartialGroConfig} from './config.js';
-import {basePathToSourceId} from '../paths.js';
 
 // This is the default config that's used if the current project does not define one.
 
 const createConfig: GroConfigCreator = async () => {
 	const config: PartialGroConfig = {
-		// TODO include only tasks and such in the Node build,
-		// and follow imports from entry points in the browser build so things like tasks aren't included
 		builds: [
 			{
 				name: 'browser',
@@ -19,10 +16,7 @@ const createConfig: GroConfigCreator = async () => {
 			{
 				name: 'node',
 				platform: 'node',
-				// TODO should this be a pattern/filter for all tasks/tests/gen/etc? add in other subexts like `gen` and `test` too?
-				// input: [..., createFilter('**/*.{task,test,gen}*.ts')],
-				input: '.',
-				include: createFilter(undefined, basePathToSourceId('**/*.svelte')),
+				input: [createFilter('**/*.{task,test,gen}*.ts')],
 			},
 		],
 	};

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -19,9 +19,8 @@ const createConfig: GroConfigCreator = async () => {
 			{
 				name: 'node',
 				platform: 'node',
-				// TODO should this be a pattern/filter for all tasks? add in other subexts like `gen` and `test` too?
-				// input: ['**/*.task.ts'],
-				// input: [createFilter('**/*.task.ts')],
+				// TODO should this be a pattern/filter for all tasks/tests/gen/etc? add in other subexts like `gen` and `test` too?
+				// input: [..., createFilter('**/*.{task,test,gen}*.ts')],
 				input: '.',
 				include: createFilter(undefined, basePathToSourceId('**/*.svelte')),
 			},

--- a/src/devServer/devServer.ts
+++ b/src/devServer/devServer.ts
@@ -13,13 +13,13 @@ import {cyan, yellow, gray} from '../colors/terminal.js';
 import {Logger, SystemLogger} from '../utils/log.js';
 import {stripAfter} from '../utils/string.js';
 import {omitUndefined} from '../utils/object.js';
+import {Filer} from '../build/Filer.js';
 import {
-	Filer,
-	BaseFile,
+	BaseFilerFile,
 	getFileMimeType,
 	getFileContentsBuffer,
 	getFileStats,
-} from '../build/Filer.js';
+} from '../build/baseFilerFile.js';
 
 export interface DevServer {
 	readonly server: Server;
@@ -127,7 +127,7 @@ const send404 = (req: IncomingMessage, res: ServerResponse, path: string) => {
 	res.end(`404 not found: ${req.url} → ${path}`);
 };
 
-const send200 = async (_req: IncomingMessage, res: ServerResponse, file: BaseFile) => {
+const send200 = async (_req: IncomingMessage, res: ServerResponse, file: BaseFilerFile) => {
 	const stats = await getFileStats(file);
 	const mimeType = getFileMimeType(file);
 	const headers: OutgoingHttpHeaders = {

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -79,7 +79,7 @@ import {GroConfigCreator} from '@feltcoop/gro/dist/config/config.js';
 
 const createConfig: GroConfigCreator = async () => {
 	return {
-		builds: [{name: 'node', platform: 'node'}],
+		builds: [{name: 'node', platform: 'node', input: 'index.ts'}],
 	};
 };
 

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -90,13 +90,14 @@ Here's what a frontend-only project with both desktop and mobile builds may look
 
 ```ts
 import {GroConfigCreator} from '@feltcoop/gro/dist/config/config.js';
+import {createFilter} from '@rollup/pluginutils';
 
 const createConfig: GroConfigCreator = async () => {
 	return {
 		builds: [
 			{name: 'browser_mobile', platform: 'browser', dist: true},
 			{name: 'browser_desktop', platform: 'browser', dist: true, primary: true},
-			// {name: 'node', platform: 'node'}, // this is implicit to run tasks, tests, codegen, etc
+			{name: 'node', platform: 'node', input: [createFilter('**/*.{task,test,gen}*.ts')]},
 		],
 	};
 };

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -44,7 +44,9 @@ The `platform` can currently be `"node"` or `"browser"` and
 is used by Gro's default compilers to customize the output.
 When compiling for the browser, dependencies in `node_modules/` are imported via Snowpack's
 [`esinstall`](https://github.com/snowpackjs/snowpack/tree/master/esinstall).
-When compiling for Node, the Svelte compiler outputs SSR components instead of the normal DOM ones.
+When compiling for Node, the Svelte compiler outputs
+[SSR components](https://svelte.dev/docs#Server-side_component_API)
+instead of the normal DOM ones.
 
 The `input` field specifies the source code entry points for the build.
 Each input can be a file or directory path (absolute or relative to `src/`),

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -32,17 +32,19 @@ export interface PartialBuildConfig {
 }
 ```
 
-The `platform` can currently be `"node"` or `"browser"` and
-is used by compilers for TypeScript and Svelte.
-When compiling for Node, the Svelte compiler outputs SSR components instead of the normal DOM ones.
+The `name` field can be anything and maps to the build's output directory name.
+By defining `"name": "foo",`, running `gro dev`/`gro compile` or `gro build` creates builds
+in `.gro/dev/foo/` and `.gro/prod/foo/`, respectively.
 
-The `name` field can be anything and maps to the build's directory name.
-By defining `"name": "node",`, running `gro compile`, `gro dev`, or `gro build` creates builds
-in `.gro/dev/node/` and `.gro/prod/node/`, respectively.
-
-> Importantly, **Gro always includes a hardcoded Node build named `"node"`**
-> that it uses to compile your project and run things like tests, tasks, and codegen.
+> Importantly, **Gro requires a Node build named `"node"`**
+> that it uses to run things like tests, tasks, and codegen.
 > Ideally this would be configurable, but doing so would slow Gro down in many cases.
+
+The `platform` can currently be `"node"` or `"browser"` and
+is used by Gro's default compilers to customize the output.
+When compiling for the browser, dependencies in `node_modules/` are imported via Snowpack's
+[`esinstall`](https://github.com/snowpackjs/snowpack/tree/master/esinstall).
+When compiling for Node, the Svelte compiler outputs SSR components instead of the normal DOM ones.
 
 The `input` field specifies the source code entry points for the build.
 Each input can be a file or directory path (absolute or relative to `src/`),

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -105,4 +105,6 @@ const createConfig: GroConfigCreator = async () => {
 export default createConfig;
 ```
 
-Here's [Gro's own internal config](/src/gro.config.ts).
+Here's [Gro's own internal config](/src/gro.config.ts) and
+here's [`the default config`](/src/config/gro.config.default.ts)
+that's used for projects that do not define one.

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -25,9 +25,9 @@ Here's the [`PartialBuildConfig`](/src/config/buildConfig.ts) type:
 export interface PartialBuildConfig {
 	readonly name: string;
 	readonly platform: PlatformTarget; // 'node' | 'browser'
+	readonly input: BuildConfigInput | BuildConfigInput[];
 	readonly dist?: boolean;
 	readonly primary?: boolean;
-	readonly include?: null | ((id: string) => boolean);
 }
 ```
 
@@ -39,9 +39,16 @@ The `name` field can be anything and maps to the build's directory name.
 By defining `"name": "node",`, running `gro compile`, `gro dev`, or `gro build` creates builds
 in `.gro/dev/node/` and `.gro/prod/node/`, respectively.
 
-Importantly, **Gro always includes a hardcoded Node build named `"node"`**
-that it uses to compile your project and run things like tests, tasks, and codegen.
-Ideally this would be configurable, but doing so would slow Gro down in many cases.
+> Importantly, **Gro always includes a hardcoded Node build named `"node"`**
+> that it uses to compile your project and run things like tests, tasks, and codegen.
+> Ideally this would be configurable, but doing so would slow Gro down in many cases.
+
+The `input` field specifies the source code entry points for the build.
+Each input can be a file or directory path (absolute or relative to `src/`),
+or a filter function with the signature `(id: string) => boolean`.
+(it's convenient to use the
+[`createFilter` helper](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createFilter)
+from `@rollup/pluginutils`)
 
 The optional `dist` flag marks builds for inclusion in the root `dist/` directory
 by [the `gro dist` task](/src/dist.task.ts).
@@ -61,9 +68,6 @@ For browser builds, this is the build that's served by the development server.
 As mentioned above, the `primary` Node build is always named `"node"`.
 For other platforms, if no `primary` flag exists on any build,
 Gro marks the first build in the `builds` array as primary.
-
-The optional `include` property can be used to include or exclude a particular file.
-It's convenient to use the `createFilter` helper from `@rollup/pluginutils` here.
 
 ## examples
 

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -95,9 +95,9 @@ import {createFilter} from '@rollup/pluginutils';
 const createConfig: GroConfigCreator = async () => {
 	return {
 		builds: [
-			{name: 'browser_mobile', platform: 'browser', dist: true},
-			{name: 'browser_desktop', platform: 'browser', dist: true, primary: true},
-			{name: 'node', platform: 'node', input: [createFilter('**/*.{task,test,gen}*.ts')]},
+			{name: 'browser_mobile', platform: 'browser', input: 'index.ts', dist: true},
+			{name: 'browser_desktop', platform: 'browser', input: 'index.ts', dist: true, primary: true},
+			{name: 'node', platform: 'node', input: createFilter('**/*.{task,test,gen}*.ts')},
 		],
 	};
 };

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -38,6 +38,7 @@ in `.gro/dev/foo/` and `.gro/prod/foo/`, respectively.
 
 > Importantly, **Gro requires a Node build named `"node"`**
 > that it uses to run things like tests, tasks, and codegen.
+> It must be the primary Node build.
 > Ideally this would be configurable, but doing so would slow Gro down in many cases.
 
 The `platform` can currently be `"node"` or `"browser"` and

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -13,13 +13,14 @@ To accomplish this, Gro has an optional config file that lives at `$PROJECT/src/
 If a project does not define a config, Gro imports a default config from
 [`src/config/gro.config.default.ts`](/src/config/gro.config.default.ts).
 
-See [`src/config/config.ts`](/src/config/config.ts) for the config implementation.
+See [`src/config/config.ts`](/src/config/config.ts) for the config types and implementation.
 
 ## build config
 
 The `builds` property of the Gro config
 is an array of build configs that describe a project's outputs.
-Here's the [`PartialBuildConfig`](/src/config/buildConfig.ts) type:
+Here's the [`PartialBuildConfig`](/src/config/buildConfig.ts) type,
+which is the user-facing version of the [`BuildConfig`](/src/config/buildConfig.ts):
 
 ```ts
 export interface PartialBuildConfig {
@@ -102,3 +103,5 @@ const createConfig: GroConfigCreator = async () => {
 
 export default createConfig;
 ```
+
+Here's [Gro's own internal config](/src/gro.config.ts).

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -106,5 +106,5 @@ export default createConfig;
 ```
 
 Here's [Gro's own internal config](/src/gro.config.ts) and
-here's [`the default config`](/src/config/gro.config.default.ts)
+here's [the default config](/src/config/gro.config.default.ts)
 that's used for projects that do not define one.

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -50,11 +50,12 @@ When compiling for Node, the Svelte compiler outputs
 instead of the normal DOM ones.
 
 The `input` field specifies the source code entry points for the build.
-Each input can be a file or directory path (absolute or relative to `src/`),
+Each input must be a file path (absolute or relative to `src/`),
 or a filter function with the signature `(id: string) => boolean`.
-(it's convenient to use the
+To define filters, it's convenient to use the
 [`createFilter` helper](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createFilter)
-from `@rollup/pluginutils`)
+from `@rollup/pluginutils` and
+Gro's own [`createDirectoryFilter` helper](../build/utils.ts).
 
 The optional `dist` flag marks builds for inclusion in the root `dist/` directory
 by [the `gro dist` task](/src/dist.task.ts).

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -3,6 +3,7 @@ import App from './App.svelte';
 import './foo.js';
 import {bar} from './bar.js';
 import * as math from '../utils/math.js';
+// import '../build/includeme.js';
 
 console.log('math', math);
 

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -2,6 +2,9 @@ import './devtools.js';
 import App from './App.svelte';
 import './foo.js';
 import {bar} from './bar.js';
+import * as math from '../utils/math.js';
+
+console.log('math', math);
 
 // test fully qualified import
 import * as motion from 'svelte/motion/index.js';

--- a/src/fs/modules.test.ts
+++ b/src/fs/modules.test.ts
@@ -179,25 +179,22 @@ test('loadModules()', () => {
 		);
 		t.ok(!result.ok);
 		t.ok(result.reasons.length);
-		if (result.type === 'loadModuleFailures') {
-			t.is(result.loadModuleFailures.length, 2);
-			const [failure1, failure2] = result.loadModuleFailures;
-			if (failure1.type === 'invalid') {
-				t.is(failure1.id, idBar1);
-				t.ok(failure1.mod);
-				t.is(failure1.validation, testValidation.name);
-			} else {
-				t.fail('Expected to fail with invalid');
-			}
-			if (failure2.type === 'importFailed') {
-				t.is(failure2.id, idBar2);
-				t.is(failure2.error, error);
-			} else {
-				t.fail('Expected to fail with importFailed');
-			}
-		} else {
+		if (result.type !== 'loadModuleFailures') {
 			t.fail('Expected to fail with loadModuleFailures');
 		}
+		t.is(result.loadModuleFailures.length, 2);
+		const [failure1, failure2] = result.loadModuleFailures;
+		if (failure1.type !== 'invalid') {
+			t.fail('Expected to fail with invalid');
+		}
+		t.is(failure1.id, idBar1);
+		t.ok(failure1.mod);
+		t.is(failure1.validation, testValidation.name);
+		if (failure2.type !== 'importFailed') {
+			t.fail('Expected to fail with importFailed');
+		}
+		t.is(failure2.id, idBar2);
+		t.is(failure2.error, error);
 		t.is(result.modules.length, 2);
 		t.is(result.modules[0].id, idBaz1);
 		t.is(result.modules[0].mod, modTestBaz1);

--- a/src/fs/modules.ts
+++ b/src/fs/modules.ts
@@ -6,7 +6,7 @@ import {Timings} from '../utils/time.js';
 import {PathStats, PathData} from './pathData.js';
 import {toImportId, pathsFromId} from '../paths.js';
 import {UnreachableError} from '../utils/error.js';
-import {DEFAULT_BUILD_CONFIG} from '../config/defaultBuildConfig.js';
+import {DEFAULT_BUILD_CONFIG_NAME} from '../config/defaultBuildConfig.js';
 
 /*
 
@@ -34,11 +34,11 @@ export const loadModule = async <T>(
 	id: string,
 	validate?: (mod: Obj) => mod is T,
 	dev = true,
-	buildConfig = DEFAULT_BUILD_CONFIG,
+	buildConfigName = DEFAULT_BUILD_CONFIG_NAME,
 ): Promise<LoadModuleResult<ModuleMeta<T>>> => {
 	let mod;
 	try {
-		mod = await import(toImportId(id, dev, buildConfig.name));
+		mod = await import(toImportId(id, dev, buildConfigName));
 	} catch (err) {
 		return {ok: false, type: 'importFailed', id, error: err};
 	}

--- a/src/gen/README.md
+++ b/src/gen/README.md
@@ -9,7 +9,7 @@ The `gro gen` task allows us to enhance our projects
 with convention-based code generation (codegen) techniques.
 
 Why? Codegen can produce cool results and eternal pain.
-Used well, they can improve performance, flexibility, consistency, and development speed.
+Used well, codegen can improve performance, flexibility, consistency, and development speed.
 As developers, automating our work is a natural thing to do,
 and whether or not it's a wise thing to do,
 `gro gen` can bring automation deeper into our code authoring workflows.
@@ -20,8 +20,7 @@ and it outputs a file stripped of `.gen.` to the same directory.
 The `*.gen.*` origin files export a `gen` function
 that returns the contents of the output file.
 More flexibility is available when needed
-including custom file names, custom output directories,
-and multiple output files.
+including multiple custom output files.
 
 Normally you'll want to commit generated files to git,
 but you can always gitignore a specific pattern like `*.ignore.*`

--- a/src/gen/README.md
+++ b/src/gen/README.md
@@ -225,6 +225,7 @@ which is called in the npm [`"preversion"`](../../package.json) script.
 
 - [x] basic functionality
 - [x] format output with Prettier
+- [ ] assess libraries for generating types
 - [ ] watch mode and build integration
 - [ ] support gen files authored in languages beyond TypeScript like
       Svelte/[MDSveX](https://github.com/pngwn/MDsveX)/etc

--- a/src/globalTypes.ts
+++ b/src/globalTypes.ts
@@ -24,6 +24,10 @@ declare type PartialValues<T> = {
 	[P in keyof T]: Partial<T[P]>;
 };
 
+type Writable<T, K extends keyof T = keyof T> = {
+	-readonly [P in K]: T[P];
+};
+
 declare type Result<TValue = {}, TError = {}> = ({ok: true} & TValue) | ({ok: false} & TError);
 
 /*

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -1,5 +1,5 @@
 import {createFilter} from '@rollup/pluginutils';
-import {createDirectoryFilter} from './build/utils.js';
+// import {createDirectoryFilter} from './build/utils.js';
 
 import {GroConfigCreator, PartialGroConfig} from './config/config.js';
 
@@ -16,11 +16,12 @@ const createConfig: GroConfigCreator = async () => {
 				primary: true,
 				input: ['index.ts', createFilter(['**/*.{task,test,gen}*.ts', '**/fixtures/**'])],
 			},
-			{
-				name: 'browser',
-				platform: 'browser',
-				input: createDirectoryFilter('frontend'),
-			},
+			// TODO
+			// {
+			// 	name: 'browser',
+			// 	platform: 'browser',
+			// 	input: createDirectoryFilter('frontend'),
+			// },
 		],
 	};
 

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -1,4 +1,5 @@
 import {createFilter} from '@rollup/pluginutils';
+import {createDirectoryFilter} from './build/utils.js';
 
 import {GroConfigCreator, PartialGroConfig} from './config/config.js';
 
@@ -18,7 +19,7 @@ const createConfig: GroConfigCreator = async () => {
 			{
 				name: 'browser',
 				platform: 'browser',
-				input: 'frontend/index.ts', // TODO should this be `frontend/`?
+				input: createDirectoryFilter('frontend'),
 			},
 		],
 	};

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -13,7 +13,7 @@ const createConfig: GroConfigCreator = async () => {
 				platform: 'node',
 				dist: true,
 				primary: true,
-				input: ['index.ts', createFilter('**/*.{task,test,gen}*.ts')],
+				input: ['index.ts', createFilter(['**/*.{task,test,gen}*.ts', '**/fixtures/**'])],
 			},
 			{
 				name: 'browser',

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -1,7 +1,4 @@
-import {createFilter} from '@rollup/pluginutils';
-
 import {GroConfigCreator, PartialGroConfig} from './config/config.js';
-import {basePathToSourceId} from './paths.js';
 
 // This is the config for the Gro project itself.
 // The default config for dependent projects is located at `./config/gro.config.default.ts`.
@@ -14,14 +11,12 @@ const createConfig: GroConfigCreator = async () => {
 				platform: 'node',
 				dist: true,
 				primary: true,
-				include: createFilter(undefined, basePathToSourceId('frontend/**/*')),
+				input: 'src/index.ts',
 			},
 			{
 				name: 'browser',
 				platform: 'browser',
-				// TODO this doesn't allow the frontend to import modules outside of its directory.
-				// We probably want to either define entrypoints or automatically include all transitive dependencies.
-				include: createFilter(basePathToSourceId('frontend/**/*')),
+				input: 'src/frontend/index.ts',
 			},
 		],
 	};

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -1,3 +1,5 @@
+import {createFilter} from '@rollup/pluginutils';
+
 import {GroConfigCreator, PartialGroConfig} from './config/config.js';
 
 // This is the config for the Gro project itself.
@@ -11,12 +13,12 @@ const createConfig: GroConfigCreator = async () => {
 				platform: 'node',
 				dist: true,
 				primary: true,
-				input: 'index.ts',
+				input: ['index.ts', createFilter('**/*.{task,test,gen}*.ts')],
 			},
 			{
 				name: 'browser',
 				platform: 'browser',
-				input: 'frontend/index.ts',
+				input: 'frontend/index.ts', // TODO should this be `frontend/`?
 			},
 		],
 	};

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -11,12 +11,12 @@ const createConfig: GroConfigCreator = async () => {
 				platform: 'node',
 				dist: true,
 				primary: true,
-				input: 'src/index.ts',
+				input: 'index.ts',
 			},
 			{
 				name: 'browser',
 				platform: 'browser',
-				input: 'src/frontend/index.ts',
+				input: 'frontend/index.ts',
 			},
 		],
 	};

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -99,7 +99,7 @@ test('toImportId()', () => {
 	t.is(toImportId(resolve('src/foo/bar.ts'), false, 'baz'), resolve('.gro/prod/baz/foo/bar.js'));
 	t.is(
 		toImportId(resolve('src/foo/bar.svelte'), true, 'baz'),
-		resolve('.gro/prod/baz/foo/bar.svelte.js'),
+		resolve('.gro/dev/baz/foo/bar.svelte.js'),
 	);
 });
 

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -13,6 +13,9 @@ import {
 	toPathParts,
 	toPathSegments,
 	toImportId,
+	toBuildExtension,
+	toSourceExtension,
+	toBuildBasePath,
 } from './paths.js';
 
 test('createPaths()', () => {
@@ -46,6 +49,14 @@ test('basePathToSourceId()', () => {
 	test('does not change extension', () => {
 		t.is(basePathToSourceId('foo/bar/baz.js'), resolve('src/foo/bar/baz.js'));
 	});
+});
+
+// TODO !
+// test('toBuildsOutDir()', () => {});
+// test('toBuildOutPath()', () => {});
+
+test('toBuildBasePath()', () => {
+	t.is(toBuildBasePath(resolve('.gro/dev/buildName/foo/bar/baz.js')), 'foo/bar/baz.js');
 });
 
 test('hasSourceExtension()', () => {
@@ -86,4 +97,23 @@ test('toPathParts()', () => {
 test('toImportId()', () => {
 	t.is(toImportId(resolve('src/foo/bar.ts'), true, 'baz'), resolve('.gro/dev/baz/foo/bar.js'));
 	t.is(toImportId(resolve('src/foo/bar.ts'), false, 'baz'), resolve('.gro/prod/baz/foo/bar.js'));
+	t.is(
+		toImportId(resolve('src/foo/bar.svelte'), true, 'baz'),
+		resolve('.gro/prod/baz/foo/bar.svelte.js'),
+	);
+});
+
+test('toBuildExtension()', () => {
+	t.is(toBuildExtension('foo/bar.ts'), 'foo/bar.js');
+	t.is(toBuildExtension('foo/bar.svelte'), 'foo/bar.svelte.js');
+	t.is(toBuildExtension('foo/bar.css'), 'foo/bar.css');
+	t.is(toBuildExtension('foo/bar.png'), 'foo/bar.png');
+});
+
+test('toSourceExtension()', () => {
+	t.is(toSourceExtension('foo/bar.js'), 'foo/bar.ts');
+	t.is(toSourceExtension('foo/bar.svelte.js'), 'foo/bar.svelte');
+	t.is(toSourceExtension('foo/bar.svelte.css'), 'foo/bar.svelte');
+	t.is(toSourceExtension('foo/bar.css'), 'foo/bar.css');
+	t.is(toSourceExtension('foo/bar.png'), 'foo/bar.png');
 });

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -112,8 +112,17 @@ test('toBuildExtension()', () => {
 
 test('toSourceExtension()', () => {
 	t.is(toSourceExtension('foo/bar.js'), 'foo/bar.ts');
+	t.is(toSourceExtension('foo/bar.js.map'), 'foo/bar.ts');
 	t.is(toSourceExtension('foo/bar.svelte.js'), 'foo/bar.svelte');
+	t.is(toSourceExtension('foo/bar.svelte.js.map'), 'foo/bar.svelte');
 	t.is(toSourceExtension('foo/bar.svelte.css'), 'foo/bar.svelte');
+	t.is(toSourceExtension('foo/bar.svelte.css.map'), 'foo/bar.svelte');
 	t.is(toSourceExtension('foo/bar.css'), 'foo/bar.css');
+	t.is(toSourceExtension('foo/bar.css.map'), 'foo/bar.css');
 	t.is(toSourceExtension('foo/bar.png'), 'foo/bar.png');
+	t.is(toSourceExtension('foo/bar.png.map'), 'foo/bar.png');
+	t.is(toSourceExtension('foo/bar/'), 'foo/bar/');
+	t.is(toSourceExtension('foo/bar'), 'foo/bar');
+	t.is(toSourceExtension('foo/'), 'foo/');
+	t.is(toSourceExtension('foo'), 'foo');
 });

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -160,6 +160,7 @@ export const toBuildExtension = (sourceId: string): string =>
 		: sourceId;
 
 // This implementation is complicated but it's fast.
+// TODO see `toBuildExtension` comments for discussion about making this generic and configurable
 export const toSourceExtension = (buildId: string): string => {
 	let len = buildId.length;
 	let i = len;

--- a/src/project/rollup-plugin-gro-svelte.ts
+++ b/src/project/rollup-plugin-gro-svelte.ts
@@ -5,7 +5,7 @@ import {Plugin} from 'rollup';
 import {createFilter} from '@rollup/pluginutils';
 
 import {magenta, red} from '../colors/terminal.js';
-import {getPathStem, replaceExtension} from '../utils/path.js';
+import {getPathStem} from '../utils/path.js';
 import {SystemLogger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 import {GroCssBuild} from './types.js';
@@ -16,6 +16,7 @@ import {
 	handleWarn,
 	handleStats,
 } from '../compile/svelteHelpers.js';
+import {CSS_EXTENSION} from '../paths.js';
 
 // TODO support `package.json` "svelte" field
 // see reference here https://github.com/rollup/rollup-plugin-svelte/blob/master/index.js#L190
@@ -118,7 +119,7 @@ export const groSveltePlugin = (opts: InitialOptions): GroSveltePlugin => {
 
 			onstats(id, stats, handleStats, log, this);
 
-			let cssId = replaceExtension(id, '.css');
+			const cssId = `${id}${CSS_EXTENSION}`;
 			log.trace('add css import', printPath(cssId));
 			addCssBuild({
 				id: cssId,

--- a/src/task/README.md
+++ b/src/task/README.md
@@ -178,8 +178,7 @@ What makes Gro different?
   Task modules do not have any side effects when imported,
   while Node scripts just execute when imported -
   their primary purpose is to cause side effects.
-- Module resolution is different,
-  and not just by making `.task.ts` optional.
+- Module resolution is different.
   - When a task name is given to Gro,
     it first searches the current working directory and
     falls back to searching the Gro directory.
@@ -193,3 +192,5 @@ What makes Gro different?
     both relative to the current working directory and Gro's directory.
     So when you run `gro src` or simply `gro`,
     it'll print all tasks available both in your project and Gro.
+  - The trailing `.task.ts` in the file path provided to `gro` is optional,
+    so for example, `gro foo/bar` is the same as `gro foo/bar.task.ts`.

--- a/src/utils/array.test.ts
+++ b/src/utils/array.test.ts
@@ -1,14 +1,14 @@
 import {test, t} from '../oki/oki.js';
 
-import {last, arraysEqual} from './array.js';
+import {last, arraysEqual, ensureArray} from './array.js';
 
-test('last', () => {
+test('last()', () => {
 	t.is(last([1, 2]), 2);
 	t.is(last([1]), 1);
 	t.is(last([]), undefined);
 });
 
-test('arraysEqual', () => {
+test('arraysEqual()', () => {
 	t.ok(arraysEqual([1, 2, 3], [1, 2, 3]));
 	test('different order', () => {
 		t.ok(!arraysEqual([1, 2, 3], [1, 3, 2]));
@@ -30,4 +30,11 @@ test('arraysEqual', () => {
 			!arraysEqual([1, {a: 2}, {a: {b: {c: 3, d: NaN}}}], [1, {a: 2}, {a: {b: {c: 4, d: NaN}}}]),
 		);
 	});
+});
+
+test('ensureArray()', () => {
+	const array = [1, 2, 3];
+	t.is(array, ensureArray(array));
+	t.equal([1], ensureArray(1));
+	t.equal([{a: 1}], ensureArray({a: 1}));
 });

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,6 +1,6 @@
 export {arraysEqual} from './deepEqual.js';
 
-export const EMPTY_ARRAY = Object.freeze([]);
+export const EMPTY_ARRAY: any[] = Object.freeze([]) as any;
 
 export const last = <T>(array: T[]): T | undefined => array[array.length - 1];
 

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -3,3 +3,5 @@ export {arraysEqual} from './deepEqual.js';
 export const EMPTY_ARRAY = Object.freeze([]);
 
 export const last = <T>(array: T[]): T | undefined => array[array.length - 1];
+
+export const ensureArray = <T>(value: T | T[]): T[] => (Array.isArray(value) ? value : [value]);


### PR DESCRIPTION
This is a big PR that implements the `input` field of the `BuildConfig`. It involves refactoring and rewriting some of the `Filer`'s internals.

The main regression that I know of is that stale files are not deleted from the build directory on startup. I'll fix that in the next PR.