### PR TITLE
detect deprecated SPA projects and handle gracefully

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.7.2
+
+- gracefully handle deprecated Gro frontends
+  ([#118](https://github.com/feltcoop/gro/pull/118))
+
 ## 0.7.1
 
 - rename `src/types.ts` to `src/utils/types.ts`

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -8,7 +8,7 @@ import {EXTERNALS_BUILD_DIR_SUBPATH, JS_EXTENSION, paths, toBuildOutPath} from '
 import {nulls, omitUndefined} from '../utils/object.js';
 import {UnreachableError} from '../utils/error.js';
 import {Logger, SystemLogger} from '../utils/log.js';
-import {gray, magenta, red, blue} from '../utils/terminal.js';
+import {gray, magenta, red, blue, cyan} from '../utils/terminal.js';
 import {printError} from '../utils/print.js';
 import type {
 	Build,
@@ -208,8 +208,8 @@ export class Filer implements BuildContext {
 			watcherDebounce,
 		);
 		this.servedDirs = servedDirs;
-		log.trace('buildConfigs', buildConfigs);
-		log.trace('servedDirs', servedDirs);
+		log.trace(cyan('buildConfigs'), buildConfigs);
+		log.trace(cyan('servedDirs'), servedDirs);
 	}
 
 	// Searches for a file matching `path`, limited to the directories that are served.

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -208,6 +208,7 @@ export class Filer implements BuildContext {
 			watcherDebounce,
 		);
 		this.servedDirs = servedDirs;
+		log.trace('buildConfigs', buildConfigs);
 		log.trace('servedDirs', servedDirs);
 	}
 

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -35,7 +35,6 @@ const toDefaultBrowserBuild = (): PartialBuildConfig => ({
 
 // TODO extract helper?
 const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
-	// TODO these paths
 	const [hasIndexHtml, hasIndexTs] = await Promise.all([
 		pathExists('src/index.html'),
 		pathExists('src/index.ts'),

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -2,19 +2,14 @@ import {createFilter} from '@rollup/pluginutils';
 
 import type {GroConfigCreator, PartialGroConfig} from './config.js';
 import {LogLevel} from '../utils/log.js';
+import {PartialBuildConfig} from './buildConfig.js';
 
 // This is the default config that's used if the current project does not define one.
 
 const createConfig: GroConfigCreator = async () => {
-	const assetPaths = ['html', 'css', 'json', 'ico', 'png', 'jpg', 'webp', 'webm', 'mp3'];
 	const config: PartialGroConfig = {
 		builds: [
-			{
-				name: 'browser',
-				platform: 'browser',
-				input: ['index.ts', createFilter(`**/*.{${assetPaths.join(',')}}`)],
-				dist: true,
-			},
+			toDefaultBrowserBuild(),
 			{
 				name: 'node',
 				platform: 'node',
@@ -27,3 +22,11 @@ const createConfig: GroConfigCreator = async () => {
 };
 
 export default createConfig;
+
+const assetPaths = ['html', 'css', 'json', 'ico', 'png', 'jpg', 'webp', 'webm', 'mp3'];
+const toDefaultBrowserBuild = (): PartialBuildConfig => ({
+	name: 'browser',
+	platform: 'browser',
+	input: ['index.ts', createFilter(`**/*.{${assetPaths.join(',')}}`)],
+	dist: true,
+});

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -3,13 +3,14 @@ import {createFilter} from '@rollup/pluginutils';
 import type {GroConfigCreator, PartialGroConfig} from './config.js';
 import {LogLevel} from '../utils/log.js';
 import {PartialBuildConfig} from './buildConfig.js';
+import {pathExists} from '../fs/nodeFs.js';
 
 // This is the default config that's used if the current project does not define one.
 
 const createConfig: GroConfigCreator = async () => {
 	const config: PartialGroConfig = {
 		builds: [
-			toDefaultBrowserBuild(),
+			(await hasDeprecatedGroFrontend()) ? toDefaultBrowserBuild() : null,
 			{
 				name: 'node',
 				platform: 'node',
@@ -24,9 +25,20 @@ const createConfig: GroConfigCreator = async () => {
 export default createConfig;
 
 const assetPaths = ['html', 'css', 'json', 'ico', 'png', 'jpg', 'webp', 'webm', 'mp3'];
+
 const toDefaultBrowserBuild = (): PartialBuildConfig => ({
 	name: 'browser',
 	platform: 'browser',
 	input: ['index.ts', createFilter(`**/*.{${assetPaths.join(',')}}`)],
 	dist: true,
 });
+
+// TODO extract helper?
+const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
+	// TODO these paths
+	const [hasIndexHtml, hasIndexTs] = await Promise.all([
+		pathExists('src/index.html'),
+		pathExists('src/index.ts'),
+	]);
+	return hasIndexHtml && hasIndexTs;
+};


### PR DESCRIPTION
Gro's SPA behavior is now deprecated as we think long term about offering an alternative in SvelteKit to Vite. This changes the default to only include a Gro browser build if that project form is detected. Otherwise, no browser build is created, and SvelteKit with Vite own any frontend completely.