### PR TITLE
set importsNotUsedAsValues to remove

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,8 +4,6 @@
 
 - restrict the dev server to development usage
   ([#107](https://github.com/feltcoop/gro/pull/107))
-- change TypeScript setting `importsNotUsedAsValues` to `"error"`
-  ([#109](https://github.com/feltcoop/gro/pull/109))
 
 ## 0.6.2
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     // "incremental": true, // Enable incremental compilation by reading/writing information from prior compilations to a file on disk.
     // TODO turn `isolatedModules` on once TS4.3 lands and `exports` are added and `globalTypes` is redesigned
     "isolatedModules": false, // Transpile each file as a separate module (similar to 'ts.transpileModule').
-    "importsNotUsedAsValues": "error", // This flag controls how imports work. When set to `remove`, imports that only reference types are dropped. When set to `preserve`, imports are never dropped. When set to `error`, imports that can be replaced with `import type` will result in a compiler error. Requires TypeScript version 3.8 or later.
+    "importsNotUsedAsValues": "remove", // This flag controls how imports work. When set to `remove`, imports that only reference types are dropped. When set to `preserve`, imports are never dropped. When set to `error`, imports that can be replaced with `import type` will result in a compiler error. Requires TypeScript version 3.8 or later.
     // "listEmittedFiles": false, // Print names of generated files part of the compilation.
     // "listFiles": true, // Print names of files part of the compilation.
     // "noErrorTruncation": false, // Do not truncate error messages.


### PR DESCRIPTION
This reverts the TypeScript setting `importsNotUsedAsValues` to "remove". This seems much better for TypeScript files than "error".