### PR TITLE
detect default server build

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 - gracefully handle deprecated Gro frontends
   ([#118](https://github.com/feltcoop/gro/pull/118))
-- detect default server build
+- detect default server build at `src/server/server.ts`
   ([#119](https://github.com/feltcoop/gro/pull/119))
 
 ## 0.7.1

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - gracefully handle deprecated Gro frontends
   ([#118](https://github.com/feltcoop/gro/pull/118))
+- detect default server build
+  ([#119](https://github.com/feltcoop/gro/pull/119))
 
 ## 0.7.1
 

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -208,8 +208,8 @@ export class Filer implements BuildContext {
 			watcherDebounce,
 		);
 		this.servedDirs = servedDirs;
-		log.trace(cyan('buildConfigs'), buildConfigs);
-		log.trace(cyan('servedDirs'), servedDirs);
+		log.trace(cyan('buildConfigs\n'), buildConfigs);
+		log.trace(cyan('servedDirs\n'), servedDirs);
 	}
 
 	// Searches for a file matching `path`, limited to the directories that are served.

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -14,7 +14,10 @@ const createConfig: GroConfigCreator = async () => {
 			{
 				name: 'node',
 				platform: 'node',
-				input: [createFilter('**/*.{task,test,config,gen}*.ts')],
+				input: [
+					(await pathExists('src/server/server.ts')) ? 'server/server.ts' : null!,
+					createFilter('**/*.{task,test,config,gen}*.ts'),
+				].filter(Boolean),
 			},
 		],
 		logLevel: LogLevel.Trace,

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -6,6 +6,11 @@ import {PartialBuildConfig} from './buildConfig.js';
 import {pathExists} from '../fs/nodeFs.js';
 
 // This is the default config that's used if the current project does not define one.
+// The default config detects
+// Gro's deprecated SPA mode - https://github.com/feltcoop/gro/issues/106 -
+// if it sees both a `src/index.html` and `src/index.ts`.
+// It also looks for a primary Node server entry point at `src/server/server.ts`.
+// Both are no-ops if not detected.
 
 const createConfig: GroConfigCreator = async () => {
 	const config: PartialGroConfig = {

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -13,6 +13,12 @@ To accomplish this, Gro has an optional config file that lives at `$PROJECT/src/
 If a project does not define a config, Gro imports a default config from
 [`src/config/gro.config.default.ts`](/src/config/gro.config.default.ts).
 
+> The default config detects
+> [Gro's deprecated SPA mode](https://github.com/feltcoop/gro/issues/106)
+> if it sees both a `src/index.html` and `src/index.ts`.
+> It also looks for a primary Node server entry point at `src/server/server.ts`.
+> Both are no-ops if not detected.
+
 See [`src/config/config.ts`](/src/config/config.ts) for the config types and implementation.
 
 ## examples


### PR DESCRIPTION
This changes the default build config to detect if there's a `server/server.ts` file. If so, it'll add it as an entry point to the primary Node build. As always, projects can define their own config and builds at `src/gro.config.ts`.