### PR TITLE
move target, sourceMap, and logLevel to the gro config

### DIFF
--- a/src/build/buildSourceDirectory.ts
+++ b/src/build/buildSourceDirectory.ts
@@ -34,6 +34,8 @@ export const buildSourceDirectory = async (
 		sourceDirs: [paths.source],
 		buildConfigs: config.builds,
 		watch: false,
+		target: config.target,
+		sourceMap: config.sourceMap,
 		dev,
 	});
 	timingToCreateFiler();

--- a/src/compile.task.ts
+++ b/src/compile.task.ts
@@ -1,12 +1,15 @@
 import {Task} from './task/task.js';
 import {buildSourceDirectory} from './build/buildSourceDirectory.js';
 import {loadGroConfig} from './config/config.js';
+import {configureLogLevel} from './utils/log.js';
 
 export const task: Task = {
 	description: 'compiles all files to the build directory',
 	run: async ({log}) => {
 		// TODO how to do this?
 		const dev = process.env.NODE_ENV !== 'production';
-		await buildSourceDirectory(await loadGroConfig(), dev, log);
+		const config = await loadGroConfig();
+		configureLogLevel(config.logLevel);
+		await buildSourceDirectory(config, dev, log);
 	},
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -10,6 +10,7 @@ import {magenta} from '../colors/terminal.js';
 import {importTs} from '../fs/importTs.js';
 import {pathExists} from '../fs/nodeFs.js';
 import {DEFAULT_BUILD_CONFIG} from './defaultBuildConfig.js';
+import {DEFAULT_ECMA_SCRIPT_TARGET, EcmaScriptTarget} from '../build/tsBuildHelpers.js';
 
 /*
 
@@ -35,12 +36,16 @@ const FALLBACK_CONFIG_BUILD_BASE_PATH = 'config/gro.config.default.js';
 
 export interface GroConfig {
 	readonly builds: BuildConfig[];
+	readonly target: EcmaScriptTarget;
+	readonly sourceMap: boolean;
 	readonly primaryNodeBuildConfig: BuildConfig;
 	readonly primaryBrowserBuildConfig: BuildConfig | null;
 }
 
 export interface PartialGroConfig {
 	readonly builds: PartialBuildConfig[];
+	readonly target?: EcmaScriptTarget;
+	readonly sourceMap?: boolean;
 }
 
 export interface GroConfigModule {
@@ -178,6 +183,8 @@ const normalizeConfig = (config: PartialGroConfig): GroConfig => {
 	return {
 		...config,
 		builds: buildConfigs,
+		target: config.target || DEFAULT_ECMA_SCRIPT_TARGET,
+		sourceMap: process.env.NODE_ENV !== 'production', // TODO hmm where does this come from?
 		primaryNodeBuildConfig,
 		primaryBrowserBuildConfig,
 	};

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,12 +5,13 @@ import {
 	PartialBuildConfig,
 	validateBuildConfigs,
 } from './buildConfig.js';
-import {Logger, SystemLogger} from '../utils/log.js';
+import {Logger, LogLevel, SystemLogger} from '../utils/log.js';
 import {magenta} from '../colors/terminal.js';
 import {importTs} from '../fs/importTs.js';
 import {pathExists} from '../fs/nodeFs.js';
 import {DEFAULT_BUILD_CONFIG} from './defaultBuildConfig.js';
 import {DEFAULT_ECMA_SCRIPT_TARGET, EcmaScriptTarget} from '../build/tsBuildHelpers.js';
+import {omitUndefined} from '../utils/object.js';
 
 /*
 
@@ -38,6 +39,7 @@ export interface GroConfig {
 	readonly builds: BuildConfig[];
 	readonly target: EcmaScriptTarget;
 	readonly sourceMap: boolean;
+	readonly logLevel: LogLevel;
 	readonly primaryNodeBuildConfig: BuildConfig;
 	readonly primaryBrowserBuildConfig: BuildConfig | null;
 }
@@ -46,6 +48,7 @@ export interface PartialGroConfig {
 	readonly builds: PartialBuildConfig[];
 	readonly target?: EcmaScriptTarget;
 	readonly sourceMap?: boolean;
+	readonly logLevel?: LogLevel;
 }
 
 export interface GroConfigModule {
@@ -181,10 +184,11 @@ const normalizeConfig = (config: PartialGroConfig): GroConfig => {
 	const primaryBrowserBuildConfig =
 		buildConfigs.find((b) => b.primary && b.platform === 'browser') || null;
 	return {
-		...config,
+		sourceMap: process.env.NODE_ENV !== 'production', // TODO hmm where does this come from?
+		logLevel: LogLevel.Info,
+		...omitUndefined(config),
 		builds: buildConfigs,
 		target: config.target || DEFAULT_ECMA_SCRIPT_TARGET,
-		sourceMap: process.env.NODE_ENV !== 'production', // TODO hmm where does this come from?
 		primaryNodeBuildConfig,
 		primaryBrowserBuildConfig,
 	};

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -4,11 +4,13 @@ import {createDevServer} from './devServer/devServer.js';
 import {createDefaultBuilder} from './build/defaultBuilder.js';
 import {paths, toBuildOutPath} from './paths.js';
 import {loadGroConfig} from './config/config.js';
+import {configureLogLevel} from './utils/log.js';
 
 export const task: Task = {
 	description: 'start development server',
 	run: async (): Promise<void> => {
 		const config = await loadGroConfig();
+		configureLogLevel(config.logLevel);
 		// TODO should this be `findServedBuildConfig`? or should this be a property on the config itself?
 		// maybe that gets added by a normalization step?
 		const buildConfigToServe = config.primaryBrowserBuildConfig ?? config.primaryNodeBuildConfig;

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -3,31 +3,24 @@ import {Filer} from './build/Filer.js';
 import {createDevServer} from './devServer/devServer.js';
 import {createDefaultBuilder} from './build/defaultBuilder.js';
 import {paths, toBuildOutPath} from './paths.js';
-import {loadTsconfig, toEcmaScriptTarget} from './build/tsBuildHelpers.js';
 import {loadGroConfig} from './config/config.js';
 
 export const task: Task = {
 	description: 'start development server',
-	run: async ({log}): Promise<void> => {
+	run: async (): Promise<void> => {
 		const config = await loadGroConfig();
 		// TODO should this be `findServedBuildConfig`? or should this be a property on the config itself?
 		// maybe that gets added by a normalization step?
 		const buildConfigToServe = config.primaryBrowserBuildConfig ?? config.primaryNodeBuildConfig;
 		const buildOutDirToServe = toBuildOutPath(true, buildConfigToServe.name, '');
 
-		// TODO probably replace these with the Gro config values
-		// maybe the default config reads these from tsconfig?
-		const tsconfig = loadTsconfig(log);
-		const target = toEcmaScriptTarget(tsconfig.compilerOptions?.target);
-		const sourceMap = tsconfig.compilerOptions?.sourceMap ?? true;
-
 		const filer = new Filer({
 			builder: createDefaultBuilder(),
 			sourceDirs: [paths.source],
 			servedDirs: [buildOutDirToServe],
 			buildConfigs: config.builds,
-			target,
-			sourceMap,
+			target: config.target,
+			sourceMap: config.sourceMap,
 		});
 
 		const devServer = createDevServer({filer});

--- a/src/dist.task.ts
+++ b/src/dist.task.ts
@@ -5,6 +5,7 @@ import {isTestBuildFile, isTestBuildArtifact} from './oki/testModule.js';
 import {printPath} from './utils/print.js';
 import {cleanDist} from './project/clean.js';
 import {loadGroConfig} from './config/config.js';
+import {configureLogLevel} from './utils/log.js';
 
 export const isDistFile = (path: string): boolean =>
 	!isTestBuildFile(path) && !isTestBuildArtifact(path);
@@ -18,6 +19,7 @@ export const task: Task = {
 		// See the docs at `./docs/config.md`.
 		const dev = process.env.NODE_ENV !== 'production';
 		const config = await loadGroConfig();
+		configureLogLevel(config.logLevel);
 		const buildConfigsForDist = config.builds.filter((b) => b.dist);
 		await Promise.all(
 			buildConfigsForDist.map((buildConfig) => {

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -2,6 +2,7 @@ import {createFilter} from '@rollup/pluginutils';
 // import {createDirectoryFilter} from './build/utils.js';
 
 import {GroConfigCreator, PartialGroConfig} from './config/config.js';
+import {LogLevel} from './utils/log.js';
 
 // This is the config for the Gro project itself.
 // The default config for dependent projects is located at `./config/gro.config.default.ts`.
@@ -24,8 +25,8 @@ const createConfig: GroConfigCreator = async () => {
 				// input: createDirectoryFilter('frontend'),
 			},
 		],
+		logLevel: LogLevel.Trace,
 	};
-
 	return config;
 };
 

--- a/src/project/dev.task.ts
+++ b/src/project/dev.task.ts
@@ -6,6 +6,7 @@ import {createDefaultBuilder} from '../build/defaultBuilder.js';
 import {paths, toBuildOutPath} from '../paths.js';
 import {createDevServer} from '../devServer/devServer.js';
 import {loadGroConfig} from '../config/config.js';
+import {configureLogLevel} from '../utils/log.js';
 
 export const task: Task = {
 	description: 'build typescript in watch mode for development',
@@ -14,6 +15,7 @@ export const task: Task = {
 
 		const timingToLoadConfig = timings.start('load config');
 		const config = await loadGroConfig();
+		configureLogLevel(config.logLevel);
 		timingToLoadConfig();
 
 		const timingToCreateFiler = timings.start('create filer');

--- a/src/project/dev.task.ts
+++ b/src/project/dev.task.ts
@@ -5,7 +5,6 @@ import {Timings} from '../utils/time.js';
 import {createDefaultBuilder} from '../build/defaultBuilder.js';
 import {paths, toBuildOutPath} from '../paths.js';
 import {createDevServer} from '../devServer/devServer.js';
-import {loadTsconfig, toEcmaScriptTarget} from '../build/tsBuildHelpers.js';
 import {loadGroConfig} from '../config/config.js';
 
 export const task: Task = {
@@ -17,14 +16,6 @@ export const task: Task = {
 		const config = await loadGroConfig();
 		timingToLoadConfig();
 
-		// TODO probably replace these with the Gro config values
-		// see the `src/dev.task.ts` for the same thing
-		const timingToLoadTsconfig = timings.start('load tsconfig');
-		const tsconfig = loadTsconfig(log);
-		const target = toEcmaScriptTarget(tsconfig.compilerOptions?.target);
-		const sourceMap = tsconfig.compilerOptions?.sourceMap ?? true;
-		timingToLoadTsconfig();
-
 		const timingToCreateFiler = timings.start('create filer');
 		const filer = new Filer({
 			builder: createDefaultBuilder(),
@@ -34,8 +25,8 @@ export const task: Task = {
 				toBuildOutPath(true, 'browser', ''),
 			],
 			buildConfigs: config.builds,
-			sourceMap,
-			target,
+			target: config.target,
+			sourceMap: config.sourceMap,
 		});
 		timingToCreateFiler();
 

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -1,6 +1,6 @@
 import {magenta, cyan, red, gray} from '../colors/terminal.js';
 import {Args} from '../cli/types';
-import {SystemLogger, Logger} from '../utils/log.js';
+import {SystemLogger, Logger, configureLogLevel} from '../utils/log.js';
 import {runTask} from './runTask.js';
 import {createStopwatch, Timings} from '../utils/time.js';
 import {printMs, printPath, printPathOrGroPath, printTiming} from '../utils/print.js';
@@ -84,6 +84,7 @@ export const invokeTask = async (taskName: string, args: Args): Promise<void> =>
 				log.info('building project to run task');
 				const timingToLoadConfig = timings.start('load config');
 				const config = await loadGroConfig();
+				configureLogLevel(config.logLevel);
 				timingToLoadConfig();
 				const timingToBuildProject = timings.start('build project');
 				await buildSourceDirectory(config, true, log);

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -101,7 +101,7 @@ export class Logger {
 		this.state.log('\n');
 	}
 
-	// These properties can be mutated at runtime
+	// These properties can be mutated at runtime (see `configureLog`)
 	// to affect all loggers instantiated with the default `state`.
 	// See the comment on `LoggerState` for more.
 	static level = LogLevel.Trace;
@@ -160,3 +160,16 @@ export class SystemLogger extends Logger {
 		super(prefixes, suffixes, state);
 	}
 }
+
+export const configureLogLevel = (
+	level: LogLevel,
+	configureMainLogger = true,
+	configureSystemLogger = true,
+): void => {
+	if (configureMainLogger) {
+		Logger.level = level;
+	}
+	if (configureSystemLogger) {
+		SystemLogger.level = level;
+	}
+};


### PR DESCRIPTION
This moves three variables from random bits of code to the Gro config, the ECMAScript `target`, boolean `sourceMap`, and `LogLevel` `logLevel` for the main and Gro system loggers. These new options are not required - pass `undefined` to get their default values, or just omit them from config objects.