### PR TITLE
improve input error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.6.5
+
+- improve the error message when a build config input is missing
+  ([#113](https://github.com/feltcoop/gro/pull/113))
+
 ## 0.6.4
 
 - add `args` hooks to `src/dev.task.ts`

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -306,8 +306,8 @@ export class Filer implements BuildContext {
 				// TODO this assert throws with a bad error - should print `input`
 				try {
 					assertBuildableSourceFile(file);
-				} catch (err) {
-					this.log.error(red('missing input'), input, buildConfig, printError(err));
+				} catch (_err) {
+					this.log.error(red('missing input'), input, buildConfig);
 					throw Error('Missing input: check the build config and source files for the above input');
 				}
 				if (!file.buildConfigs.has(buildConfig)) {

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -308,7 +308,7 @@ export class Filer implements BuildContext {
 					assertBuildableSourceFile(file);
 				} catch (err) {
 					this.log.error(red('missing input'), input, printError(err));
-					throw Error(`Missing input`);
+					throw Error('Missing input: check the build config and source files for the above input');
 				}
 				if (!file.buildConfigs.has(buildConfig)) {
 					promises.push(this.addSourceFileToBuild(file, buildConfig, true));

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -304,7 +304,12 @@ export class Filer implements BuildContext {
 				}
 				const file = this.files.get(input);
 				// TODO this assert throws with a bad error - should print `input`
-				assertBuildableSourceFile(file);
+				try {
+					assertBuildableSourceFile(file);
+				} catch (err) {
+					this.log.error(red('missing input'), input, printError(err));
+					throw Error(`Missing input`);
+				}
 				if (!file.buildConfigs.has(buildConfig)) {
 					promises.push(this.addSourceFileToBuild(file, buildConfig, true));
 				}

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -307,7 +307,7 @@ export class Filer implements BuildContext {
 				try {
 					assertBuildableSourceFile(file);
 				} catch (err) {
-					this.log.error(red('missing input'), input, printError(err));
+					this.log.error(red('missing input'), input, buildConfig, printError(err));
 					throw Error('Missing input: check the build config and source files for the above input');
 				}
 				if (!file.buildConfigs.has(buildConfig)) {


### PR DESCRIPTION
This improves the error message when a build config input is missing. The bare assertion isn't very helpful!