### PR TITLE
add ui system

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,7 +37,8 @@
 - add a basic client to view project data
   ([#86](https://github.com/feltcoop/gro/pull/86),
   [#87](https://github.com/feltcoop/gro/pull/87),
-  [#90](https://github.com/feltcoop/gro/pull/90))
+  [#90](https://github.com/feltcoop/gro/pull/90),
+  [#91](https://github.com/feltcoop/gro/pull/91))
 - add server caching
   ([#77](https://github.com/feltcoop/gro/pull/77))
 

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -17,12 +17,31 @@
 	import SourceMetaBuildTreeExplorer from './SourceMetaBuildTreeExplorer.svelte';
 	import SourceMetaTreeExplorer from './SourceMetaTreeExplorer.svelte';
 	import SourceMetaTreeExplorers from './SourceMetaTreeExplorers.svelte';
+	import MarkupView from '../ui/MarkupView.svelte';
+	import {MarkupNode} from '../ui/markup.js';
 	import {createSourceTree, SourceTree} from './sourceTree.js';
 	import type {ProjectState} from '../server/projectState.js';
 	import type {View} from './view.js';
 	import {provideProjectState} from './projectState.js';
 
 	console.log('enter App.svelte');
+
+	let id = 0;
+	const markupNode: MarkupNode = {
+		type: 'Block',
+		id: id++,
+		children: [
+			{type: 'Text', id: id++, content: 'hey~!'},
+			{
+				type: 'Block',
+				id: id++,
+				children: [
+					{type: 'Text', id: id++, content: 'check it out, a language!'},
+					{type: 'Text', id: id++, content: 'wow'},
+				],
+			},
+		],
+	};
 
 	$: homepage = ($ctx?.packageJson.homepage || '') as string;
 	let sourceTree: SourceTree;
@@ -109,6 +128,8 @@
 				</nav>
 			</header>
 		</section>
+
+		<MarkupView node={markupNode} />
 
 		{#if showFilerVisualizer1}
 			<section transition:slide>

--- a/src/ui/MarkupView.svelte
+++ b/src/ui/MarkupView.svelte
@@ -1,0 +1,20 @@
+<script type="ts">
+	import {MarkupNode} from './markup.js';
+
+	export let node: MarkupNode;
+
+	// This currently renders nodes generically based on the available properties,
+	// with no regard for the type or if the combination of properties makes sense.
+	// We may need to change this strategy in the future to support certain features.
+</script>
+
+<div class="markup-{node.type}">
+	{#if node.content !== undefined}
+		<p>{node.content}</p>
+	{/if}
+	{#if node.children}
+		{#each node.children as child (child.id)}
+			<svelte:self node={child} />
+		{/each}
+	{/if}
+</div>

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -1,0 +1,3 @@
+# ui
+
+> what if we grew our UIs from tiny seeds? and then shared them and cared for them?

--- a/src/ui/markup.ts
+++ b/src/ui/markup.ts
@@ -1,0 +1,19 @@
+export interface BaseMarkupNode {
+	type: string;
+	id: number; // TODO
+	// optional properties that any node type can have - trying to stick close to Activity Streams
+	children?: BaseMarkupNode[];
+	content?: string;
+}
+
+export type MarkupNode = MarkupBlockNode | MarkupTextNode;
+
+export interface MarkupBlockNode extends BaseMarkupNode {
+	type: 'Block';
+	children: MarkupNode[];
+}
+
+export interface MarkupTextNode extends BaseMarkupNode {
+	type: 'Text';
+	content: string;
+}


### PR DESCRIPTION
This is the first attempt at a UI system for Gro. The question it asks is:

> what if we grew our UIs from tiny seeds? and then shared them and cared for them?

Svelte made it clear how to make apps that include only the code they need. Rather than thinking in terms of tree shaking a bunch of dependencies off an app, we can think of Svelte apps as minimal by default, organic little things that attach only useful parts as they grow.

Let's apply the same pattern to end user UI, letting people create and share customized layouts, and see where it goes. There's huge overlap with other systems and concerns, so we're going to try to get a minimal foothold here that we can merge to be the default client UI, replacing its current functionality, and from there, who knows where we'll go.

I'm trying to look at both structure and content simultaneously, and these commits start with content, but I may need to back out and stick to structure only. (e.g. frames/views/models)

- [ ] play around until the right composable primitives appear
- [ ] rebuild the existing UI with the new system
- [ ] extract to a standalone library, probably