### PR TITLE
remove the sourcemapOf build file property

### DIFF
--- a/src/build/buildFile.ts
+++ b/src/build/buildFile.ts
@@ -2,19 +2,16 @@ import type {Build, BuildContext, BuildDependency, BuildResult} from './builder.
 import {UnreachableError} from '../utils/error.js';
 import {BaseFilerFile} from './baseFilerFile.js';
 import type {SourceMeta} from './sourceMeta.js';
-import {SOURCEMAP_EXTENSION} from '../paths.js';
 import {postprocess} from './postprocess.js';
 import {basename, dirname, extname} from 'path';
 import {loadContents} from './load.js';
 import {BuildableSourceFile} from './sourceFile.js';
-import {stripEnd} from '../utils/string.js';
 import {BuildConfig} from '../config/buildConfig.js';
 
 export type BuildFile = TextBuildFile | BinaryBuildFile;
 export interface TextBuildFile extends BaseBuildFile {
 	readonly encoding: 'utf8';
 	readonly contents: string;
-	readonly sourcemapOf: string | null; // TODO maybe prefer a union with an `isSourcemap` boolean flag?
 }
 export interface BinaryBuildFile extends BaseBuildFile {
 	readonly encoding: null;
@@ -53,7 +50,6 @@ export const createBuildFile = (
 				extension: build.extension,
 				encoding: build.encoding,
 				contents: contents as string,
-				sourcemapOf: build.sourcemapOf,
 				contentsBuffer: undefined,
 				contentsHash: undefined,
 				stats: undefined,
@@ -110,9 +106,6 @@ export const reconstructBuildFiles = async (
 							extension,
 							encoding,
 							contents: contents as string,
-							sourcemapOf: id.endsWith(SOURCEMAP_EXTENSION)
-								? stripEnd(id, SOURCEMAP_EXTENSION)
-								: null,
 							contentsBuffer: undefined,
 							contentsHash: undefined,
 							stats: undefined,

--- a/src/build/builder.ts
+++ b/src/build/builder.ts
@@ -54,7 +54,6 @@ export type Build = TextBuild | BinaryBuild;
 export interface TextBuild extends BaseBuild {
 	encoding: 'utf8';
 	contents: string;
-	sourcemapOf: string | null; // TODO for sourcemaps? hmm. maybe we want a union with an `isSourcemap` boolean flag?
 }
 export interface BinaryBuild extends BaseBuild {
 	encoding: null;
@@ -101,7 +100,6 @@ export const noopBuilder: Builder = {
 					extension,
 					encoding: source.encoding,
 					contents: source.contents,
-					sourcemapOf: null,
 					buildConfig,
 				};
 				break;

--- a/src/build/esbuildBuilder.ts
+++ b/src/build/esbuildBuilder.ts
@@ -71,7 +71,6 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 				contents: output.map
 					? addJsSourcemapFooter(output.code, jsFilename + SOURCEMAP_EXTENSION)
 					: output.code,
-				sourcemapOf: null,
 				buildConfig,
 			},
 		];
@@ -83,7 +82,6 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 				extension: SOURCEMAP_EXTENSION,
 				encoding: source.encoding,
 				contents: output.map,
-				sourcemapOf: jsId,
 				buildConfig,
 			});
 		}

--- a/src/build/externalsBuilder.ts
+++ b/src/build/externalsBuilder.ts
@@ -120,7 +120,6 @@ export const createExternalsBuilder = (opts: InitialOptions = {}): ExternalsBuil
 								extension: JS_EXTENSION,
 								encoding,
 								contents: await loadContents(encoding, id),
-								sourcemapOf: null,
 								buildConfig,
 							};
 						},
@@ -231,7 +230,6 @@ const loadCommonBuilds = async (
 				extension: JS_EXTENSION,
 				encoding,
 				contents: await loadContents(encoding, commonDependencyId),
-				sourcemapOf: null,
 				buildConfig,
 			}),
 		),

--- a/src/build/svelteBuilder.ts
+++ b/src/build/svelteBuilder.ts
@@ -123,7 +123,6 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 				contents: hasJsSourcemap
 					? addJsSourcemapFooter(js.code, jsFilename + SOURCEMAP_EXTENSION)
 					: js.code,
-				sourcemapOf: null,
 				buildConfig,
 			},
 		];
@@ -135,7 +134,6 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 				extension: SOURCEMAP_EXTENSION,
 				encoding,
 				contents: JSON.stringify(js.map), // TODO do we want to also store the object version?
-				sourcemapOf: jsId,
 				buildConfig,
 			});
 		}
@@ -149,7 +147,6 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 				contents: hasCssSourcemap
 					? addCssSourcemapFooter(css.code, cssFilename + SOURCEMAP_EXTENSION)
 					: css.code,
-				sourcemapOf: null,
 				buildConfig,
 			});
 			if (hasCssSourcemap) {
@@ -160,7 +157,6 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 					extension: SOURCEMAP_EXTENSION,
 					encoding,
 					contents: JSON.stringify(css.map), // TODO do we want to also store the object version?
-					sourcemapOf: cssId,
 					buildConfig,
 				});
 			}


### PR DESCRIPTION
This was used during the `Filer`'s development but it's no longer used, and sourcemaps can be cheaply duck-typed if it's ever needed: we should be able to safely assume the build file is the same but without the suffix `.map`.