### PR TITLE
export more things from root

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,8 +5,9 @@
 - **break**: rename `src/fs/node.ts` from `src/fs/nodeFs.ts`
   ([#154](https://github.com/feltcoop/gro/pull/154))
 - **break**: rename `toArray` from `ensureArray`
-  ([#154](https://github.com/feltcoop/gro/pull/154))
-- export `AsyncStatus` from root
+  ([#117](https://github.com/feltcoop/gro/pull/117))
+- export many more things from root: `import {/* !!! */} from '@feltcoop/gro';`
+  ([#117](https://github.com/feltcoop/gro/pull/117))
 
 ## 0.13.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 
 - **break**: rename `src/fs/node.ts` from `src/fs/nodeFs.ts`
   ([#154](https://github.com/feltcoop/gro/pull/154))
+- **break**: rename `toArray` from `ensureArray`
+  ([#154](https://github.com/feltcoop/gro/pull/154))
+- export `AsyncStatus` from root
 
 ## 0.13.1
 

--- a/src/config/buildConfig.ts
+++ b/src/config/buildConfig.ts
@@ -1,6 +1,6 @@
 import {resolve} from 'path';
 
-import {ensureArray} from '../utils/array.js';
+import {toArray} from '../utils/array.js';
 import {PRIMARY_NODE_BUILD_CONFIG_NAME} from './defaultBuildConfig.js';
 import {paths} from '../paths.js';
 import {blue, gray} from '../utils/terminal.js';
@@ -71,7 +71,7 @@ export const normalizeBuildConfigs = (
 };
 
 const normalizeBuildConfigInput = (input: PartialBuildConfig['input']): BuildConfig['input'] =>
-	ensureArray(input as any[]).map((v) => (typeof v === 'string' ? resolve(paths.source, v) : v));
+	toArray(input as any[]).map((v) => (typeof v === 'string' ? resolve(paths.source, v) : v));
 
 // TODO replace this with JSON schema validation (or most of it at least)
 export const validateBuildConfigs = (buildConfigs: BuildConfig[]): Result<{}, {reason: string}> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,17 @@
 export type {Task, TaskContext} from './task/task.js';
-export {TaskError} from './task/task.js';
-
-export type {Gen} from './gen/gen.js';
+export type {Gen, GenContext} from './gen/gen.js';
 
 // by definition, these are generic, so just export everything
 export * from './utils/types.js';
 
-// these seem useful and generic enough to
+// these seem useful and generic enough to export to users
 export type {AsyncStatus} from './utils/async.js';
+export type {SpawnedProcess, SpawnResult} from './utils/process.js';
+export type {Lazy} from './utils/function.js';
+export type {ErrorClass} from './utils/error.js';
+
+// types above, code below
 export {wait, wrap} from './utils/async.js';
+export {last, toArray, EMPTY_ARRAY} from './utils/array.js';
+export {loadPackageJson} from './project/packageJson.js';
+export {TaskError} from './task/task.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,9 @@ export {TaskError} from './task/task.js';
 
 export type {Gen} from './gen/gen.js';
 
+// by definition, these are generic, so just export everything
 export * from './utils/types.js';
+
+// these seem useful and generic enough to
+export type {AsyncStatus} from './utils/async.js';
+export {wait, wrap} from './utils/async.js';

--- a/src/utils/array.test.ts
+++ b/src/utils/array.test.ts
@@ -1,7 +1,7 @@
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
 
-import {last, ensureArray} from './array.js';
+import {last, toArray} from './array.js';
 
 /* test_last */
 const test_last = suite('last');
@@ -15,15 +15,15 @@ test_last('basic behavior', () => {
 test_last.run();
 /* /test_last */
 
-/* test_ensureArray */
-const test_ensureArray = suite('ensureArray');
+/* test_toArray */
+const test_toArray = suite('toArray');
 
-test_ensureArray('basic behavior', () => {
+test_toArray('basic behavior', () => {
 	const array = [1, 2, 3];
-	t.is(array, ensureArray(array));
-	t.equal([1], ensureArray(1));
-	t.equal([{a: 1}], ensureArray({a: 1}));
+	t.is(array, toArray(array));
+	t.equal([1], toArray(1));
+	t.equal([{a: 1}], toArray({a: 1}));
 });
 
-test_ensureArray.run();
-/* /test_ensureArray */
+test_toArray.run();
+/* /test_toArray */

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -2,4 +2,4 @@ export const EMPTY_ARRAY: any[] = Object.freeze([]) as any;
 
 export const last = <T>(array: T[]): T | undefined => array[array.length - 1];
 
-export const ensureArray = <T>(value: T | T[]): T[] => (Array.isArray(value) ? value : [value]);
+export const toArray = <T>(value: T | T[]): T[] => (Array.isArray(value) ? value : [value]);

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,5 +1,5 @@
-import type {Lazy} from './lazy.js';
-import {lazy} from './lazy.js';
+import type {Lazy} from './function.js';
+import {lazy} from './function.js';
 
 // TODO validation?
 

--- a/src/utils/function.ts
+++ b/src/utils/function.ts
@@ -1,3 +1,10 @@
 export const noop: (...args: any[]) => void = () => {};
 
 export const identity = <T>(t: T): T => t;
+
+export interface Lazy<T> {
+	(): T;
+}
+
+export const lazy = <T>(value: T | Lazy<T>): T =>
+	typeof value === 'function' ? (value as Function)() : value; // TODO fix type casting

--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -1,6 +1,0 @@
-export interface Lazy<T> {
-	(): T;
-}
-
-export const lazy = <T>(value: T | Lazy<T>): T =>
-	typeof value === 'function' ? (value as Function)() : value; // TODO fix type casting


### PR DESCRIPTION
It seems like we may want to export a number of things from the root. Soon, TypeScript 4.3 will deliver package exports support, so we can finally fix the `/dist/` import path wart into Gro's modules. This is a good time to start thinking about what the top-level API should include, thinking ahead to having good import paths as well.

For now we're mostly exporting just types.