### PR TITLE
sourcemap is one word now

### DIFF
--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -31,13 +31,13 @@ export const task: Task = {
 		const basePath = undefined; // TODO parameterized options?
 		const tsconfig = loadTsconfig(log, tsconfigPath, basePath);
 		const target = toEcmaScriptTarget(tsconfig.compilerOptions?.target);
-		const sourceMap = tsconfig.compilerOptions?.sourceMap ?? process.env.NODE_ENV !== 'production';
-		const esbuildOptions = getDefaultEsbuildOptions(target, sourceMap);
+		const sourcemap = tsconfig.compilerOptions?.sourceMap ?? process.env.NODE_ENV !== 'production';
+		const esbuildOptions = getDefaultEsbuildOptions(target, sourcemap);
 
 		if (inputFiles.length) {
 			const build = createBuild({
 				dev,
-				sourceMap,
+				sourcemap,
 				inputFiles,
 				outputDir,
 				watch,

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -72,7 +72,7 @@ export interface Options {
 	servedDirs: ServedDir[];
 	externalsAliases: ExternalsAliases;
 	mapDependencyToSourceId: MapDependencyToSourceId;
-	sourceMap: boolean;
+	sourcemap: boolean;
 	target: EcmaScriptTarget;
 	watch: boolean;
 	watcherDebounce: number | undefined;
@@ -135,7 +135,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 		dev,
 		externalsAliases: DEFAULT_EXTERNALS_ALIASES,
 		mapDependencyToSourceId,
-		sourceMap: true,
+		sourcemap: true,
 		target: DEFAULT_ECMA_SCRIPT_TARGET,
 		watch: true,
 		watcherDebounce: undefined,
@@ -166,7 +166,7 @@ export class Filer implements BuildContext {
 	readonly log: Logger;
 	readonly buildDir: string;
 	readonly dev: boolean;
-	readonly sourceMap: boolean;
+	readonly sourcemap: boolean;
 	readonly target: EcmaScriptTarget; // TODO shouldn't build configs have this?
 	readonly servedDirs: readonly ServedDir[];
 	readonly externalsAliases: ExternalsAliases; // TODO should this allow aliasing anything? not just externals?
@@ -183,7 +183,7 @@ export class Filer implements BuildContext {
 			servedDirs,
 			externalsAliases,
 			mapDependencyToSourceId,
-			sourceMap,
+			sourcemap,
 			target,
 			watch,
 			watcherDebounce,
@@ -195,7 +195,7 @@ export class Filer implements BuildContext {
 		this.buildDir = buildDir;
 		this.mapDependencyToSourceId = mapDependencyToSourceId;
 		this.externalsAliases = externalsAliases;
-		this.sourceMap = sourceMap;
+		this.sourcemap = sourcemap;
 		this.target = target;
 		this.log = log;
 		this.dirs = createFilerDirs(

--- a/src/build/buildFile.ts
+++ b/src/build/buildFile.ts
@@ -14,7 +14,7 @@ export type BuildFile = TextBuildFile | BinaryBuildFile;
 export interface TextBuildFile extends BaseBuildFile {
 	readonly encoding: 'utf8';
 	readonly contents: string;
-	readonly sourceMapOf: string | null; // TODO maybe prefer a union with an `isSourceMap` boolean flag?
+	readonly sourcemapOf: string | null; // TODO maybe prefer a union with an `isSourceMap` boolean flag?
 }
 export interface BinaryBuildFile extends BaseBuildFile {
 	readonly encoding: null;
@@ -53,7 +53,7 @@ export const createBuildFile = (
 				extension: build.extension,
 				encoding: build.encoding,
 				contents: contents as string,
-				sourceMapOf: build.sourceMapOf,
+				sourcemapOf: build.sourcemapOf,
 				contentsBuffer: undefined,
 				contentsHash: undefined,
 				stats: undefined,
@@ -110,7 +110,7 @@ export const reconstructBuildFiles = async (
 							extension,
 							encoding,
 							contents: contents as string,
-							sourceMapOf: id.endsWith(SOURCEMAP_EXTENSION)
+							sourcemapOf: id.endsWith(SOURCEMAP_EXTENSION)
 								? stripEnd(id, SOURCEMAP_EXTENSION)
 								: null,
 							contentsBuffer: undefined,

--- a/src/build/buildFile.ts
+++ b/src/build/buildFile.ts
@@ -14,7 +14,7 @@ export type BuildFile = TextBuildFile | BinaryBuildFile;
 export interface TextBuildFile extends BaseBuildFile {
 	readonly encoding: 'utf8';
 	readonly contents: string;
-	readonly sourcemapOf: string | null; // TODO maybe prefer a union with an `isSourceMap` boolean flag?
+	readonly sourcemapOf: string | null; // TODO maybe prefer a union with an `isSourcemap` boolean flag?
 }
 export interface BinaryBuildFile extends BaseBuildFile {
 	readonly encoding: null;

--- a/src/build/buildSourceDirectory.ts
+++ b/src/build/buildSourceDirectory.ts
@@ -35,7 +35,7 @@ export const buildSourceDirectory = async (
 		buildConfigs: config.builds,
 		watch: false,
 		target: config.target,
-		sourceMap: config.sourceMap,
+		sourcemap: config.sourcemap,
 		dev,
 	});
 	timingToCreateFiler();

--- a/src/build/builder.ts
+++ b/src/build/builder.ts
@@ -54,7 +54,7 @@ export type Build = TextBuild | BinaryBuild;
 export interface TextBuild extends BaseBuild {
 	encoding: 'utf8';
 	contents: string;
-	sourcemapOf: string | null; // TODO for sourcemaps? hmm. maybe we want a union with an `isSourceMap` boolean flag?
+	sourcemapOf: string | null; // TODO for sourcemaps? hmm. maybe we want a union with an `isSourcemap` boolean flag?
 }
 export interface BinaryBuild extends BaseBuild {
 	encoding: null;

--- a/src/build/builder.ts
+++ b/src/build/builder.ts
@@ -38,7 +38,7 @@ export interface BuildContext {
 	readonly log: Logger;
 	readonly buildDir: string;
 	readonly dev: boolean;
-	readonly sourceMap: boolean;
+	readonly sourcemap: boolean;
 	readonly target: EcmaScriptTarget;
 	readonly servedDirs: readonly ServedDir[];
 	readonly externalsAliases: ExternalsAliases;
@@ -54,7 +54,7 @@ export type Build = TextBuild | BinaryBuild;
 export interface TextBuild extends BaseBuild {
 	encoding: 'utf8';
 	contents: string;
-	sourceMapOf: string | null; // TODO for source maps? hmm. maybe we want a union with an `isSourceMap` boolean flag?
+	sourcemapOf: string | null; // TODO for sourcemaps? hmm. maybe we want a union with an `isSourceMap` boolean flag?
 }
 export interface BinaryBuild extends BaseBuild {
 	encoding: null;
@@ -101,7 +101,7 @@ export const noopBuilder: Builder = {
 					extension,
 					encoding: source.encoding,
 					contents: source.contents,
-					sourceMapOf: null,
+					sourcemapOf: null,
 					buildConfig,
 				};
 				break;

--- a/src/build/esbuildBuilder.ts
+++ b/src/build/esbuildBuilder.ts
@@ -8,7 +8,7 @@ import {omitUndefined} from '../utils/object.js';
 import type {Builder, BuildResult, TextBuild, TextBuildSource} from './builder.js';
 import {replaceExtension} from '../utils/path.js';
 import {cyan} from '../utils/terminal.js';
-import {addJsSourceMapFooter} from './utils.js';
+import {addJsSourcemapFooter} from './utils.js';
 
 export interface Options {
 	log: Logger;
@@ -69,7 +69,7 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 				extension: JS_EXTENSION,
 				encoding: source.encoding,
 				contents: output.map
-					? addJsSourceMapFooter(output.code, jsFilename + SOURCEMAP_EXTENSION)
+					? addJsSourcemapFooter(output.code, jsFilename + SOURCEMAP_EXTENSION)
 					: output.code,
 				sourcemapOf: null,
 				buildConfig,

--- a/src/build/esbuildBuilder.ts
+++ b/src/build/esbuildBuilder.ts
@@ -31,13 +31,13 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 
 	const esbuildOptionsCache: Map<string, esbuild.TransformOptions> = new Map();
 	const getEsbuildOptions = (
-		sourceMap: boolean,
+		sourcemap: boolean,
 		target: EcmaScriptTarget,
 	): esbuild.TransformOptions => {
-		const key = sourceMap + target;
+		const key = sourcemap + target;
 		const existingEsbuildOptions = esbuildOptionsCache.get(key);
 		if (existingEsbuildOptions !== undefined) return existingEsbuildOptions;
-		const newEsbuildOptions = createEsbuildOptions(target, sourceMap);
+		const newEsbuildOptions = createEsbuildOptions(target, sourcemap);
 		esbuildOptionsCache.set(key, newEsbuildOptions);
 		return newEsbuildOptions;
 	};
@@ -45,7 +45,7 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 	const build: EsbuildBuilder['build'] = async (
 		source,
 		buildConfig,
-		{buildDir, dev, sourceMap, target},
+		{buildDir, dev, sourcemap, target},
 	) => {
 		if (source.encoding !== 'utf8') {
 			throw Error(`esbuild only handles utf8 encoding, not ${source.encoding}`);
@@ -55,7 +55,7 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 		}
 		const outDir = toBuildOutPath(dev, buildConfig.name, source.dirBasePath, buildDir);
 		const esbuildOptions = {
-			...getEsbuildOptions(sourceMap, target),
+			...getEsbuildOptions(sourcemap, target),
 			sourcefile: source.id,
 		};
 		const output = await esbuild.transform(source.contents, esbuildOptions);
@@ -71,7 +71,7 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 				contents: output.map
 					? addJsSourceMapFooter(output.code, jsFilename + SOURCEMAP_EXTENSION)
 					: output.code,
-				sourceMapOf: null,
+				sourcemapOf: null,
 				buildConfig,
 			},
 		];
@@ -83,7 +83,7 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 				extension: SOURCEMAP_EXTENSION,
 				encoding: source.encoding,
 				contents: output.map,
-				sourceMapOf: jsId,
+				sourcemapOf: jsId,
 				buildConfig,
 			});
 		}
@@ -96,8 +96,8 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 
 type CreateEsbuildOptions = (
 	target: EcmaScriptTarget,
-	sourceMap: boolean,
+	sourcemap: boolean,
 ) => esbuild.TransformOptions;
 
-const createDefaultEsbuildOptions: CreateEsbuildOptions = (target, sourceMap) =>
-	getDefaultEsbuildOptions(target, sourceMap);
+const createDefaultEsbuildOptions: CreateEsbuildOptions = (target, sourcemap) =>
+	getDefaultEsbuildOptions(target, sourcemap);

--- a/src/build/externalsBuilder.ts
+++ b/src/build/externalsBuilder.ts
@@ -63,9 +63,9 @@ export const createExternalsBuilder = (opts: InitialOptions = {}): ExternalsBuil
 	const build: ExternalsBuilder['build'] = async (
 		source,
 		buildConfig,
-		{buildDir, dev, sourceMap, target, state, externalsAliases},
+		{buildDir, dev, sourcemap, target, state, externalsAliases},
 	) => {
-		// if (sourceMap) {
+		// if (sourcemap) {
 		// 	log.warn('Source maps are not yet supported by the externals builder.');
 		// }
 		if (!dev) {
@@ -90,7 +90,7 @@ export const createExternalsBuilder = (opts: InitialOptions = {}): ExternalsBuil
 			groSveltePlugin({
 				dev,
 				addCssBuild: addSvelteCssBuild,
-				preprocessor: createDefaultPreprocessor(target, sourceMap),
+				preprocessor: createDefaultPreprocessor(target, sourcemap),
 				compileOptions: {},
 			}),
 		];
@@ -120,7 +120,7 @@ export const createExternalsBuilder = (opts: InitialOptions = {}): ExternalsBuil
 								extension: JS_EXTENSION,
 								encoding,
 								contents: await loadContents(encoding, id),
-								sourceMapOf: null,
+								sourcemapOf: null,
 								buildConfig,
 							};
 						},
@@ -231,7 +231,7 @@ const loadCommonBuilds = async (
 				extension: JS_EXTENSION,
 				encoding,
 				contents: await loadContents(encoding, commonDependencyId),
-				sourceMapOf: null,
+				sourcemapOf: null,
 				buildConfig,
 			}),
 		),

--- a/src/build/svelteBuildHelpers.ts
+++ b/src/build/svelteBuildHelpers.ts
@@ -15,11 +15,11 @@ import {EcmaScriptTarget} from './tsBuildHelpers.js';
 
 export type CreatePreprocessor = (
 	target: EcmaScriptTarget,
-	sourceMap: boolean,
+	sourcemap: boolean,
 ) => PreprocessorGroup | PreprocessorGroup[] | null;
 
-export const createDefaultPreprocessor: CreatePreprocessor = (target, sourceMap) =>
-	sveltePreprocessEsbuild.typescript(getDefaultEsbuildPreprocessOptions(target, sourceMap));
+export const createDefaultPreprocessor: CreatePreprocessor = (target, sourcemap) =>
+	sveltePreprocessEsbuild.typescript(getDefaultEsbuildPreprocessOptions(target, sourcemap));
 
 // TODO type could be improved, not sure how tho
 export interface SvelteCompileStats {

--- a/src/build/svelteBuilder.ts
+++ b/src/build/svelteBuilder.ts
@@ -55,13 +55,13 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 
 	const preprocessorCache: Map<string, PreprocessorGroup | PreprocessorGroup[] | null> = new Map();
 	const getPreprocessor = (
-		sourceMap: boolean,
+		sourcemap: boolean,
 		target: EcmaScriptTarget,
 	): PreprocessorGroup | PreprocessorGroup[] | null => {
-		const key = sourceMap + target;
+		const key = sourcemap + target;
 		const existingPreprocessor = preprocessorCache.get(key);
 		if (existingPreprocessor !== undefined) return existingPreprocessor;
-		const newPreprocessor = createPreprocessor(target, sourceMap);
+		const newPreprocessor = createPreprocessor(target, sourcemap);
 		preprocessorCache.set(key, newPreprocessor);
 		return newPreprocessor;
 	};
@@ -69,7 +69,7 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 	const build: SvelteBuilder['build'] = async (
 		source,
 		buildConfig,
-		{buildDir, dev, sourceMap, target},
+		{buildDir, dev, sourcemap, target},
 	) => {
 		if (source.encoding !== 'utf8') {
 			throw Error(`svelte only handles utf8 encoding, not ${source.encoding}`);
@@ -83,7 +83,7 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 
 		// TODO see rollup-plugin-svelte for how to track deps
 		// let dependencies = [];
-		const preprocessor = getPreprocessor(sourceMap, target);
+		const preprocessor = getPreprocessor(sourcemap, target);
 		if (preprocessor !== null) {
 			const preprocessed = await svelte.preprocess(contents, preprocessor, {filename: id});
 			preprocessedCode = preprocessed.code;
@@ -110,8 +110,8 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 		const cssFilename = `${source.filename}${CSS_EXTENSION}`;
 		const jsId = `${outDir}${jsFilename}`;
 		const cssId = `${outDir}${cssFilename}`;
-		const hasJsSourceMap = sourceMap && js.map !== undefined;
-		const hasCssSourceMap = sourceMap && css.map !== undefined;
+		const hasJsSourceMap = sourcemap && js.map !== undefined;
+		const hasCssSourceMap = sourcemap && css.map !== undefined;
 
 		const builds: TextBuild[] = [
 			{
@@ -123,7 +123,7 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 				contents: hasJsSourceMap
 					? addJsSourceMapFooter(js.code, jsFilename + SOURCEMAP_EXTENSION)
 					: js.code,
-				sourceMapOf: null,
+				sourcemapOf: null,
 				buildConfig,
 			},
 		];
@@ -135,7 +135,7 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 				extension: SOURCEMAP_EXTENSION,
 				encoding,
 				contents: JSON.stringify(js.map), // TODO do we want to also store the object version?
-				sourceMapOf: jsId,
+				sourcemapOf: jsId,
 				buildConfig,
 			});
 		}
@@ -149,7 +149,7 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 				contents: hasCssSourceMap
 					? addCssSourceMapFooter(css.code, cssFilename + SOURCEMAP_EXTENSION)
 					: css.code,
-				sourceMapOf: null,
+				sourcemapOf: null,
 				buildConfig,
 			});
 			if (hasCssSourceMap) {
@@ -160,7 +160,7 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 					extension: SOURCEMAP_EXTENSION,
 					encoding,
 					contents: JSON.stringify(css.map), // TODO do we want to also store the object version?
-					sourceMapOf: cssId,
+					sourcemapOf: cssId,
 					buildConfig,
 				});
 			}

--- a/src/build/svelteBuilder.ts
+++ b/src/build/svelteBuilder.ts
@@ -24,7 +24,7 @@ import type {Builder, BuildResult, TextBuild, TextBuildSource} from './builder.j
 import {BuildConfig} from '../config/buildConfig.js';
 import {UnreachableError} from '../utils/error.js';
 import {cyan} from '../utils/terminal.js';
-import {addCssSourceMapFooter, addJsSourceMapFooter} from './utils.js';
+import {addCssSourcemapFooter, addJsSourcemapFooter} from './utils.js';
 
 export interface Options {
 	log: Logger;
@@ -110,8 +110,8 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 		const cssFilename = `${source.filename}${CSS_EXTENSION}`;
 		const jsId = `${outDir}${jsFilename}`;
 		const cssId = `${outDir}${cssFilename}`;
-		const hasJsSourceMap = sourcemap && js.map !== undefined;
-		const hasCssSourceMap = sourcemap && css.map !== undefined;
+		const hasJsSourcemap = sourcemap && js.map !== undefined;
+		const hasCssSourcemap = sourcemap && css.map !== undefined;
 
 		const builds: TextBuild[] = [
 			{
@@ -120,14 +120,14 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 				dir: outDir,
 				extension: JS_EXTENSION,
 				encoding,
-				contents: hasJsSourceMap
-					? addJsSourceMapFooter(js.code, jsFilename + SOURCEMAP_EXTENSION)
+				contents: hasJsSourcemap
+					? addJsSourcemapFooter(js.code, jsFilename + SOURCEMAP_EXTENSION)
 					: js.code,
 				sourcemapOf: null,
 				buildConfig,
 			},
 		];
-		if (hasJsSourceMap) {
+		if (hasJsSourcemap) {
 			builds.push({
 				id: jsId + SOURCEMAP_EXTENSION,
 				filename: jsFilename + SOURCEMAP_EXTENSION,
@@ -146,13 +146,13 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 				dir: outDir,
 				extension: CSS_EXTENSION,
 				encoding,
-				contents: hasCssSourceMap
-					? addCssSourceMapFooter(css.code, cssFilename + SOURCEMAP_EXTENSION)
+				contents: hasCssSourcemap
+					? addCssSourcemapFooter(css.code, cssFilename + SOURCEMAP_EXTENSION)
 					: css.code,
 				sourcemapOf: null,
 				buildConfig,
 			});
-			if (hasCssSourceMap) {
+			if (hasCssSourcemap) {
 				builds.push({
 					id: cssId + SOURCEMAP_EXTENSION,
 					filename: cssFilename + SOURCEMAP_EXTENSION,

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -36,8 +36,8 @@ export const mapDependencyToSourceId: MapDependencyToSourceId = (dependency, bui
 	}
 };
 
-export const addJsSourceMapFooter = (code: string, sourceMapPath: string): string =>
-	`${code}\n//# sourceMappingURL=${sourceMapPath}`;
+export const addJsSourceMapFooter = (code: string, sourcemapPath: string): string =>
+	`${code}\n//# sourceMappingURL=${sourcemapPath}`;
 
-export const addCssSourceMapFooter = (code: string, sourceMapPath: string): string =>
-	`${code}\n/*# sourceMappingURL=${sourceMapPath} */`;
+export const addCssSourceMapFooter = (code: string, sourcemapPath: string): string =>
+	`${code}\n/*# sourceMappingURL=${sourcemapPath} */`;

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -36,8 +36,8 @@ export const mapDependencyToSourceId: MapDependencyToSourceId = (dependency, bui
 	}
 };
 
-export const addJsSourceMapFooter = (code: string, sourcemapPath: string): string =>
+export const addJsSourcemapFooter = (code: string, sourcemapPath: string): string =>
 	`${code}\n//# sourceMappingURL=${sourcemapPath}`;
 
-export const addCssSourceMapFooter = (code: string, sourcemapPath: string): string =>
+export const addCssSourcemapFooter = (code: string, sourcemapPath: string): string =>
 	`${code}\n/*# sourceMappingURL=${sourcemapPath} */`;

--- a/src/cli/invoke.ts
+++ b/src/cli/invoke.ts
@@ -2,9 +2,9 @@
 import {attachProcessErrorHandlers} from '../utils/process.js';
 attachProcessErrorHandlers();
 
-// install source maps
-import sourceMapSupport from 'source-map-support';
-sourceMapSupport.install({
+// install sourcemaps
+import sourcemapSupport from 'source-map-support';
+sourcemapSupport.install({
 	handleUncaughtExceptions: false,
 });
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -40,7 +40,7 @@ const FALLBACK_CONFIG_BUILD_BASE_PATH = 'config/gro.config.default.js';
 export interface GroConfig {
 	readonly builds: BuildConfig[];
 	readonly target: EcmaScriptTarget;
-	readonly sourceMap: boolean;
+	readonly sourcemap: boolean;
 	readonly host: string;
 	readonly port: number;
 	readonly logLevel: LogLevel;
@@ -52,7 +52,7 @@ export interface GroConfig {
 export interface PartialGroConfig {
 	readonly builds: PartialBuildConfig[];
 	readonly target?: EcmaScriptTarget;
-	readonly sourceMap?: boolean;
+	readonly sourcemap?: boolean;
 	readonly host?: string;
 	readonly port?: number;
 	readonly logLevel?: LogLevel;
@@ -192,7 +192,7 @@ const normalizeConfig = (config: PartialGroConfig): GroConfig => {
 	const primaryBrowserBuildConfig =
 		buildConfigs.find((b) => b.primary && b.platform === 'browser') || null;
 	return {
-		sourceMap: process.env.NODE_ENV !== 'production', // TODO hmm where does this come from?
+		sourcemap: process.env.NODE_ENV !== 'production', // TODO hmm where does this come from?
 		host: DEFAULT_SERVER_HOST,
 		port: DEFAULT_SERVER_PORT,
 		logLevel: LogLevel.Trace,

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -26,7 +26,7 @@ export const task: Task = {
 			servedDirs: config.serve || getDefaultServedDirs(config),
 			buildConfigs: config.builds,
 			target: config.target,
-			sourceMap: config.sourceMap,
+			sourcemap: config.sourcemap,
 		});
 		timingToCreateFiler();
 

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -60,7 +60,7 @@ The [`PartialGroConfig`](/src/gro.config.ts) is the return value of config files
 export interface PartialGroConfig {
 	readonly builds: PartialBuildConfig[];
 	readonly target?: EcmaScriptTarget;
-	readonly sourceMap?: boolean;
+	readonly sourcemap?: boolean;
 	readonly host?: string;
 	readonly port?: number;
 	readonly logLevel?: LogLevel;

--- a/src/fs/importTs.ts
+++ b/src/fs/importTs.ts
@@ -50,7 +50,7 @@ export const importTs = async (
 		log: new SystemLogger([cyan('[importTs]')]),
 		buildDir: tempDir,
 		dev: true,
-		sourceMap: false,
+		sourcemap: false,
 		target: DEFAULT_ECMA_SCRIPT_TARGET,
 		// TODO these last two aren't needed, maybe the builder's type should explicitly choose which options it uses?
 		servedDirs: [],

--- a/src/gen/README.md
+++ b/src/gen/README.md
@@ -44,8 +44,8 @@ Ergonomics are key to unlocking codegen's full potential.
 It adds a layer of indirection between the code you write and run.
 Also, you could introduce security vulnerabilities
 if you fail to escape certain inputs.
-Importantly, there is no support for source maps right now.
-Source maps could be added at some point, at least in many cases.
+Importantly, there is no support for sourcemaps right now.
+Sourcemaps could be added at some point, at least in many cases.
 
 Inspirations include Lisp macros and
 [Svelte](https://github.com/sveltejs/svelte), a compiler for building UIs.
@@ -231,4 +231,4 @@ which is called in the npm [`"preversion"`](../../package.json) script.
       Svelte/[MDSveX](https://github.com/pngwn/MDsveX)/etc
       to generate html/markdown/etc
 - [ ] support generating non-text files
-- [ ] source maps
+- [ ] sourcemaps

--- a/src/project/build.ts
+++ b/src/project/build.ts
@@ -36,7 +36,7 @@ import {
 export interface Options {
 	esbuildOptions: EsbuildTransformOptions;
 	dev: boolean;
-	sourceMap: boolean;
+	sourcemap: boolean;
 	inputFiles: string[];
 	outputDir: string;
 	watch: boolean;
@@ -49,7 +49,7 @@ export type RequiredOptions = 'esbuildOptions';
 export type InitialOptions = PartialExcept<Options, RequiredOptions>;
 export const initOptions = (opts: InitialOptions): Options => ({
 	dev: true,
-	sourceMap: opts.dev ?? true,
+	sourcemap: opts.dev ?? true,
 	inputFiles: [resolve('index.ts')],
 	outputDir: resolve('dist/'),
 	watch: true,
@@ -106,7 +106,7 @@ const runBuild = async (options: Options, log: Logger): Promise<void> => {
 };
 
 const createInputOptions = (inputFile: string, options: Options, _log: Logger): InputOptions => {
-	const {dev, sourceMap, cssCache, esbuildOptions} = options;
+	const {dev, sourcemap, cssCache, esbuildOptions} = options;
 
 	// TODO make this extensible - how? should bundles be combined for production builds?
 	const addPlainCssBuild = cssCache.addCssBuild.bind(null, 'bundle.plain.css');
@@ -124,7 +124,7 @@ const createInputOptions = (inputFile: string, options: Options, _log: Logger): 
 				addCssBuild: addSvelteCssBuild,
 				preprocessor: [
 					sveltePreprocessEsbuild.typescript(
-						getDefaultEsbuildPreprocessOptions(esbuildOptions.target, sourceMap),
+						getDefaultEsbuildPreprocessOptions(esbuildOptions.target, sourcemap),
 					),
 				],
 				compileOptions: {},
@@ -133,11 +133,11 @@ const createInputOptions = (inputFile: string, options: Options, _log: Logger): 
 			plainCssPlugin({addCssBuild: addPlainCssBuild}),
 			outputCssPlugin({
 				getCssBundles: cssCache.getCssBundles,
-				sourcemap: sourceMap,
+				sourcemap,
 			}),
 			resolvePlugin(),
 			commonjsPlugin(),
-			...(dev ? [] : [groTerserPlugin({minifyOptions: {sourceMap: sourceMap}})]),
+			...(dev ? [] : [groTerserPlugin({minifyOptions: {sourceMap: sourcemap}})]),
 		],
 
 		// >> advanced input options
@@ -192,7 +192,7 @@ const createOutputOptions = (options: Options, log: Logger): OutputOptions => {
 		// paths,
 		// preserveModules,
 		// preserveModulesRoot,
-		sourcemap: options.sourceMap,
+		sourcemap: options.sourcemap,
 		// sourcemapExcludeSources,
 		// sourcemapFile,
 		// sourcemapPathTransform,

--- a/src/project/rollup-plugin-gro-esbuild.ts
+++ b/src/project/rollup-plugin-gro-esbuild.ts
@@ -67,7 +67,7 @@ export const groEsbuildPlugin = (opts: InitialOptions): Plugin => {
 			log.trace('transpile', printPath(id));
 			let output: esbuild.TransformResult;
 			try {
-				// TODO do we need to add `sourcefile` to `esbuildOptions` for source maps?
+				// TODO do we need to add `sourcefile` to `esbuildOptions` for sourcemaps?
 				// currently not seeing a difference in the output
 				output = await esbuild.transform(code, esbuildOptions);
 			} catch (err) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -88,7 +88,7 @@
     "sourceMap": true // Generates corresponding '.map' file.
     // "sourceRoot": "", // Specify the location where debugger should locate TypeScript files instead of source locations.
     // "mapRoot": "", // Specify the location where debugger should locate map files instead of generated locations.
-    // "inlineSourceMap": true, // Emit a single file with source maps instead of having a separate file.
+    // "inlineSourceMap": true, // Emit a single file with sourcemaps instead of having a separate file.
     // "inlineSources": true, // Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set.
 
     // JSX options


### PR DESCRIPTION
I previously went with the `sourceMap` convention instead of `sourcemap` to match TypeScript, but Svelte, Rollup, and esbuild use the latter, and we want to follow their lead in these cases. This is one of those things that's generally inconsistent - e.g. Rollup and others export types with `SourceMap` in the name, and TypeScript has "type maps" which suggest it's a two word thing, but.. `sourcemap` it is.