### PR TITLE
add unwrap Result type helper

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - rename `src/types.ts` to `src/utils/types.ts`
   ([#115](https://github.com/feltcoop/gro/pull/115))
+- add `unwrap` helper to `src/utils/types.ts`
+  ([#116](https://github.com/feltcoop/gro/pull/116))
 
 ## 0.7.0
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -31,6 +31,22 @@ export type Assignable<T, K extends keyof T = keyof T> = {
 };
 
 export type Result<TValue = {}, TError = {}> = ({ok: true} & TValue) | ({ok: false} & TError);
+// A helper that says,
+// "hey I know this is wrapped in a `Result`, but I expect it to be `ok`,
+// so if it's not, I understand it will throw an error"
+export const unwrap = <
+	TValue extends {value: TWrappedValue},
+	TWrappedValue,
+	TError extends {reason?: string}
+>(
+	result: Result<TValue, TError>,
+): TWrappedValue => {
+	if (result.ok) {
+		return result.value;
+	} else {
+		throw Error(result.reason || 'Failed to unwrap result with unknown reason');
+	}
+};
 
 /*
 


### PR DESCRIPTION
This adds the the `unwrap` type helper to `src/utils/types.ts`. The idea is that it extracts the value of a wrapped `Result` that you expect to be `ok`. If it's not `ok`, it'll throw. The design is inspired by Rust.

The type looks gnarly but it's easy to use. You shouldn't need any explicit annotations, just past it a `Result`. The type also may be improvable.