### PR TITLE
restrict dev server to development usage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.6.3
+
+- restrict the dev server to development usage
+  ([#107](https://github.com/feltcoop/gro/pull/107))
+
 ## 0.6.2
 
 - allow deleting input files

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -7,10 +7,6 @@ import {loadHttpsCredentials} from './server/https.js';
 export const task: Task = {
 	description: 'start static file server',
 	run: async ({log, args}): Promise<void> => {
-		if (process.env.NODE_ENV === 'production') {
-			// We don't want to have to worry about the security of the dev server.
-			throw Error('Serve should not be used in production');
-		}
 		// TODO validate
 		const host: string | undefined = (args.host as string) || process.env.HOST;
 		const port: number | undefined = Number(args.port) || Number(process.env.PORT) || undefined;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -24,6 +24,11 @@ import {paths} from '../paths.js';
 import {loadPackageJson} from '../project/packageJson.js';
 import {ProjectState} from './projectState.js';
 
+// We don't want to have to worry about the security of the dev server.
+if (process.env.NODE_ENV !== 'development') {
+	throw Error('The dev server is only designed for development. Security cannot be guaranteed.');
+}
+
 type Http2StreamHandler = (
 	stream: ServerHttp2Stream,
 	headers: IncomingHttpHeaders,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -24,11 +24,6 @@ import {paths} from '../paths.js';
 import {loadPackageJson} from '../project/packageJson.js';
 import {ProjectState} from './projectState.js';
 
-// We don't want to have to worry about the security of the dev server.
-if (process.env.NODE_ENV !== 'development') {
-	throw Error('The dev server is only designed for development. Security cannot be guaranteed.');
-}
-
 type Http2StreamHandler = (
 	stream: ServerHttp2Stream,
 	headers: IncomingHttpHeaders,
@@ -65,6 +60,11 @@ export const initOptions = (opts: InitialOptions): Options => {
 };
 
 export const createDevServer = (opts: InitialOptions): DevServer => {
+	// We don't want to have to worry about the security of the dev server.
+	if (process.env.NODE_ENV !== 'development') {
+		throw Error('The dev server may only be run in development for security reasons.');
+	}
+
 	const options = initOptions(opts);
 	const {filer, host, port, https, log} = options;
 


### PR DESCRIPTION
The Gro dev server is designed to be as useful as it can be in development mode, and this means it might have security holes in a production environment. For now it will throw unless the `NODE_ENV === 'development'`. It's for our own good!!