### PR TITLE
document and rename the serve config property

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,8 @@
 - add support for a config file at `src/gro.config.ts` for custom builds
   ([#67](https://github.com/feltcoop/gro/pull/67),
   [#68](https://github.com/feltcoop/gro/pull/68),
-  [#82](https://github.com/feltcoop/gro/pull/82))
+  [#82](https://github.com/feltcoop/gro/pull/82),
+  [#83](https://github.com/feltcoop/gro/pull/83))
 - add `Filer` to replace `CachingCompiler` with additional filesystem capabilities
   ([#54](https://github.com/feltcoop/gro/pull/54),
   [#55](https://github.com/feltcoop/gro/pull/55),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -41,7 +41,7 @@ export interface GroConfig {
 	readonly target: EcmaScriptTarget;
 	readonly sourceMap: boolean;
 	readonly logLevel: LogLevel;
-	readonly servedDirs?: ServedDirPartial[];
+	readonly serve?: ServedDirPartial[];
 	readonly primaryNodeBuildConfig: BuildConfig;
 	readonly primaryBrowserBuildConfig: BuildConfig | null;
 }
@@ -51,7 +51,7 @@ export interface PartialGroConfig {
 	readonly target?: EcmaScriptTarget;
 	readonly sourceMap?: boolean;
 	readonly logLevel?: LogLevel;
-	readonly servedDirs?: ServedDirPartial[];
+	readonly serve?: ServedDirPartial[];
 }
 
 export interface GroConfigModule {

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -23,7 +23,7 @@ export const task: Task = {
 		const filer = new Filer({
 			builder: await createDefaultBuilder(),
 			sourceDirs: [paths.source],
-			servedDirs: config.servedDirs || getDefaultServedDirs(config),
+			servedDirs: config.serve || getDefaultServedDirs(config),
 			buildConfigs: config.builds,
 			target: config.target,
 			sourceMap: config.sourceMap,

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -113,4 +113,34 @@ export default createConfig;
 
 Here's [Gro's own internal config](/src/gro.config.ts) and
 here's [the default config](/src/config/gro.config.default.ts)
-that's used for projects that do not define one.
+that's used for projects that do not define one at `src/gro.config.ts`.
+
+Config files allow projects to define a [`PartialGroConfig`](/src/gro.config.ts)
+to customize things when conventions aren't enough:
+
+```ts
+export interface PartialGroConfig {
+	readonly builds: PartialBuildConfig[];
+	readonly target?: EcmaScriptTarget;
+	readonly sourceMap?: boolean;
+	readonly logLevel?: LogLevel;
+	readonly serve?: ServedDirPartial[];
+}
+```
+
+[Gro's internal config](/src/gro.config.ts) uses the `serve` property
+to serve the contents of both `src/` and `src/client/` off of the root directory.
+
+```ts
+serve: [toBuildOutPath(true, 'browser', 'client'), toBuildOutPath(true, 'browser', '')],
+```
+
+An optional `servedAt` property can be paired with the directories passed to `serve`:
+
+```ts
+serve: [
+	{dir: '/some/path', servedAt: '/some'},
+	'/a', // is the same as:
+	{dir: '/a'},
+];
+```

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -15,67 +15,6 @@ If a project does not define a config, Gro imports a default config from
 
 See [`src/config/config.ts`](/src/config/config.ts) for the config types and implementation.
 
-## build config
-
-The `builds` property of the Gro config
-is an array of build configs that describe a project's outputs.
-Here's the [`PartialBuildConfig`](/src/config/buildConfig.ts) type,
-which is the user-facing version of the [`BuildConfig`](/src/config/buildConfig.ts):
-
-```ts
-export interface PartialBuildConfig {
-	readonly name: string;
-	readonly platform: PlatformTarget; // 'node' | 'browser'
-	readonly input: BuildConfigInput | BuildConfigInput[];
-	readonly dist?: boolean;
-	readonly primary?: boolean;
-}
-```
-
-The `name` field can be anything and maps to the build's output directory name.
-By defining `"name": "foo",`, running `gro dev`/`gro compile` or `gro build` creates builds
-in `.gro/dev/foo/` and `.gro/prod/foo/`, respectively.
-
-> Importantly, **Gro requires a Node build named `"node"`**
-> that it uses to run things like tests, tasks, and codegen.
-> It must be the primary Node build.
-> Ideally this would be configurable, but doing so would slow Gro down in many cases.
-
-The `platform` can currently be `"node"` or `"browser"` and
-is used by Gro's default builders to customize the output.
-When compiling for the browser, dependencies in `node_modules/` are imported via Snowpack's
-[`esinstall`](https://github.com/snowpackjs/snowpack/tree/master/esinstall).
-When compiling for Node, the Svelte compiler outputs
-[SSR components](https://svelte.dev/docs#Server-side_component_API)
-instead of the normal DOM ones.
-
-The `input` field specifies the source code entry points for the build.
-Each input must be a file path (absolute or relative to `src/`),
-or a filter function with the signature `(id: string) => boolean`.
-To define filters, it's convenient to use the
-[`createFilter` helper](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createFilter)
-from `@rollup/pluginutils` and
-Gro's own [`createDirectoryFilter` helper](../build/utils.ts).
-
-The optional `dist` flag marks builds for inclusion in the root `dist/` directory
-by [the `gro dist` task](/src/dist.task.ts).
-If no `dist` flag is found on any builds, all builds are included.
-If multiple builds are found, the `gro dist` task copies their directories into `dist/`,
-named according to the `name` build config field.
-If one build is found, its contents are put directly into `dist/` with no directory namespacing.
-Like all builtin tasks, you can easily customize this behavior
-by creating `src/dist.task.ts` in your project and optionally
-[invoking the original task](/src/task#run-a-task-inside-another-task).
-
-The optional `primary` flag tells Gro which build of each platform
-should be used when doing something that needs exactly one build.
-For Node builds, this includes things like running tasks, tests, codegen,
-and other Node-related development concerns.
-For browser builds, this is the build that's served by the development server.
-As mentioned above, the `primary` Node build is always named `"node"`.
-For other platforms, if no `primary` flag exists on any build,
-Gro marks the first build in the `builds` array as primary.
-
 ## examples
 
 Here's a config for a simple Node project:
@@ -143,3 +82,64 @@ serve: [
 	{dir: '/a'},
 ];
 ```
+
+## build config
+
+The `builds` property of the Gro config
+is an array of build configs that describe a project's outputs.
+Here's the [`PartialBuildConfig`](/src/config/buildConfig.ts) type,
+which is the user-facing version of the [`BuildConfig`](/src/config/buildConfig.ts):
+
+```ts
+export interface PartialBuildConfig {
+	readonly name: string;
+	readonly platform: PlatformTarget; // 'node' | 'browser'
+	readonly input: BuildConfigInput | BuildConfigInput[];
+	readonly dist?: boolean;
+	readonly primary?: boolean;
+}
+```
+
+The `name` field can be anything and maps to the build's output directory name.
+By defining `"name": "foo",`, running `gro dev`/`gro compile` or `gro build` creates builds
+in `.gro/dev/foo/` and `.gro/prod/foo/`, respectively.
+
+> Importantly, **Gro requires a Node build named `"node"`**
+> that it uses to run things like tests, tasks, and codegen.
+> It must be the primary Node build.
+> Ideally this would be configurable, but doing so would slow Gro down in many cases.
+
+The `platform` can currently be `"node"` or `"browser"` and
+is used by Gro's default builders to customize the output.
+When compiling for the browser, dependencies in `node_modules/` are imported via Snowpack's
+[`esinstall`](https://github.com/snowpackjs/snowpack/tree/master/esinstall).
+When compiling for Node, the Svelte compiler outputs
+[SSR components](https://svelte.dev/docs#Server-side_component_API)
+instead of the normal DOM ones.
+
+The `input` field specifies the source code entry points for the build.
+Each input must be a file path (absolute or relative to `src/`),
+or a filter function with the signature `(id: string) => boolean`.
+To define filters, it's convenient to use the
+[`createFilter` helper](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createFilter)
+from `@rollup/pluginutils` and
+Gro's own [`createDirectoryFilter` helper](../build/utils.ts).
+
+The optional `dist` flag marks builds for inclusion in the root `dist/` directory
+by [the `gro dist` task](/src/dist.task.ts).
+If no `dist` flag is found on any builds, all builds are included.
+If multiple builds are found, the `gro dist` task copies their directories into `dist/`,
+named according to the `name` build config field.
+If one build is found, its contents are put directly into `dist/` with no directory namespacing.
+Like all builtin tasks, you can easily customize this behavior
+by creating `src/dist.task.ts` in your project and optionally
+[invoking the original task](/src/task#run-a-task-inside-another-task).
+
+The optional `primary` flag tells Gro which build of each platform
+should be used when doing something that needs exactly one build.
+For Node builds, this includes things like running tasks, tests, codegen,
+and other Node-related development concerns.
+For browser builds, this is the build that's served by the development server.
+As mentioned above, the `primary` Node build is always named `"node"`.
+For other platforms, if no `primary` flag exists on any build,
+Gro marks the first build in the `builds` array as primary.

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -115,8 +115,7 @@ Here's [Gro's own internal config](/src/gro.config.ts) and
 here's [the default config](/src/config/gro.config.default.ts)
 that's used for projects that do not define one at `src/gro.config.ts`.
 
-Config files allow projects to define a [`PartialGroConfig`](/src/gro.config.ts)
-to customize things when conventions aren't enough:
+The [`PartialGroConfig`](/src/gro.config.ts) is the return value of config files:
 
 ```ts
 export interface PartialGroConfig {

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -76,11 +76,13 @@ serve: [toBuildOutPath(true, 'browser', 'client'), toBuildOutPath(true, 'browser
 An optional `servedAt` property can be paired with the directories passed to `serve`:
 
 ```ts
-serve: [
-	{dir: '/some/path', servedAt: '/some'},
-	'/a', // is the same as:
-	{dir: '/a'},
-];
+config = {
+	serve: [
+		{dir: '/some/path', servedAt: '/some'},
+		'/a', // is the same as:
+		{dir: '/a'},
+	],
+};
 ```
 
 ## build config

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -27,7 +27,7 @@ const createConfig: GroConfigCreator = async () => {
 			},
 		],
 		logLevel: LogLevel.Trace,
-		servedDirs: [toBuildOutPath(true, 'browser', 'client'), toBuildOutPath(true, 'browser', '')],
+		serve: [toBuildOutPath(true, 'browser', 'client'), toBuildOutPath(true, 'browser', '')],
 	};
 	return config;
 };


### PR DESCRIPTION
This adds some documentation about the Gro config.

It also renames the config property `servedDirs` to `serve`, which is a friendlier external name. The precedent for breaking external naming conventions from internal ones was established with `builds` for `buildConfigs` - nobody wants to write `buildConfigs`, we want to write `builds`, but internally in Gro we really prefer to be explicit that these are `BuildConfig`, and not `Build` objects, which are very different.