### PR TITLE
track source file dependencies

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "program": "${workspaceFolder}/dist/cli/gro.js",
       "args": ["project/dev"],
       "runtimeArgs": [],
-      "outFiles": ["${workspaceRoot}/dist/**/*.js"], // enables breakpoints in TS source
+      "outFiles": ["${workspaceRoot}/.gro/dev/node/**/*.js"], // enables breakpoints in TS source
       "env": {
         // "NODE_ENV": "production"
         "NODE_ENV": "development"

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -274,10 +274,6 @@ export class Filer {
 
 		// Clean the dev output directories,
 		// removing any files that can't be mapped back to source files.
-		// TODO so wait.. when updating the stale files,
-		// what if we looked at the cached source info, and diff deps?
-		// wouldn't that be a precise way of updating the cached source info,
-		// and detecting unknown files without this whole process?
 		if (this.cleanOutputDirs && this.buildConfigs !== null) {
 			await Promise.all(
 				this.buildConfigs.map(async (buildConfig) => {

--- a/src/build/buildFile.ts
+++ b/src/build/buildFile.ts
@@ -91,7 +91,7 @@ export const reconstructBuildFiles = async (
 ): Promise<Map<BuildConfig, BuildFile[]>> => {
 	const buildFiles: Map<BuildConfig, BuildFile[]> = new Map();
 	await Promise.all(
-		cachedSourceInfo.compilations.map(
+		cachedSourceInfo.data.compilations.map(
 			async (compilation): Promise<void> => {
 				const {
 					id,
@@ -110,7 +110,7 @@ export const reconstructBuildFiles = async (
 					case 'utf8':
 						buildFile = {
 							type: 'build',
-							sourceFileId: cachedSourceInfo.sourceId,
+							sourceFileId: cachedSourceInfo.data.sourceId,
 							buildConfig,
 							localDependencies: localDependencies && new Set(localDependencies),
 							externalDependencies: externalDependencies && new Set(externalDependencies),
@@ -132,7 +132,7 @@ export const reconstructBuildFiles = async (
 					case null:
 						buildFile = {
 							type: 'build',
-							sourceFileId: cachedSourceInfo.sourceId,
+							sourceFileId: cachedSourceInfo.data.sourceId,
 							buildConfig,
 							localDependencies: localDependencies && new Set(localDependencies),
 							externalDependencies: externalDependencies && new Set(externalDependencies),

--- a/src/build/buildFile.ts
+++ b/src/build/buildFile.ts
@@ -172,7 +172,7 @@ const addBuildFile = (
 };
 
 // TODO rename? move?
-interface DependencyInfo {
+export interface DependencyInfo {
 	id: string;
 	external: boolean;
 }
@@ -185,9 +185,10 @@ interface DependencyInfo {
 export const diffDependencies = (
 	newFiles: readonly BuildFile[],
 	oldFiles: readonly BuildFile[] | null,
-):
-	| null
-	| [addedDependencies: DependencyInfo[] | null, removedDependencies: DependencyInfo[] | null] => {
+): {
+	addedDependencies: DependencyInfo[] | null;
+	removedDependencies: DependencyInfo[] | null;
+} | null => {
 	let addedDependencies: DependencyInfo[] | null = null;
 	let removedDependencies: DependencyInfo[] | null = null;
 
@@ -268,6 +269,6 @@ export const diffDependencies = (
 	}
 
 	return addedDependencies !== null || removedDependencies !== null
-		? [addedDependencies, removedDependencies]
+		? {addedDependencies, removedDependencies}
 		: null;
 };

--- a/src/build/sourceFile.ts
+++ b/src/build/sourceFile.ts
@@ -56,6 +56,7 @@ export interface BaseBuildableFile {
 	readonly buildFiles: Map<BuildConfig, readonly BuildFile[]>;
 	readonly buildConfigs: Set<BuildConfig>;
 	readonly isInputToBuildConfigs: null | Set<BuildConfig>;
+	readonly dependencies: Map<BuildConfig, Set<string>>; // `dependencies` are source file ids that this one imports or otherwise depends on (they may point to nonexistent files!)
 	readonly dependents: Map<BuildConfig, Set<BuildableSourceFile>>; // `dependents` are other buildable source files that import or otherwise depend on this one
 }
 export interface NonBuildableTextSourceFile extends TextSourceFile, BaseNonBuildableFile {}
@@ -66,6 +67,7 @@ export interface BaseNonBuildableFile {
 	readonly buildFiles: null;
 	readonly buildConfigs: null;
 	readonly isInputToBuildConfigs: null;
+	readonly dependencies: null;
 	readonly dependents: null;
 }
 
@@ -105,6 +107,7 @@ export const createSourceFile = async (
 			buildable: true,
 			buildConfigs: new Set(),
 			isInputToBuildConfigs: null,
+			dependencies: new Map(),
 			dependents: new Map(),
 			id,
 			filename,
@@ -132,6 +135,7 @@ export const createSourceFile = async (
 						sourceType: 'text',
 						buildConfigs: new Set(),
 						isInputToBuildConfigs: null,
+						dependencies: new Map(),
 						dependents: new Map(),
 						buildable: true,
 						id,
@@ -153,6 +157,7 @@ export const createSourceFile = async (
 						sourceType: 'text',
 						buildConfigs: null,
 						isInputToBuildConfigs: null,
+						dependencies: null,
 						dependents: null,
 						buildable: false,
 						id,
@@ -176,6 +181,7 @@ export const createSourceFile = async (
 						sourceType: 'binary',
 						buildConfigs: new Set(),
 						isInputToBuildConfigs: null,
+						dependencies: new Map(),
 						dependents: new Map(),
 						buildable: true,
 						id,
@@ -197,6 +203,7 @@ export const createSourceFile = async (
 						sourceType: 'binary',
 						buildConfigs: null,
 						isInputToBuildConfigs: null,
+						dependencies: null,
 						dependents: null,
 						buildable: false,
 						id,

--- a/src/build/sourceFile.ts
+++ b/src/build/sourceFile.ts
@@ -88,7 +88,7 @@ export const createSourceFile = async (
 			throw new UnreachableError(encoding);
 		}
 		contentsHash = toHash(contentsBuffer!);
-		if (contentsHash === cachedSourceInfo.contentsHash) {
+		if (contentsHash === cachedSourceInfo.data.contentsHash) {
 			reconstructedBuildFiles = await reconstructBuildFiles(cachedSourceInfo, buildConfigs!);
 		}
 	}

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -59,3 +59,30 @@ export const reorder = <T extends Record<K, any>, K extends string | number>(
 	for (const k in obj) result[k] = obj[k];
 	return result;
 };
+
+/*
+
+This `nulls` thing allows easier destructuring of `null`s from potentially error-causing values:
+
+`const {a, b} = maybeUndestructureable() || nulls;`
+
+If `thing()` returns a non-destructureable value, the `|| nulls` ensures `a` and `b` default to `null`.
+
+*/
+export const nulls: {[key: string]: null} = new Proxy(
+	{},
+	{
+		get() {
+			return null;
+		},
+	},
+);
+// sure:
+export const undefineds: {[key: string]: undefined} = new Proxy(
+	{},
+	{
+		get() {
+			return undefined;
+		},
+	},
+);


### PR DESCRIPTION
This adds tracking of source file dependencies. Unknown source files have their `id` inferred and can now be added after the `Filer` starts up.