### PR TITLE
add 304 caching with etags

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,8 @@
   ([#70](https://github.com/feltcoop/gro/pull/70))
 - replace deep equality helpers with `dequal`
   ([#73](https://github.com/feltcoop/gro/pull/73))
+- add server caching
+  ([#77](https://github.com/feltcoop/gro/pull/77))
 
 ## 0.4.0
 

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -208,9 +208,10 @@ export class Filer implements BuildContext {
 		const {files} = this;
 		for (const servedDir of this.servedDirs) {
 			const id = `${servedDir.servedAt}/${path}`;
-			this.log.trace(`findByPath: checking: ${id}`);
 			const file = files.get(id);
-			if (file !== undefined) {
+			if (file === undefined) {
+				this.log.trace(`findByPath: miss: ${id}`);
+			} else {
 				this.log.trace(`findByPath: found: ${id}`);
 				return file;
 			}
@@ -1195,6 +1196,9 @@ const createFilerDirs = (
 		// it's already in the Filer's memory cache and does not need to be loaded as a directory.
 		// Additionally, the same is true for `servedDir`s that are inside other `servedDir`s.
 		if (
+			// TODO I think these are bugged with trailing slashes -
+			// note the `servedDir.dir` of `servedDir.dir.startsWith` could also not have a trailing slash!
+			// so I think you add `{dir} + '/'` to both?
 			!sourceDirs.find((d) => servedDir.dir.startsWith(d)) &&
 			!servedDirs.find((d) => d !== servedDir && servedDir.dir.startsWith(d.dir)) &&
 			!servedDir.dir.startsWith(buildRootDir)

--- a/src/devServer/devServer.ts
+++ b/src/devServer/devServer.ts
@@ -37,7 +37,7 @@ export interface Options {
 }
 export type RequiredOptions = 'filer';
 export type InitialOptions = PartialExcept<Options, RequiredOptions>;
-const DEFAULT_HOST = 'localhost'; // or 0.0.0.0?
+const DEFAULT_HOST = 'localhost';
 const DEFAULT_PORT = 8999;
 export const initOptions = (opts: InitialOptions): Options => ({
 	host: DEFAULT_HOST,
@@ -104,7 +104,9 @@ const createRequestListener = (filer: Filer, log: Logger): RequestListener => {
 			log.info(`${yellow('404')} ${red(localPath)}`);
 			return send404(req, res);
 		}
-		if (req.headers['if-none-match'] === toETag(file)) {
+		// console.log('req headers', gray(file.id), req.headers);
+		const etag = req.headers['if-none-match'];
+		if (etag && etag === toETag(file)) {
 			log.info(`${yellow('304')} ${gray(localPath)}`);
 			return send304(res);
 		}
@@ -148,13 +150,21 @@ const send200 = async (_req: IncomingMessage, res: ServerResponse, file: BaseFil
 				? `${mimeType}; charset=utf-8`
 				: mimeType,
 		'Content-Length': stats.size,
+		// TODO this works but not for source maps.
+		// not sure why. browser isn't returning the 'if-modified-since' header
 		ETag: toETag(file),
-		// TODO ?
-		'Cache-Control': 'must-revalidate',
-		// 'Cache-Control': 'no-cache',
-		// 'Cache-Control': 'max-age=31536000',
+
+		// TODO any of these helpful?
 		// 'Last-Modified': stats.mtime.toUTCString(),
+		// 'Cache-Control': 'no-cache,must-revalidate',
+		// 'Cache-Control': 'must-revalidate',
+
+		// TODO probably support various types of resource caching,
+		// especially if we output files with contents hashes.
+		// 'Cache-Control': 'immutable',
+		// 'Cache-Control': 'max-age=31536000',
 	};
+	// console.log('res headers', gray(file.id), headers);
 	res.writeHead(200, headers);
 	res.end(getFileContentsBuffer(file));
 };

--- a/src/fs/mime.test.ts
+++ b/src/fs/mime.test.ts
@@ -18,7 +18,7 @@ test('getMimeTypeByExtension()', () => {
 
 test('getExtensionsByMimeType()', () => {
 	t.equal(getExtensionsByMimeType('text/plain'), ['txt', 'log']);
-	t.equal(getExtensionsByMimeType('application/json'), ['json']);
+	t.equal(getExtensionsByMimeType('application/json'), ['json', 'map']);
 	t.equal(getExtensionsByMimeType('text/javascript'), ['js', 'mjs']);
 	t.equal(getExtensionsByMimeType('fake/test-type'), null);
 });

--- a/src/fs/mime.ts
+++ b/src/fs/mime.ts
@@ -56,7 +56,7 @@ export const removeMimeTypeExtension = (extension: string): boolean => {
 (() => {
 	const types: [string, string[]][] = [
 		// Since 'application/octet-stream' is the default, we don't include it.
-		['application/json', ['json']],
+		['application/json', ['json', 'map']],
 		['application/schema+json', ['json']],
 		['application/schema-instance+json', ['json']],
 		['application/ld+json', ['jsonld']],


### PR DESCRIPTION
This adds content-based caching to the dev server using [ETags](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) and the contents hash functionality the `Filer` already provided.

I'm not sure what the best header values are here, like for `'Cache-Control'`. I left some comments for followup investigation - nothing blocking. I'm testing in Firefox and Chrome, and currently, things look correct except Chrome is not sending the `'if-none-match'` header for `.map` source map files, so those are always returning a 200 instead of 304 right now. Can't find anything to fix that in a brief search - they're always being requested with "no-cache" header values. Works in Firefox.