### PR TITLE
add alias support to externals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,7 +25,8 @@
   ([#61](https://github.com/feltcoop/gro/pull/61),
   [#71](https://github.com/feltcoop/gro/pull/71),
   [#76](https://github.com/feltcoop/gro/pull/76),
-  [#81](https://github.com/feltcoop/gro/pull/81))
+  [#81](https://github.com/feltcoop/gro/pull/81),
+  [#88](https://github.com/feltcoop/gro/pull/88))
 - make `createBuilder` pluggable allowing users to provide a compiler for each file
   ([#57](https://github.com/feltcoop/gro/pull/57))
 - rename `compiler` to `builder`

--- a/package-lock.json
+++ b/package-lock.json
@@ -552,6 +552,11 @@
         "wrappy": "1"
       }
     },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "fs-extra": "^9.0.1",
     "kleur": "^4.1.3",
     "mri": "^1.1.6",
+    "path-browserify": "^1.0.1",
     "prettier": "^2.1.2",
     "prettier-plugin-svelte": "^1.4.0",
     "rollup": "^2.37.1",

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -35,6 +35,8 @@ import {loadContents} from './load.js';
 import {isExternalBrowserModule} from '../utils/module.js';
 import {wrap} from '../utils/async.js';
 import {
+	DEFAULT_EXTERNALS_ALIASES,
+	ExternalsAliases,
 	EXTERNALS_SOURCE_ID,
 	getExternalsBuilderState,
 	getExternalsBuildState,
@@ -64,10 +66,11 @@ export type FilerFile = SourceFile | BuildFile; // TODO or `Directory`?
 export interface Options {
 	dev: boolean;
 	builder: Builder | null;
-	sourceDirs: string[];
-	servedDirs: ServedDir[];
 	buildConfigs: BuildConfig[] | null;
 	buildDir: string;
+	sourceDirs: string[];
+	servedDirs: ServedDir[];
+	externalsAliases: ExternalsAliases;
 	mapDependencyToSourceId: MapDependencyToSourceId;
 	sourceMap: boolean;
 	target: EcmaScriptTarget;
@@ -125,6 +128,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 	return {
 		dev,
 		mapDependencyToSourceId,
+		externalsAliases: DEFAULT_EXTERNALS_ALIASES,
 		sourceMap: true,
 		target: DEFAULT_ECMA_SCRIPT_TARGET,
 		watch: true,
@@ -158,6 +162,7 @@ export class Filer implements BuildContext {
 	readonly sourceMap: boolean;
 	readonly target: EcmaScriptTarget; // TODO shouldn't build configs have this?
 	readonly servedDirs: readonly ServedDir[];
+	readonly externalsAliases: ExternalsAliases; // TODO should this allow aliasing anything? not just externals?
 	readonly state: BuilderState = {};
 	readonly buildingSourceFiles: Set<string> = new Set(); // needed by hacky externals code, used to check if the filer is busy
 
@@ -170,6 +175,7 @@ export class Filer implements BuildContext {
 			mapDependencyToSourceId,
 			sourceDirs,
 			servedDirs,
+			externalsAliases,
 			sourceMap,
 			target,
 			watch,
@@ -180,6 +186,7 @@ export class Filer implements BuildContext {
 		this.buildConfigs = buildConfigs;
 		this.buildDir = buildDir;
 		this.mapDependencyToSourceId = mapDependencyToSourceId;
+		this.externalsAliases = externalsAliases;
 		this.sourceMap = sourceMap;
 		this.target = target;
 		this.log = log;

--- a/src/build/builder.ts
+++ b/src/build/builder.ts
@@ -1,7 +1,11 @@
 import {UnreachableError} from '../utils/error.js';
 import {BuildConfig} from '../config/buildConfig.js';
 import {toBuildOutPath} from '../paths.js';
-import type {ExternalsBuilderState, EXTERNALS_BUILDER_STATE_KEY} from './externalsBuildHelpers.js';
+import type {
+	ExternalsAliases,
+	ExternalsBuilderState,
+	EXTERNALS_BUILDER_STATE_KEY,
+} from './externalsBuildHelpers.js';
 import {EcmaScriptTarget} from './tsBuildHelpers.js';
 import {ServedDir} from './ServedDir.js';
 import {Logger} from '../utils/log.js';
@@ -29,6 +33,7 @@ export interface BuildResult<TBuild extends Build = Build> {
 	builds: TBuild[];
 }
 
+// For docs on these, see where they're implemented in the `Filer`.
 export interface BuildContext {
 	readonly log: Logger;
 	readonly buildDir: string;
@@ -36,6 +41,7 @@ export interface BuildContext {
 	readonly sourceMap: boolean;
 	readonly target: EcmaScriptTarget;
 	readonly servedDirs: readonly ServedDir[];
+	readonly externalsAliases: ExternalsAliases;
 	readonly state: BuilderState;
 	readonly buildingSourceFiles: Set<string>;
 }

--- a/src/build/externalsBuildHelpers.ts
+++ b/src/build/externalsBuildHelpers.ts
@@ -6,6 +6,14 @@ import {gray} from '../colors/terminal.js';
 import {BuildConfig} from '../config/buildConfig.js';
 import {outputFile, pathExists, readJson} from '../fs/nodeFs.js';
 
+// TODO these can currently only be customized by mutating the object
+export interface ExternalsAliasMap {
+	[key: string]: string;
+}
+export const DEFAULT_EXTERNALS_ALIASES: ExternalsAliasMap = {
+	path: 'path-browserify',
+};
+
 export interface ExternalsBuilderState {
 	readonly buildStates: Map<BuildConfig, ExternalsBuildState>;
 }
@@ -99,6 +107,13 @@ export const loadImportMapFromDisk = async (dest: string): Promise<ImportMap | u
 	if (!(await pathExists(importMapPath))) return undefined;
 	const importMap: ImportMap = await readJson(importMapPath);
 	return importMap;
+};
+
+// This is inefficient but it's currently only called after installing externals,
+// so it's whatever the opposite of a hot code path is.
+export const toImportMapSpecifiers = (importMap: ImportMap, alias: ExternalsAliasMap): string[] => {
+	const excludedAliases = new Set(Object.values(alias));
+	return Object.keys(importMap.imports).filter((specifier) => !excludedAliases.has(specifier));
 };
 
 export interface DelayedPromise<T> {

--- a/src/build/externalsBuildHelpers.ts
+++ b/src/build/externalsBuildHelpers.ts
@@ -6,14 +6,6 @@ import {gray} from '../colors/terminal.js';
 import {BuildConfig} from '../config/buildConfig.js';
 import {outputFile, pathExists, readJson} from '../fs/nodeFs.js';
 
-// TODO these can currently only be customized by mutating the object
-export interface ExternalsAliasMap {
-	[key: string]: string;
-}
-export const DEFAULT_EXTERNALS_ALIASES: ExternalsAliasMap = {
-	path: 'path-browserify',
-};
-
 export interface ExternalsBuilderState {
 	readonly buildStates: Map<BuildConfig, ExternalsBuildState>;
 }
@@ -109,11 +101,11 @@ export const loadImportMapFromDisk = async (dest: string): Promise<ImportMap | u
 	return importMap;
 };
 
-// This is inefficient but it's currently only called after installing externals,
-// so it's whatever the opposite of a hot code path is.
-export const toImportMapSpecifiers = (importMap: ImportMap, alias: ExternalsAliasMap): string[] => {
-	const excludedAliases = new Set(Object.values(alias));
-	return Object.keys(importMap.imports).filter((specifier) => !excludedAliases.has(specifier));
+export interface ExternalsAliases {
+	[key: string]: string;
+}
+export const DEFAULT_EXTERNALS_ALIASES: ExternalsAliases = {
+	path: 'path-browserify',
 };
 
 export interface DelayedPromise<T> {

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -14,11 +14,7 @@ import {
 import type {Build, BuildContext, BuildResult, BuildSource, BuildDependency} from './builder.js';
 import {stripStart} from '../utils/string.js';
 import {getIsExternalModule} from '../utils/module.js';
-import {
-	EXTERNALS_SOURCE_ID,
-	isExternalBuildId,
-	DEFAULT_EXTERNALS_ALIASES,
-} from './externalsBuildHelpers.js';
+import {EXTERNALS_SOURCE_ID, isExternalBuildId} from './externalsBuildHelpers.js';
 
 // TODO this is all hacky and should be refactored
 // make it pluggable like builders, maybe
@@ -67,8 +63,8 @@ export const postprocess = (
 				} else if (isExternalImport || source.id === EXTERNALS_SOURCE_ID) {
 					// handle regular externals
 					if (isBrowser) {
-						if (mappedSpecifier in DEFAULT_EXTERNALS_ALIASES) {
-							mappedSpecifier = DEFAULT_EXTERNALS_ALIASES[mappedSpecifier];
+						if (mappedSpecifier in ctx.externalsAliases) {
+							mappedSpecifier = ctx.externalsAliases[mappedSpecifier];
 						}
 						if (mappedSpecifier.endsWith(JS_EXTENSION) && shouldModifyDotJs(mappedSpecifier)) {
 							mappedSpecifier = mappedSpecifier.replace(/\.js$/, 'js');

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -14,7 +14,11 @@ import {
 import type {Build, BuildContext, BuildResult, BuildSource, BuildDependency} from './builder.js';
 import {stripStart} from '../utils/string.js';
 import {getIsExternalModule} from '../utils/module.js';
-import {EXTERNALS_SOURCE_ID, isExternalBuildId} from './externalsBuildHelpers.js';
+import {
+	EXTERNALS_SOURCE_ID,
+	isExternalBuildId,
+	DEFAULT_EXTERNALS_ALIASES,
+} from './externalsBuildHelpers.js';
 
 // TODO this is all hacky and should be refactored
 // make it pluggable like builders, maybe
@@ -63,6 +67,9 @@ export const postprocess = (
 				} else if (isExternalImport || source.id === EXTERNALS_SOURCE_ID) {
 					// handle regular externals
 					if (isBrowser) {
+						if (mappedSpecifier in DEFAULT_EXTERNALS_ALIASES) {
+							mappedSpecifier = DEFAULT_EXTERNALS_ALIASES[mappedSpecifier];
+						}
 						if (mappedSpecifier.endsWith(JS_EXTENSION) && shouldModifyDotJs(mappedSpecifier)) {
 							mappedSpecifier = mappedSpecifier.replace(/\.js$/, 'js');
 						}

--- a/src/client/SourceMetaExpanderItem.svelte
+++ b/src/client/SourceMetaExpanderItem.svelte
@@ -15,7 +15,9 @@
 	$: hovered = sourceMeta === $hoveredSourceMeta;
 	$: selected = sourceMeta === $selectedSourceMeta;
 
-	const onPointerDown = () => {
+	const onPointerDown = (e: PointerEvent) => {
+		// TODO this needs to be done for all of the handlers..
+		if (e.button !== 0) return;
 		$selectedSourceMeta = selected ? null : sourceMeta;
 	};
 	const onPointerEnter = () => {

--- a/src/client/SourceMetaRawItem.svelte
+++ b/src/client/SourceMetaRawItem.svelte
@@ -54,7 +54,7 @@
 		on:pointerleave={onPointerLeave}
 		class:hovering
 	>
-		{expandedText}
+		<span class="icon">{expandedText}</span>
 		<SourceId id={sourceMeta.data.sourceId} />
 	</button>
 </div>
@@ -90,5 +90,9 @@
 	}
 	.deemphasized {
 		opacity: 0.62;
+	}
+	.icon {
+		opacity: 0.6;
+		padding-right: var(--spacing_sm);
 	}
 </style>

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,8 +1,5 @@
 import './devtools.js';
 import App from './App.svelte';
-import * as fp from 'path';
-console.log('fp', fp);
-(window as any).fp = fp;
 
 // TODO remove when we have another import from outside `src/client/`
 import {mix} from '../utils/math.js';

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,8 @@
 import './devtools.js';
 import App from './App.svelte';
+import * as fp from 'path';
+console.log('fp', fp);
+(window as any).fp = fp;
 
 // TODO remove when we have another import from outside `src/client/`
 import {mix} from '../utils/math.js';

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -1,6 +1,6 @@
 *,
-*:before,
-*:after {
+*::before,
+*::after {
 	box-sizing: border-box;
 	margin: 0;
 	overflow-wrap: break-word;

--- a/src/fs/importTs.ts
+++ b/src/fs/importTs.ts
@@ -54,6 +54,7 @@ export const importTs = async (
 		target: DEFAULT_ECMA_SCRIPT_TARGET,
 		// TODO these last two aren't needed, maybe the swc compiler's type should explicitly choose which options it uses?
 		servedDirs: [],
+		externalsAliases: {},
 		state: {},
 		buildingSourceFiles: new Set(),
 	};


### PR DESCRIPTION
This adds alias support for externals. The motivating use case is swapping `path-browserify` for `path` so it works in the browser.