### PR TITLE
dev task hooks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.6.4
+
+- add `args` hooks to `src/dev.task.ts`
+  ([#112](https://github.com/feltcoop/gro/pull/112))
+
 ## 0.6.3
 
 - fix import path


### PR DESCRIPTION
This adds some optional hooks to `src/dev.task.ts`, the main dev task. It lets user code get some juicy inside bits.

This is in service of a larger goal, to let external user code implement an automatic server restarter. We'll experiment with that API, but this is a good start.