### PR TITLE
allow deleting input files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.6.2
+
+- allow deleting input files
+  ([#105](https://github.com/feltcoop/gro/pull/105))
+
 ## 0.6.1
 
 - temporarily pin `esinstall` version to fix a breaking regression

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -385,11 +385,6 @@ export class Filer implements BuildContext {
 		this.log.trace(
 			`removing source file from build ${printBuildConfig(buildConfig)} ${gray(sourceFile.id)}`,
 		);
-		if (sourceFile.isInputToBuildConfigs?.has(buildConfig)) {
-			throw Error(
-				`Removing build configs from input files is not allowed: ${buildConfig}: ${sourceFile.id}`,
-			);
-		}
 
 		await this.updateBuildFiles(sourceFile, [], buildConfig);
 


### PR DESCRIPTION
This removes a check that disallowed removing build configs from source files that are inputs. The logic to properly keep input files is working, so this check did nothing except incorrectly throw when an input file is deleted from the source tree.