### PR TITLE
add install option to externals builder

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,7 +26,8 @@
   [#71](https://github.com/feltcoop/gro/pull/71),
   [#76](https://github.com/feltcoop/gro/pull/76),
   [#81](https://github.com/feltcoop/gro/pull/81),
-  [#88](https://github.com/feltcoop/gro/pull/88))
+  [#88](https://github.com/feltcoop/gro/pull/88),
+  [#89](https://github.com/feltcoop/gro/pull/89))
 - make `createBuilder` pluggable allowing users to provide a compiler for each file
   ([#57](https://github.com/feltcoop/gro/pull/57))
 - rename `compiler` to `builder`

--- a/src/build/externalsBuilder.ts
+++ b/src/build/externalsBuilder.ts
@@ -1,5 +1,5 @@
 import {basename, dirname, join} from 'path';
-import {install, InstallResult} from 'esinstall';
+import {install as installWithEsinstall, InstallResult} from 'esinstall';
 import {Plugin as RollupPlugin} from 'rollup';
 
 import {Logger, SystemLogger} from '../utils/log.js';
@@ -38,7 +38,7 @@ but this isn't a great solution
 */
 
 export interface Options {
-	install: typeof install;
+	install: typeof installWithEsinstall;
 	basePath: string;
 	log: Logger;
 }
@@ -46,7 +46,7 @@ export type InitialOptions = Partial<Options>;
 export const initOptions = (opts: InitialOptions): Options => {
 	const log = opts.log || new SystemLogger([cyan('[externalsBuilder]')]);
 	return {
-		install,
+		install: installWithEsinstall,
 		basePath: EXTERNALS_BUILD_DIR,
 		...omitUndefined(opts),
 		log,

--- a/src/build/externalsBuilder.ts
+++ b/src/build/externalsBuilder.ts
@@ -38,6 +38,7 @@ but this isn't a great solution
 */
 
 export interface Options {
+	install: typeof install;
 	basePath: string;
 	log: Logger;
 }
@@ -45,6 +46,7 @@ export type InitialOptions = Partial<Options>;
 export const initOptions = (opts: InitialOptions): Options => {
 	const log = opts.log || new SystemLogger([cyan('[externalsBuilder]')]);
 	return {
+		install,
 		basePath: EXTERNALS_BUILD_DIR,
 		...omitUndefined(opts),
 		log,
@@ -56,7 +58,7 @@ type ExternalsBuilder = Builder<TextBuildSource, TextBuild>;
 const encoding = 'utf8';
 
 export const createExternalsBuilder = (opts: InitialOptions = {}): ExternalsBuilder => {
-	const {basePath, log} = initOptions(opts);
+	const {install, basePath, log} = initOptions(opts);
 
 	const build: ExternalsBuilder['build'] = async (
 		source,
@@ -80,7 +82,6 @@ export const createExternalsBuilder = (opts: InitialOptions = {}): ExternalsBuil
 
 		log.info(`bundling externals ${printBuildConfig(buildConfig)}: ${gray(source.id)}`);
 
-		// TODO add an external API for customizing the `install` params
 		// TODO this is legacy stuff that we need to rethink when we handle CSS better
 		const cssCache = createCssCache();
 		// const addPlainCssBuild = cssCache.addCssBuild.bind(null, 'bundle.plain.css');


### PR DESCRIPTION
This lets users provide an optional `install` function to the externals builder. The idea is to give defer full control if the user code wants it, but provide the default. Users can now intercept the install arguments before forwarding them, or call a custom `install` function, or whatever.