### PR TITLE
use the target option

### DIFF
--- a/src/build/builder.ts
+++ b/src/build/builder.ts
@@ -18,7 +18,7 @@ export interface BuildResult<TBuild extends Build = Build> {
 }
 export interface BuildOptions {
 	readonly sourceMap: boolean;
-	readonly target: EcmaScriptTarget;
+	readonly target: EcmaScriptTarget; // TODO probably make this overrideable by each build config
 	readonly buildRootDir: string;
 	readonly dev: boolean;
 	readonly externalsDirBasePath: string;

--- a/src/build/externalsBuilder.ts
+++ b/src/build/externalsBuilder.ts
@@ -50,7 +50,7 @@ export const createExternalsBuilder = (opts: InitialOptions = {}): ExternalsBuil
 	const build: ExternalsBuilder['build'] = async (
 		source,
 		buildConfig,
-		{buildRootDir, dev, externalsDirBasePath, sourceMap},
+		{buildRootDir, dev, externalsDirBasePath, sourceMap, target},
 	) => {
 		if (sourceMap) {
 			log.warn('Source maps are not yet supported by the externals builder.');
@@ -69,9 +69,6 @@ export const createExternalsBuilder = (opts: InitialOptions = {}): ExternalsBuil
 		log.info(`bundling externals ${buildConfig.name}: ${gray(source.id)}`);
 
 		// TODO add an external API for customizing the `install` params
-		// TODO where should `target` be customized?
-		// probably on each BuildConfig, and globally in gro.config.ts?
-		const target = 'es2019';
 		// TODO this is legacy stuff that we need to rethink when we handle CSS better
 		const cssCache = createCssCache();
 		// const addPlainCssBuild = cssCache.addCssBuild.bind(null, 'bundle.plain.css');


### PR DESCRIPTION
This fixes an oversight in the externals builder. The `target` - the version of ECMAScript that's output - was already available in the options, and additional overriding per build config will be left to a later commit.