### PR TITLE
lazy load modules to speed up normal invoke task case

### DIFF
--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -5,7 +5,6 @@ import {findTestModules} from './oki/testModule.js';
 export const task: Task = {
 	description: 'check that everything is ready to commit',
 	run: async ({log, args, invokeTask}) => {
-		await invokeTask('clean');
 		await invokeTask('typecheck');
 
 		// Run tests only if the the project has some.

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -22,8 +22,6 @@ import {plural} from '../utils/string.js';
 import {loadTaskModule} from './taskModule.js';
 import {loadGroPackageJson} from '../project/packageJson.js';
 import {DEFAULT_BUILD_CONFIG_NAME} from '../config/defaultBuildConfig.js';
-import {buildSourceDirectory} from '../build/buildSourceDirectory.js';
-import {loadGroConfig} from '../config/config.js';
 
 /*
 
@@ -83,10 +81,12 @@ export const invokeTask = async (taskName: string, args: Args): Promise<void> =>
 				// every time a task is invoked.
 				log.info('building project to run task');
 				const timingToLoadConfig = timings.start('load config');
+				const {loadGroConfig} = await import('../config/config.js');
 				const config = await loadGroConfig();
 				configureLogLevel(config.logLevel);
 				timingToLoadConfig();
 				const timingToBuildProject = timings.start('build project');
+				const {buildSourceDirectory} = await import('../build/buildSourceDirectory.js');
 				await buildSourceDirectory(config, true, log);
 				timingToBuildProject();
 			}


### PR DESCRIPTION
This dramatically improves Gro CLI startup time for most usage. The changes are trivial, too, and have no real downsides. I've been thinking there could be gains here since I implemented this code originally - code to lazy-build a Gro project's tasks - but I didn't think the gains would be this big. Makes me wonder how much of the remaining 0.15-0.2s we could shave off. I know that's an eternity in Real CLI land, but for Node/TypeScript I'm alright with that overhead. Or at least, it's not keeping me up tonight - I might get inspired to look for more gains.

`$ time gro project/echo hey`

before:

```
gro project/echo hey 0.58s user 0.08s system 118% cpu 0.557 total
gro project/echo hey 0.66s user 0.04s system 127% cpu 0.554 total
gro project/echo hey 0.60s user 0.07s system 119% cpu 0.560 total
gro project/echo hey 0.58s user 0.08s system 120% cpu 0.545 total
gro project/echo hey 0.64s user 0.06s system 125% cpu 0.558 total
gro project/echo hey 0.63s user 0.05s system 121% cpu 0.564 total
gro project/echo hey 0.67s user 0.05s system 125% cpu 0.575 total
gro project/echo hey 0.65s user 0.01s system 118% cpu 0.554 total
gro project/echo hey 0.54s user 0.10s system 119% cpu 0.535 total
gro project/echo hey 0.62s user 0.05s system 120% cpu 0.557 total
```

after:

```
gro project/echo hey 0.16s user 0.03s system 134% cpu 0.137 total
gro project/echo hey 0.18s user 0.01s system 137% cpu 0.135 total
gro project/echo hey 0.17s user 0.02s system 136% cpu 0.136 total
gro project/echo hey 0.19s user 0.00s system 137% cpu 0.137 total
gro project/echo hey 0.15s user 0.04s system 136% cpu 0.135 total
gro project/echo hey 0.16s user 0.02s system 137% cpu 0.136 total
gro project/echo hey 0.17s user 0.04s system 145% cpu 0.144 total
gro project/echo hey 0.18s user 0.01s system 135% cpu 0.140 total
gro project/echo hey 0.18s user 0.01s system 135% cpu 0.137 total
gro project/echo hey 0.17s user 0.01s system 134% cpu 0.136 total
```