### PR TITLE
break: change global types to root exports

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.7.0
+
+- **breaking**: change global types to root exports
+  ([#114](https://github.com/feltcoop/gro/pull/114))
+
 ## 0.6.5
 
 - improve the error message when a build config input is missing

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.7.0
 
-- **breaking**: change global types to root exports
+- **break**: change global types to root exports
   ([#114](https://github.com/feltcoop/gro/pull/114))
 
 ## 0.6.5

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -44,6 +44,7 @@ import {
 import {queueExternalsBuild} from './externalsBuilder.js';
 import type {SourceMeta} from './sourceMeta.js';
 import {deleteSourceMeta, updateSourceMeta, cleanSourceMeta, initSourceMeta} from './sourceMeta.js';
+import type {OmitStrict, Assignable} from '../types.js';
 
 /*
 

--- a/src/build/ServedDir.ts
+++ b/src/build/ServedDir.ts
@@ -1,5 +1,7 @@
 import {resolve} from 'path';
 
+import type {PartialExcept} from '../types.js';
+
 export interface ServedDir {
 	dir: string; // TODO rename? `source`, `sourceDir`, `path`
 	servedAt: string; // TODO rename?

--- a/src/build/formatFile.ts
+++ b/src/build/formatFile.ts
@@ -2,6 +2,7 @@ import prettier from 'prettier';
 import {extname} from 'path';
 
 import {loadPackageJson} from '../project/packageJson.js';
+import type {Obj} from '../types.js';
 
 export const formatFile = async (id: string, contents: string): Promise<string> => {
 	const parser = inferParser(id);

--- a/src/build/svelteBuildHelpers.ts
+++ b/src/build/svelteBuildHelpers.ts
@@ -12,6 +12,7 @@ import {yellow} from '../utils/terminal.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';
 import {getDefaultEsbuildPreprocessOptions} from './esbuildBuildHelpers.js';
 import type {EcmaScriptTarget} from './tsBuildHelpers.js';
+import type {OmitStrict} from '../types.js';
 
 export type CreatePreprocessor = (
 	target: EcmaScriptTarget,

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,3 +1,5 @@
+import type {Obj} from '../types.js';
+
 export interface Args {
 	_: string[];
 	[key: string]: string | number | boolean | string[] | undefined;

--- a/src/client/pathHelpers.ts
+++ b/src/client/pathHelpers.ts
@@ -1,3 +1,5 @@
+import type {Obj} from '../types.js';
+
 // TODO refactor, move where? hacky because `path`, should reuse existing code
 // TODO maybe cache these values on the domain objects instead of this?
 const toBasePathCache: Obj<string> = {};

--- a/src/config/buildConfig.ts
+++ b/src/config/buildConfig.ts
@@ -4,6 +4,7 @@ import {ensureArray} from '../utils/array.js';
 import {DEFAULT_BUILD_CONFIG_NAME} from './defaultBuildConfig.js';
 import {paths} from '../paths.js';
 import {blue} from '../utils/terminal.js';
+import type {Result} from '../types.js';
 
 // See `../docs/config.md` for documentation.
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -14,6 +14,7 @@ import {DEFAULT_ECMA_SCRIPT_TARGET, EcmaScriptTarget} from '../build/tsBuildHelp
 import {omitUndefined} from '../utils/object.js';
 import type {ServedDirPartial} from '../build/ServedDir.js';
 import {DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT} from '../server/server.js';
+import type {Result} from '../types.js';
 
 /*
 

--- a/src/fs/inputPath.test.ts
+++ b/src/fs/inputPath.test.ts
@@ -11,6 +11,7 @@ import {
 } from './inputPath.js';
 import type {PathStats} from './pathData.js';
 import {groPaths, replaceRootDir, createPaths, paths} from '../paths.js';
+import type {Obj} from '../types.js';
 
 /* test_resolveRawInputPath */
 const test_resolveRawInputPath = suite('resolveRawInputPath');

--- a/src/fs/modules.test.ts
+++ b/src/fs/modules.test.ts
@@ -8,6 +8,7 @@ import * as modTestBaz1 from './fixtures/baz1/test1.baz.js';
 import * as modTestBaz2 from './fixtures/baz2/test2.baz.js';
 import {findFiles} from './nodeFs.js';
 import {getPossibleSourceIds} from './inputPath.js';
+import type {Obj} from '../types.js';
 
 /* test_loadModule */
 const test_loadModule = suite('loadModule');

--- a/src/fs/modules.ts
+++ b/src/fs/modules.ts
@@ -7,6 +7,7 @@ import type {PathStats, PathData} from './pathData.js';
 import {toImportId, pathsFromId} from '../paths.js';
 import {UnreachableError} from '../utils/error.js';
 import {DEFAULT_BUILD_CONFIG_NAME} from '../config/defaultBuildConfig.js';
+import type {Obj, Result} from '../types.js';
 
 /*
 

--- a/src/fs/testModule.ts
+++ b/src/fs/testModule.ts
@@ -2,6 +2,7 @@ import {ModuleMeta, loadModule, LoadModuleResult, findModules} from '../fs/modul
 import {paths} from '../paths.js';
 import {findFiles} from '../fs/nodeFs.js';
 import {getPossibleSourceIds} from '../fs/inputPath.js';
+import type {Obj} from '../types.js';
 
 // TODO this is no longer needed to the same extent as it was before switching to `uvu`,
 // but it contains the conventions for the app used in some other places

--- a/src/fs/watchNodeFs.ts
+++ b/src/fs/watchNodeFs.ts
@@ -2,6 +2,7 @@ import CheapWatch from 'cheap-watch';
 
 import type {PathStats, PathFilter} from './pathData.js';
 import {omitUndefined} from '../utils/object.js';
+import type {PartialExcept} from '../types.js';
 
 /*
 

--- a/src/gen/genModule.ts
+++ b/src/gen/genModule.ts
@@ -3,6 +3,7 @@ import {Gen, GenResults, GenFile, isGenPath, GEN_FILE_PATTERN} from './gen.js';
 import {pathExists, readFile, findFiles} from '../fs/nodeFs.js';
 import {getPossibleSourceIds} from '../fs/inputPath.js';
 import {paths} from '../paths.js';
+import type {Obj} from '../types.js';
 
 export interface GenModule {
 	gen: Gen;

--- a/src/globalTypes.ts
+++ b/src/globalTypes.ts
@@ -1,70 +1,3 @@
-/*
-
-These are convenient global types that can be used in both Gro and user code.
-It probably makes more sense to give this file a `.d.ts` extension,
-but that complicates the build because TypeScript does not output them.
-
-TODO probably make this `.d.ts` when we make a proper build process
-
-*/
-
-declare type Falsy = false | '' | null | undefined | 0 | -0 | typeof NaN;
-
-declare type Obj<T = any> = {[key: string]: T};
-
-declare type OmitStrict<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
-// these were thrown together quickly - is there a better way to do this?
-// there are probably better names for them!
-// see `Required`, `Exclude` and `Extract` for possible leads for improvements
-declare type PartialExcept<T, K extends keyof T> = {[P in K]: T[P]} &
-	{[P in Exclude<keyof T, K>]?: T[P]};
-declare type PartialOnly<T, K extends keyof T> = {[P in K]?: T[P]} &
-	{[P in Exclude<keyof T, K>]: T[P]};
-
-declare type PartialValues<T> = {
-	[P in keyof T]: Partial<T[P]>;
-};
-
-type Assignable<T, K extends keyof T = keyof T> = {
-	-readonly [P in K]: T[P];
-};
-
-declare type Result<TValue = {}, TError = {}> = ({ok: true} & TValue) | ({ok: false} & TError);
-
-/*
-
-The `Flavored` and `Branded` type helpers add varying degrees of nominal typing to other types.
-This is especially useful with primitives like strings and numbers.
-
-```ts
-type PhoneNumber = Branded<string, 'PhoneNumber'>;
-const phone1: PhoneNumber = 'foo'; // error!
-const phone2: PhoneNumber = 'foo' as PhoneNumber; // ok
-```
-
-`Flavored` is a looser form of `Branded` that trades safety for ergonomics.
-With `Flavored` you don't need to cast unflavored types:
-
-```ts
-type Email = Flavored<string, 'Email'>;
-const email1: Email = 'foo'; // ok
-type Address = Flavored<string, 'Address'>;
-const email2: Email = 'foo' as Address; // error!
-```
-
-*/
-declare type Branded<TValue, TName> = TValue & Brand<TName>;
-declare type Flavored<TValue, TName> = TValue & Flavor<TName>;
-declare interface Brand<T> {
-	readonly [BrandedSymbol]: T;
-}
-declare interface Flavor<T> {
-	readonly [FlavoredSymbol]?: T;
-}
-declare const BrandedSymbol: unique symbol;
-declare const FlavoredSymbol: unique symbol;
-
 declare module 'mri';
 
 declare module 'kleur/colors' {
@@ -130,7 +63,10 @@ declare module 'uvu/assert' {
 	}
 
 	export namespace not {
-		function ok(actual: any, msg?: Message): asserts actual is Falsy;
+		function ok(
+			actual: any,
+			msg?: Message,
+		): asserts actual is false | '' | null | undefined | 0 | -0 | typeof NaN;
 		function equal(actual: any, expects: any, msg?: Message): void;
 		function type(actual: any, expects: Types, msg?: Message): void;
 		function instance(actual: any, expects: any, msg?: Message): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ export type {Task} from './task/task.js';
 export {TaskError} from './task/task.js';
 
 export type {Gen} from './gen/gen.js';
+
+export * from './types.js';

--- a/src/project/build.ts
+++ b/src/project/build.ts
@@ -32,6 +32,7 @@ import {
 	EsbuildTransformOptions,
 	getDefaultEsbuildPreprocessOptions,
 } from '../build/esbuildBuildHelpers.js';
+import type {PartialExcept} from '../types.js';
 
 export interface Options {
 	esbuildOptions: EsbuildTransformOptions;

--- a/src/project/packageJson.ts
+++ b/src/project/packageJson.ts
@@ -3,6 +3,7 @@ import {join} from 'path';
 import {readJson} from '../fs/nodeFs.js';
 import {paths, groPaths, isThisProjectGro} from '../paths.js';
 import type {Json} from '../utils/json.js';
+import type {Obj} from '../types.js';
 
 /*
 

--- a/src/project/rollup-plugin-gro-esbuild.ts
+++ b/src/project/rollup-plugin-gro-esbuild.ts
@@ -10,6 +10,7 @@ import {printKeyValue, printMs, printPath} from '../utils/print.js';
 import {toRootPath, isSourceId, TS_EXTENSION} from '../paths.js';
 import {omitUndefined} from '../utils/object.js';
 import {replaceExtension} from '../utils/path.js';
+import type {PartialExcept} from '../types.js';
 
 // TODO improve along with Svelte compile stats
 interface Stats {

--- a/src/project/rollup-plugin-gro-svelte.ts
+++ b/src/project/rollup-plugin-gro-svelte.ts
@@ -17,6 +17,7 @@ import {
 	handleStats,
 } from '../build/svelteBuildHelpers.js';
 import {CSS_EXTENSION} from '../paths.js';
+import type {PartialExcept} from '../types.js';
 
 // TODO support `package.json` "svelte" field
 // see reference here https://github.com/rollup/rollup-plugin-svelte/blob/master/index.js#L190

--- a/src/project/rollup-plugin-output-css.ts
+++ b/src/project/rollup-plugin-output-css.ts
@@ -7,6 +7,7 @@ import {outputFile} from '../fs/nodeFs.js';
 import {SystemLogger, Logger} from '../utils/log.js';
 import type {GroCssBuild, GroCssBundle} from './types.js';
 import {omitUndefined} from '../utils/object.js';
+import type {PartialExcept} from '../types.js';
 
 export interface Options {
 	getCssBundles(): Map<string, GroCssBundle>;

--- a/src/project/rollup-plugin-plain-css.ts
+++ b/src/project/rollup-plugin-plain-css.ts
@@ -7,6 +7,7 @@ import {green} from '../utils/terminal.js';
 import {SystemLogger} from '../utils/log.js';
 import type {GroCssBuild} from './types.js';
 import {omitUndefined} from '../utils/object.js';
+import type {PartialExcept} from '../types.js';
 
 export interface Options {
 	addCssBuild(build: GroCssBuild): boolean;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -23,6 +23,7 @@ import {
 import {paths} from '../paths.js';
 import {loadPackageJson} from '../project/packageJson.js';
 import type {ProjectState} from './projectState.js';
+import type {Assignable, PartialExcept} from '../types.js';
 
 type Http2StreamHandler = (
 	stream: ServerHttp2Stream,

--- a/src/task/taskModule.ts
+++ b/src/task/taskModule.ts
@@ -3,6 +3,7 @@ import {ModuleMeta, LoadModuleResult, loadModule, loadModules, findModules} from
 import {Task, toTaskName, isTaskPath, TASK_FILE_SUFFIX} from './task.js';
 import {findFiles} from '../fs/nodeFs.js';
 import {getPossibleSourceIds} from '../fs/inputPath.js';
+import type {Obj} from '../types.js';
 
 export interface TaskModule {
 	task: Task;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,66 @@
+/*
+
+These are convenient global types that can be used in both Gro and user code.
+It probably makes more sense to give this file a `.d.ts` extension,
+but that complicates the build because TypeScript does not output them.
+
+TODO probably make this `.d.ts` when we make a proper build process
+
+*/
+
+export type Falsy = false | '' | null | undefined | 0 | -0 | typeof NaN;
+
+export type Obj<T = any> = {[key: string]: T};
+
+export type OmitStrict<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+// these were thrown together quickly - is there a better way to do this?
+// there are probably better names for them!
+// see `Required`, `Exclude` and `Extract` for possible leads for improvements
+export type PartialExcept<T, K extends keyof T> = {[P in K]: T[P]} &
+	{[P in Exclude<keyof T, K>]?: T[P]};
+export type PartialOnly<T, K extends keyof T> = {[P in K]?: T[P]} &
+	{[P in Exclude<keyof T, K>]: T[P]};
+
+export type PartialValues<T> = {
+	[P in keyof T]: Partial<T[P]>;
+};
+
+export type Assignable<T, K extends keyof T = keyof T> = {
+	-readonly [P in K]: T[P];
+};
+
+export type Result<TValue = {}, TError = {}> = ({ok: true} & TValue) | ({ok: false} & TError);
+
+/*
+
+The `Flavored` and `Branded` type helpers add varying degrees of nominal typing to other types.
+This is especially useful with primitives like strings and numbers.
+
+```ts
+type PhoneNumber = Branded<string, 'PhoneNumber'>;
+const phone1: PhoneNumber = 'foo'; // error!
+const phone2: PhoneNumber = 'foo' as PhoneNumber; // ok
+```
+
+`Flavored` is a looser form of `Branded` that trades safety for ergonomics.
+With `Flavored` you don't need to cast unflavored types:
+
+```ts
+type Email = Flavored<string, 'Email'>;
+const email1: Email = 'foo'; // ok
+type Address = Flavored<string, 'Address'>;
+const email2: Email = 'foo' as Address; // error!
+```
+
+*/
+export type Branded<TValue, TName> = TValue & Brand<TName>;
+export type Flavored<TValue, TName> = TValue & Flavor<TName>;
+declare const BrandedSymbol: unique symbol;
+declare const FlavoredSymbol: unique symbol;
+export interface Brand<T> {
+	readonly [BrandedSymbol]: T;
+}
+export interface Flavor<T> {
+	readonly [FlavoredSymbol]?: T;
+}

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,3 +1,5 @@
+import type {OmitStrict} from '../types.js';
+
 // Iterated keys in `for..in` are always returned as strings,
 // so to prevent usage errors the key type of `mapFn` is always a string.
 // Symbols are not enumerable as keys, so they're excluded.

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,5 +1,7 @@
 import {v4} from '@lukeed/uuid';
 
+import type {Flavored} from '../types.js';
+
 export type Uuid = Flavored<string, 'Uuid'>;
 
 export const uuid: () => Uuid = v4;


### PR DESCRIPTION
With this **breaking** change, Gro no longer exports global types like `Result` and `Flavored`. They are all available on the root, so:

```ts
// all previously global types are now exported
import type {Result} from '@feltcoop/gro';
```

I like the convenience of global types, but it feels arrogant (better word?) to use them. Gro will play by the same rules that it expects everyone else to follow.

If you have the following in your `tsconfig.json`, remove it, since it's no longer needed:

```json
{
	"compilerOptions": {
		"types": ["@feltcoop/gro"]
	}
}
```