### PR TITLE
add http2 and https support to the dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ npm-debug.log
 *.ignore
 *.ignore.*
 ignore/
+
+*.pem

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It includes:
 - [task runner](/src/task) that uses the filesystem convention `*.task.ts`
   (docs at [`src/task`](/src/task))
 - codegen by convention called `gen` (docs at [`src/gen`](/src/gen))
-- dev server with efficient caching and pluggable compilation
+- dev server with efficient caching and pluggable builders
 - formatting via [Prettier](https://github.com/prettier/prettier)
 - utilities to fill in the gaps for Node and the browser
 - more to come, exploring what deeply integrated tools enable

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ It includes:
 
 - [unbundled development](/src/docs/unbundled.md) for web frontends, servers, and libraries
 - [`task`](/src/task) runner
+- [`dev server`](/src/server)
 - [`gen`](/src/gen) code generation
 - other [docs](/src/docs)
   - [tasks](/src/docs/tasks.md)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.5.1
+
+- add http2 and https support to the dev server
+  ([#104](https://github.com/feltcoop/gro/pull/104))
+
 ## 0.5.0
 
 - change the `build/` directory to `.gro/` and support multiple builds

--- a/src/cert.task.ts
+++ b/src/cert.task.ts
@@ -1,0 +1,20 @@
+import {pathExists} from './fs/nodeFs.js';
+import {Task} from './task/task.js';
+import {spawnProcess} from './utils/process.js';
+
+export const task: Task = {
+	description: 'creates a self-signed cert for https with openssl',
+	run: async ({args}) => {
+		const host = (args.host as string) || 'localhost';
+		const certFile = `${host}-cert.pem`;
+		const keyFile = `${host}-privkey.pem`;
+		if (await pathExists(certFile)) throw Error(`File ${certFile} already exists. Aborting.`);
+		if (await pathExists(keyFile)) throw Error(`File ${keyFile} already exists. Aborting.`);
+		await spawnProcess(
+			'openssl',
+			`req -x509 -newkey rsa:2048 -nodes -sha256 -subj /CN=${host} -keyout ${keyFile} -out ${certFile}`.split(
+				' ',
+			),
+		);
+	},
+};

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -8,10 +8,11 @@ import {createDevServer} from './server/server.js';
 import {GroConfig, loadGroConfig} from './config/config.js';
 import {configureLogLevel} from './utils/log.js';
 import {ServedDirPartial} from './build/ServedDir.js';
+import {loadHttpsCredentials} from './server/https.js';
 
 export const task: Task = {
 	description: 'start dev server',
-	run: async ({log}) => {
+	run: async ({log, args}) => {
 		const timings = new Timings();
 
 		const timingToLoadConfig = timings.start('load config');
@@ -31,7 +32,11 @@ export const task: Task = {
 		timingToCreateFiler();
 
 		const timingToCreateDevServer = timings.start('create dev server');
-		const server = createDevServer({filer, host: config.host, port: config.port});
+		// TODO write docs and validate args, maybe refactor, see also `serve.task.ts`
+		const https = args.nocert
+			? null
+			: await loadHttpsCredentials(log, args.certfile as string, args.certkeyfile as string);
+		const server = createDevServer({filer, host: config.host, port: config.port, https});
 		timingToCreateDevServer();
 
 		await Promise.all([

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -7,6 +7,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 ## all tasks
 
 - [build](../build.task.ts) - build the project
+- [cert](../cert.task.ts) - creates a self-signed cert for https with openssl
 - [check](../check.task.ts) - check that everything is ready to commit
 - [clean](../clean.task.ts) - remove build and temp files
 - [deploy](../deploy.task.ts) - deploy to gh-pages

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -2,6 +2,7 @@ import {Task} from './task/task.js';
 import {createDevServer} from './server/server.js';
 import {Filer} from './build/Filer.js';
 import {printPath} from './utils/print.js';
+import {loadHttpsCredentials} from './server/https.js';
 
 export const task: Task = {
 	description: 'start static file server',
@@ -20,7 +21,12 @@ export const task: Task = {
 		const filer = new Filer({servedDirs});
 		await filer.init();
 
-		const server = createDevServer({filer, host, port});
+		// TODO write docs and validate args, maybe refactor, see also `dev.task.ts`
+		const https = args.nocert
+			? null
+			: await loadHttpsCredentials(log, args.certfile as string, args.certkeyfile as string);
+
+		const server = createDevServer({filer, host, port, https});
 		log.info(`serving on ${server.host}:${server.port}`, ...servedDirs.map((d) => printPath(d)));
 		await server.start();
 	},

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -1,0 +1,34 @@
+# dev server
+
+To enable `http2` on the dev server,
+you'll need to generate a self-signed certificate and private key,
+because browsers require a secure `https` connection for `http2`.
+To generate the cert:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' \
+  -keyout localhost-privkey.pem -out localhost-cert.pem
+```
+
+or the builtin task:
+
+```bash
+gro project/cert
+```
+
+Gro will automatically see the certs created from the above:
+
+```
+$root/localhost-cert.pem
+$root/localhost-privkey.pem
+```
+
+To ignore them in git, you can add this to `.gitignore`:
+
+```
+*.pem
+```
+
+> TODO document the options
+
+> TODO config?

--- a/src/server/https.ts
+++ b/src/server/https.ts
@@ -1,0 +1,34 @@
+import {join} from 'path';
+
+import {pathExists, readFile} from '../fs/nodeFs.js';
+import {Logger} from '../utils/log.js';
+
+export interface HttpsCredentials {
+	cert: string;
+	key: string;
+}
+
+const DEFAULT_CERT_FILE: string =
+	process.env.GRO_CERT_FILE || join(process.cwd(), 'localhost-cert.pem');
+const DEFAULT_CERTKEY_FILE: string =
+	process.env.GRO_CERTKEY_FILE || join(process.cwd(), 'localhost-privkey.pem');
+
+// Tries to load the given cert and key, returning `null` if unable.
+export const loadHttpsCredentials = async (
+	log: Logger,
+	certFile = DEFAULT_CERT_FILE,
+	keyFile = DEFAULT_CERTKEY_FILE,
+): Promise<HttpsCredentials | null> => {
+	const [certExists, keyExists] = await Promise.all([pathExists(certFile), pathExists(keyFile)]);
+	if (!certExists && !keyExists) return null;
+	if (certExists && !keyExists) {
+		log.warn('https cert exists but the key file does not', keyFile);
+		return null;
+	}
+	if (!certExists && keyExists) {
+		log.warn('https key exists but the cert file does not', certFile);
+		return null;
+	}
+	const [cert, key] = await Promise.all([readFile(certFile, 'utf8'), readFile(keyFile, 'utf8')]);
+	return {cert, key};
+};

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2,15 +2,14 @@ import {
 	createServer as createHttp1Server,
 	Server as Http1Server,
 	RequestListener as Http1RequestListener,
-	IncomingMessage as Http1ServerRequest,
 	ServerResponse as Http1ServerResponse,
 	OutgoingHttpHeaders,
 } from 'http';
 import {
 	createSecureServer as createHttp2Server,
 	Http2Server,
-	Http2ServerRequest,
-	Http2ServerResponse,
+	IncomingHttpHeaders,
+	ServerHttp2Stream,
 } from 'http2';
 import {ListenOptions} from 'net';
 
@@ -30,6 +29,12 @@ import {paths} from '../paths.js';
 import {loadPackageJson} from '../project/packageJson.js';
 import {ProjectState} from './projectState.js';
 
+type Http2StreamHandler = (
+	stream: ServerHttp2Stream,
+	headers: IncomingHttpHeaders,
+	flags: number,
+) => void;
+
 export interface DevServer {
 	readonly server: Http1Server | Http2Server;
 	start(): Promise<void>;
@@ -44,7 +49,7 @@ export interface Options {
 	filer: Filer;
 	host: string;
 	port: number;
-	https: {cert: string; key: string} | null;
+	https: {cert: string; key: string; allowHTTP1?: boolean} | null;
 	log: Logger;
 }
 export type RequiredOptions = 'filer';
@@ -83,10 +88,9 @@ export const createDevServer = (opts: InitialOptions): DevServer => {
 	};
 	let server: Http1Server | Http2Server;
 	if (https) {
-		server = createHttp2Server(https, createHttp1RequestListener(filer, log) as any);
-		// TODO streaming!
-		// server.on('error', (err) => log.error(err));
-		// server.on('stream', createHttp2StreamHandler(filer, log));
+		server = createHttp2Server(https);
+		server.on('error', (err) => log.error(err));
+		server.on('stream', createHttp2StreamListener(filer, log));
 	} else {
 		server = createHttp1Server(createHttp1RequestListener(filer, log));
 	}
@@ -132,6 +136,66 @@ export const createDevServer = (opts: InitialOptions): DevServer => {
 	return devServer;
 };
 
+// TODO refactor with `createHttp1RequestListener`, this is a lot of copypasta
+const createHttp2StreamListener = (filer: Filer, log: Logger): Http2StreamHandler => {
+	return async (stream, headers) => {
+		const rawUrl = headers[':path'];
+		if (!rawUrl) return stream.end();
+		const url = parseUrl(rawUrl);
+		const localPath = toLocalPath(url);
+		log.trace('serving', gray(rawUrl), '→', gray(localPath));
+
+		// TODO refactor - see `./projectState.ts` for more
+		// can we get a virtual source file with an etag? (might need to sort files if they're not stable?)
+		// also, `src/` is hardcoded below in `paths.source`s
+		const SOURCE_ROOT_MATCHER = /^\/src\/?$/;
+		if (SOURCE_ROOT_MATCHER.test(url)) {
+			const projectState: ProjectState = {
+				buildDir: filer.buildDir,
+				sourceDir: paths.source,
+				items: Array.from(filer.sourceMetaById.values()),
+				buildConfigs: filer.buildConfigs!,
+				packageJson: await loadPackageJson(),
+			};
+			stream.respond({
+				':status': 200,
+				'Content-Type': 'application/json',
+			});
+			return stream.end(JSON.stringify(projectState));
+		}
+
+		// search for a file with this path
+		let file = await filer.findByPath(localPath);
+		if (!file) {
+			// TODO this is just temporary - the more correct code is below. The filer needs to support directories.
+			file = await filer.findByPath(`${localPath}/index.html`);
+		}
+		// if (file?.type === 'directory') { // or `file?.isDirectory`
+		// 	file = filer.findById(file.id + '/index.html');
+		// }
+		if (!file) {
+			log.info(`${yellow('404')} ${red(localPath)}`);
+			stream.respond({
+				':status': 404,
+				'Content-Type': 'text/plain; charset=utf-8',
+			});
+			return stream.end(`404 not found: ${url}`);
+		}
+		// console.log('req headers', gray(file.id), headers);
+		const etag = headers['if-none-match'];
+		if (etag && etag === toETag(file)) {
+			log.info(`${yellow('304')} ${gray(localPath)}`);
+			stream.respond({':status': 304});
+			return stream.end();
+		}
+		log.info(`${yellow('200')} ${gray(localPath)}`);
+		const responseHeaders = await to200Headers(file);
+		responseHeaders[':status'] = 200;
+		stream.respond(responseHeaders);
+		return stream.end(getFileContentsBuffer(file));
+	};
+};
+
 const createHttp1RequestListener = (filer: Filer, log: Logger): Http1RequestListener => {
 	const requestListener: Http1RequestListener = async (req, res) => {
 		if (!req.url) return;
@@ -170,7 +234,7 @@ const createHttp1RequestListener = (filer: Filer, log: Logger): Http1RequestList
 		// }
 		if (!file) {
 			log.info(`${yellow('404')} ${red(localPath)}`);
-			return send404(req, res);
+			return send404(res, url);
 		}
 		// console.log('req headers', gray(file.id), req.headers);
 		const etag = req.headers['if-none-match'];
@@ -179,7 +243,7 @@ const createHttp1RequestListener = (filer: Filer, log: Logger): Http1RequestList
 			return send304(res);
 		}
 		log.info(`${yellow('200')} ${gray(localPath)}`);
-		return send200(req, res, file);
+		return send200(res, file);
 	};
 	return requestListener;
 };
@@ -194,27 +258,26 @@ const toLocalPath = (url: string): string => {
 	return relativePath;
 };
 
-const send404 = (
-	req: Http1ServerRequest | Http2ServerRequest,
-	res: Http1ServerResponse | Http2ServerResponse,
-) => {
+const send404 = (res: Http1ServerResponse, url: string) => {
 	const headers: OutgoingHttpHeaders = {
 		'Content-Type': 'text/plain; charset=utf-8',
 	};
 	res.writeHead(404, headers);
-	res.end(`404 not found: ${req.url}`);
+	res.end(`404 not found: ${url}`);
 };
 
-const send304 = (res: Http1ServerResponse | Http2ServerResponse) => {
+const send304 = (res: Http1ServerResponse) => {
 	res.writeHead(304);
 	res.end();
 };
 
-const send200 = async (
-	_req: Http1ServerRequest | Http2ServerRequest,
-	res: Http1ServerResponse | Http2ServerResponse,
-	file: BaseFilerFile,
-) => {
+const send200 = async (res: Http1ServerResponse, file: BaseFilerFile) => {
+	const headers = await to200Headers(file);
+	res.writeHead(200, headers);
+	res.end(getFileContentsBuffer(file));
+};
+
+const to200Headers = async (file: BaseFilerFile): Promise<OutgoingHttpHeaders> => {
 	const stats = await getFileStats(file);
 	const mimeType = getFileMimeType(file);
 	const headers: OutgoingHttpHeaders = {
@@ -238,8 +301,7 @@ const send200 = async (
 		// 'Cache-Control': 'max-age=31536000',
 	};
 	// console.log('res headers', gray(file.id), headers);
-	res.writeHead(200, headers);
-	res.end(getFileContentsBuffer(file));
+	return headers;
 };
 
 const toETag = (file: BaseFilerFile): string => `"${getFileContentsHash(file)}"`;

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -35,7 +35,7 @@ export const runTask = async (
 					? err.message
 					: `Unexpected error running task ${cyan(
 							task.name,
-					  )}. Aborting. To "turn it off and on again" run \`gro clean\`.`,
+					  )}. Aborting. If this is unexpected try running \`gro clean\`.`,
 			),
 			error: err,
 		};


### PR DESCRIPTION
This adds http2 and https support to the dev server. I was hoping it would speed up loading pages with large module waterfalls, but so far it seems like slows things down by 10-20%. I'm not sure if this is due to an oversight in the code, or if http2 just won't speed up this use case. If the latter is the case, a better long term situation is to probably use the `cache-control: immutable` header as much as possible, though we need import maps for that: WICG /import-maps/issues/146