### PR TITLE
fix: clean before production build

### DIFF
--- a/src/project/build.task.ts
+++ b/src/project/build.task.ts
@@ -5,6 +5,7 @@ import {Timings} from '../utils/time.js';
 import {buildSourceDirectory} from '../build/buildSourceDirectory.js';
 import {loadGroConfig} from '../config/config.js';
 import {configureLogLevel} from '../utils/log.js';
+import {cleanDist} from './clean.js';
 
 export const task: Task = {
 	description: 'build, create, and link the distribution',
@@ -19,7 +20,8 @@ export const task: Task = {
 		const timings = new Timings();
 
 		const timeToClean = timings.start('clean');
-		await invokeTask('clean');
+		// await invokeTask('clean');
+		await cleanDist(log);
 		timeToClean();
 
 		const timeToLoadConfig = timings.start('load config');

--- a/src/project/build.task.ts
+++ b/src/project/build.task.ts
@@ -18,6 +18,10 @@ export const task: Task = {
 		log.info(`building for ${process.env.NODE_ENV}`);
 		const timings = new Timings();
 
+		const timeToClean = timings.start('clean');
+		await invokeTask('clean');
+		timeToClean();
+
 		const timeToLoadConfig = timings.start('load config');
 		const config = await loadGroConfig();
 		configureLogLevel(config.logLevel);


### PR DESCRIPTION
This cleans the Gro `dist/` at the beginning of the production build. Previously, the important code paths were cleaning properly, but `gro project/build` did not, causing confusion.