### PR TITLE
add port and host config options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,8 @@
   ([#67](https://github.com/feltcoop/gro/pull/67),
   [#68](https://github.com/feltcoop/gro/pull/68),
   [#82](https://github.com/feltcoop/gro/pull/82),
-  [#83](https://github.com/feltcoop/gro/pull/83))
+  [#83](https://github.com/feltcoop/gro/pull/83),
+  [#95](https://github.com/feltcoop/gro/pull/95))
 - add `Filer` to replace `CachingCompiler` with additional filesystem capabilities
   ([#54](https://github.com/feltcoop/gro/pull/54),
   [#55](https://github.com/feltcoop/gro/pull/55),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -13,6 +13,7 @@ import {DEFAULT_BUILD_CONFIG} from './defaultBuildConfig.js';
 import {DEFAULT_ECMA_SCRIPT_TARGET, EcmaScriptTarget} from '../build/tsBuildHelpers.js';
 import {omitUndefined} from '../utils/object.js';
 import type {ServedDirPartial} from '../build/ServedDir.js';
+import {DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT} from '../server/server.js';
 
 /*
 
@@ -40,6 +41,8 @@ export interface GroConfig {
 	readonly builds: BuildConfig[];
 	readonly target: EcmaScriptTarget;
 	readonly sourceMap: boolean;
+	readonly host: string;
+	readonly port: number;
 	readonly logLevel: LogLevel;
 	readonly serve?: ServedDirPartial[];
 	readonly primaryNodeBuildConfig: BuildConfig;
@@ -50,6 +53,8 @@ export interface PartialGroConfig {
 	readonly builds: PartialBuildConfig[];
 	readonly target?: EcmaScriptTarget;
 	readonly sourceMap?: boolean;
+	readonly host?: string;
+	readonly port?: number;
 	readonly logLevel?: LogLevel;
 	readonly serve?: ServedDirPartial[];
 }
@@ -188,6 +193,8 @@ const normalizeConfig = (config: PartialGroConfig): GroConfig => {
 		buildConfigs.find((b) => b.primary && b.platform === 'browser') || null;
 	return {
 		sourceMap: process.env.NODE_ENV !== 'production', // TODO hmm where does this come from?
+		host: DEFAULT_SERVER_HOST,
+		port: DEFAULT_SERVER_PORT,
 		logLevel: LogLevel.Trace,
 		...omitUndefined(config),
 		builds: buildConfigs,

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -23,7 +23,6 @@ const createConfig: GroConfigCreator = async () => {
 		],
 		logLevel: LogLevel.Trace,
 	};
-
 	return config;
 };
 

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -31,7 +31,7 @@ export const task: Task = {
 		timingToCreateFiler();
 
 		const timingToCreateDevServer = timings.start('create dev server');
-		const server = createDevServer({filer});
+		const server = createDevServer({filer, host: config.host, port: config.port});
 		timingToCreateDevServer();
 
 		await Promise.all([

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -61,6 +61,8 @@ export interface PartialGroConfig {
 	readonly builds: PartialBuildConfig[];
 	readonly target?: EcmaScriptTarget;
 	readonly sourceMap?: boolean;
+	readonly host?: string;
+	readonly port?: number;
 	readonly logLevel?: LogLevel;
 	readonly serve?: ServedDirPartial[];
 }

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -10,9 +10,9 @@ export const task: Task = {
 			// We don't want to have to worry about the security of the dev server.
 			throw Error('Serve should not be used in production');
 		}
-		// TODO also take these from args
-		const host: string | undefined = process.env.HOST;
-		const port: number | undefined = Number(process.env.PORT) || undefined;
+		// TODO validate
+		const host: string | undefined = (args.host as string) || process.env.HOST;
+		const port: number | undefined = Number(args.port) || Number(process.env.PORT) || undefined;
 		const servedDirs: string[] = args._.length ? args._ : ['.'];
 
 		// TODO this is inefficient for just serving files in a directory

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -32,6 +32,9 @@ export interface DevServer {
 	readonly port: number;
 }
 
+export const DEFAULT_SERVER_HOST: string = process.env.HOST || 'localhost';
+export const DEFAULT_SERVER_PORT: number = Number(process.env.PORT) || 8999;
+
 export interface Options {
 	filer: Filer;
 	host: string;
@@ -40,11 +43,9 @@ export interface Options {
 }
 export type RequiredOptions = 'filer';
 export type InitialOptions = PartialExcept<Options, RequiredOptions>;
-const DEFAULT_HOST = 'localhost';
-const DEFAULT_PORT = 8999;
 export const initOptions = (opts: InitialOptions): Options => ({
-	host: DEFAULT_HOST,
-	port: DEFAULT_PORT,
+	host: DEFAULT_SERVER_HOST,
+	port: DEFAULT_SERVER_PORT,
 	...omitUndefined(opts),
 	log: opts.log || new SystemLogger([cyan('[server]')]),
 });


### PR DESCRIPTION
This adds the `port` and `config` options to the Gro config. 