### PR TITLE
add env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ It includes:
 
 - [unbundled development](/src/docs/unbundled.md)
   for [Svelte](https://github.com/sveltejs/svelte) UIs
-  and Node servers/libraries, inspired by [Snowpack](https://github.com/pikapkg/snowpack)
+  (inspired by [Snowpack](https://github.com/pikapkg/snowpack))
+  and integrated development for Node servers and libraries
   - Gro supports SPAs on the frontend,
     but that functionality is now deprecated for
     [SvelteKit](https://github.com/sveltejs/kit) and [Vite](https://github.com/vitejs/vite),

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It includes:
 - [unbundled development](/src/docs/unbundled.md)
   for [Svelte](https://github.com/sveltejs/svelte) UIs
   (inspired by [Snowpack](https://github.com/pikapkg/snowpack))
-  and integrated development for Node servers and libraries
+  and integrated tools for Node servers and libraries
   - Gro supports SPAs on the frontend,
     but that functionality is now deprecated for
     [SvelteKit](https://github.com/sveltejs/kit) and [Vite](https://github.com/vitejs/vite),

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3
 
+- add `src/env.ts` and `import.meta.env.DEV` support inspired by SvelteKit
 - internal rename of `src/globalTypes.ts` to `src/globals.d.ts`
   now that they only declare module types
   ([#120](https://github.com/feltcoop/gro/pull/120))

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## 0.7.3
 
 - add `src/env.ts` and `import.meta.env.DEV` support inspired by SvelteKit
+  ([#122](https://github.com/feltcoop/gro/pull/122))
 - internal rename of `src/globalTypes.ts` to `src/globals.d.ts`
   now that they only declare module types
   ([#120](https://github.com/feltcoop/gro/pull/120))

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "start": "gro",
     "test": "gro test",
-    "bootstrap": "rm -rf .gro dist && esbuild src/**/*.ts src/*.ts --outdir=.gro/prod/node/; cp -r .gro/prod/node/ dist/ && npm link",
+    "bootstrap": "rm -rf .gro dist && esbuild src/**/*.ts src/*.ts --outdir=.gro/prod/node/ --define:import.meta.env.DEV=true; cp -r .gro/prod/node/ dist/ && npm link",
     "dev": "clear && npm run bootstrap && gro dev",
     "build": "clear && npm run bootstrap && gro project/build",
     "buildprod": "clear && npm run bootstrap && gro project/build && rm -rf .gro",

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -1,5 +1,6 @@
 import {resolve} from 'path';
 
+import {dev} from './env.js';
 import {pathExists} from './fs/nodeFs.js';
 import type {Task} from './task/task.js';
 import {createBuild} from './project/build.js';
@@ -19,7 +20,7 @@ export const task: Task = {
 		log.info('inputFiles', inputFiles);
 
 		// TODO what's the best way to define these types? make `Task` generic? schema validation?
-		const dev: boolean = 'dev' in args ? !!args.dev : process.env.NODE_ENV !== 'production';
+		console.log('dev', dev);
 		if (dev) {
 			log.warn('building in development mode; normally this is only for diagnostics');
 		}

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -20,6 +20,9 @@ export const task: Task = {
 
 		// TODO what's the best way to define these types? make `Task` generic? schema validation?
 		const dev: boolean = 'dev' in args ? !!args.dev : process.env.NODE_ENV !== 'production';
+		if (dev) {
+			log.warn('building in development mode; normally this is only for diagnostics');
+		}
 		const watch: boolean = (args.watch as any) || false;
 		const outputDir: string = (args.outputDir as any) || DEFAULT_OUTPUT_DIR;
 		const mapInputOptions = args.mapInputOptions as any;

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -34,7 +34,7 @@ export const task: Task = {
 		const basePath = undefined; // TODO parameterized options?
 		const tsconfig = loadTsconfig(log, tsconfigPath, basePath);
 		const target = toEcmaScriptTarget(tsconfig.compilerOptions?.target);
-		const sourcemap = tsconfig.compilerOptions?.sourceMap ?? process.env.NODE_ENV !== 'production';
+		const sourcemap = tsconfig.compilerOptions?.sourceMap ?? process.env.NODE_ENV === 'development';
 		const esbuildOptions = getDefaultEsbuildOptions(target, sourcemap);
 
 		if (inputFiles.length) {

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -7,9 +7,6 @@ import {createBuild} from './project/build.js';
 import {getDefaultEsbuildOptions} from './build/esbuildBuildHelpers.js';
 import {loadTsconfig, toEcmaScriptTarget} from './build/tsBuildHelpers.js';
 
-// TODO how should this be done? do we want to allow development builds with Rollup?
-process.env.NODE_ENV = 'production';
-
 const DEFAULT_OUTPUT_DIR = 'dist/';
 const DEFAULT_INPUT_NAMES = ['src/index.ts'];
 
@@ -18,9 +15,6 @@ export const task: Task = {
 	run: async ({log, args}): Promise<void> => {
 		const inputFiles = await resolveInputFiles(args._);
 		log.info('inputFiles', inputFiles);
-
-		// TODO what's the best way to define these types? make `Task` generic? schema validation?
-		console.log('dev', dev);
 		if (dev) {
 			log.warn('building in development mode; normally this is only for diagnostics');
 		}
@@ -35,7 +29,7 @@ export const task: Task = {
 		const basePath = undefined; // TODO parameterized options?
 		const tsconfig = loadTsconfig(log, tsconfigPath, basePath);
 		const target = toEcmaScriptTarget(tsconfig.compilerOptions?.target);
-		const sourcemap = tsconfig.compilerOptions?.sourceMap ?? process.env.NODE_ENV === 'development';
+		const sourcemap = tsconfig.compilerOptions?.sourceMap ?? true;
 		const esbuildOptions = getDefaultEsbuildOptions(target, sourcemap);
 
 		if (inputFiles.length) {

--- a/src/build/esbuildBuildHelpers.ts
+++ b/src/build/esbuildBuildHelpers.ts
@@ -21,7 +21,7 @@ export const getDefaultEsbuildOptions = (
 	tsconfigRaw: {compilerOptions: {importsNotUsedAsValues: 'remove'}},
 	define: {
 		'import.meta.env.DEV': JSON.stringify(dev),
-		'import.meta.env.SSR': 'false', // TODO
+		// 'import.meta.env.SSR': 'false', // TODO (when implemented, also add to bootstrap npm script)
 	},
 });
 
@@ -35,6 +35,6 @@ export const getDefaultEsbuildPreprocessOptions = (
 	tsconfigRaw: {compilerOptions: {}}, // pass an empty object so the preprocessor doesn't load the tsconfig
 	define: {
 		'import.meta.env.DEV': JSON.stringify(dev),
-		'import.meta.env.SSR': 'false', // TODO
+		// 'import.meta.env.SSR': 'false', // TODO (when implemented, also add to bootstrap npm script)
 	},
 });

--- a/src/build/esbuildBuildHelpers.ts
+++ b/src/build/esbuildBuildHelpers.ts
@@ -20,7 +20,8 @@ export const getDefaultEsbuildOptions = (
 	charset: 'utf8', // following `svelte-preprocess-esbuild` here
 	tsconfigRaw: {compilerOptions: {importsNotUsedAsValues: 'remove'}},
 	define: {
-		'import.meta.env': JSON.stringify(toMetaEnv(dev)),
+		'import.meta.env.DEV': JSON.stringify(dev),
+		'import.meta.env.SSR': 'false', // TODO
 	},
 });
 
@@ -33,11 +34,7 @@ export const getDefaultEsbuildPreprocessOptions = (
 	sourcemap,
 	tsconfigRaw: {compilerOptions: {}}, // pass an empty object so the preprocessor doesn't load the tsconfig
 	define: {
-		'import.meta.env': JSON.stringify(toMetaEnv(dev)),
+		'import.meta.env.DEV': JSON.stringify(dev),
+		'import.meta.env.SSR': 'false', // TODO
 	},
-});
-
-const toMetaEnv = (dev: boolean) => ({
-	DEV: dev,
-	SSR: false, // TODO
 });

--- a/src/build/esbuildBuildHelpers.ts
+++ b/src/build/esbuildBuildHelpers.ts
@@ -11,6 +11,7 @@ export interface EsbuildTransformOptions extends esbuild.TransformOptions {
 export const getDefaultEsbuildOptions = (
 	target: EcmaScriptTarget = DEFAULT_ECMA_SCRIPT_TARGET,
 	sourcemap = true,
+	dev = true,
 ): EsbuildTransformOptions => ({
 	target,
 	sourcemap,
@@ -18,13 +19,25 @@ export const getDefaultEsbuildOptions = (
 	loader: 'ts',
 	charset: 'utf8', // following `svelte-preprocess-esbuild` here
 	tsconfigRaw: {compilerOptions: {importsNotUsedAsValues: 'remove'}},
+	define: {
+		'import.meta.env': JSON.stringify(toMetaEnv(dev)),
+	},
 });
 
 export const getDefaultEsbuildPreprocessOptions = (
 	target: EcmaScriptTarget = DEFAULT_ECMA_SCRIPT_TARGET,
 	sourcemap = true,
+	dev = true,
 ): Partial<sveltePreprocessEsbuild.Options> => ({
 	target,
 	sourcemap,
 	tsconfigRaw: {compilerOptions: {}}, // pass an empty object so the preprocessor doesn't load the tsconfig
+	define: {
+		'import.meta.env': JSON.stringify(toMetaEnv(dev)),
+	},
+});
+
+const toMetaEnv = (dev: boolean) => ({
+	DEV: dev,
+	SSR: false, // TODO
 });

--- a/src/build/esbuildBuilder.ts
+++ b/src/build/esbuildBuilder.ts
@@ -33,11 +33,12 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 	const getEsbuildOptions = (
 		sourcemap: boolean,
 		target: EcmaScriptTarget,
+		dev: boolean,
 	): esbuild.TransformOptions => {
 		const key = sourcemap + target;
 		const existingEsbuildOptions = esbuildOptionsCache.get(key);
 		if (existingEsbuildOptions !== undefined) return existingEsbuildOptions;
-		const newEsbuildOptions = createEsbuildOptions(target, sourcemap);
+		const newEsbuildOptions = createEsbuildOptions(target, sourcemap, dev);
 		esbuildOptionsCache.set(key, newEsbuildOptions);
 		return newEsbuildOptions;
 	};
@@ -55,7 +56,7 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 		}
 		const outDir = toBuildOutPath(dev, buildConfig.name, source.dirBasePath, buildDir);
 		const esbuildOptions = {
-			...getEsbuildOptions(sourcemap, target),
+			...getEsbuildOptions(sourcemap, target, dev),
 			sourcefile: source.id,
 		};
 		const output = await esbuild.transform(source.contents, esbuildOptions);
@@ -95,7 +96,8 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 type CreateEsbuildOptions = (
 	target: EcmaScriptTarget,
 	sourcemap: boolean,
+	dev: boolean,
 ) => esbuild.TransformOptions;
 
-const createDefaultEsbuildOptions: CreateEsbuildOptions = (target, sourcemap) =>
-	getDefaultEsbuildOptions(target, sourcemap);
+const createDefaultEsbuildOptions: CreateEsbuildOptions = (target, sourcemap, dev) =>
+	getDefaultEsbuildOptions(target, sourcemap, dev);

--- a/src/build/externalsBuilder.ts
+++ b/src/build/externalsBuilder.ts
@@ -87,7 +87,7 @@ export const createExternalsBuilder = (opts: InitialOptions = {}): ExternalsBuil
 			groSveltePlugin({
 				dev,
 				addCssBuild: addSvelteCssBuild,
-				preprocessor: createDefaultPreprocessor(target, sourcemap),
+				preprocessor: createDefaultPreprocessor(target, sourcemap, dev),
 				compileOptions: {},
 			}),
 		];

--- a/src/build/externalsBuilder.ts
+++ b/src/build/externalsBuilder.ts
@@ -23,6 +23,7 @@ import {
 	toSpecifiers,
 } from './externalsBuildHelpers.js';
 import {EMPTY_ARRAY} from '../utils/array.js';
+import {numberFromEnv} from '../utils/env.js';
 
 /*
 
@@ -163,7 +164,7 @@ export const createExternalsBuilder = (opts: InitialOptions = {}): ExternalsBuil
 // but it causes unnecessary delays building externals
 const IDLE_CHECK_INTERVAL = 200; // needs to be smaller than `IDLE_CHECK_DELAY`
 const IDLE_CHECK_DELAY = 700; // needs to be larger than `IDLE_CHECK_INTERVAL`
-const IDLE_TIME_LIMIT = parseInt((process.env as any).GRO_IDLE_TIME_LIMIT, 10) || 20000; // TODO hacky failsafe, it'll time out after this long, which may be totally busted in some cases..
+const IDLE_TIME_LIMIT = numberFromEnv('GRO_IDLE_TIME_LIMIT', 20000); // TODO hacky failsafe, it'll time out after this long, which may be totally busted in some cases..
 // TODO wait what's the relationship between those two? check for errors?
 
 // TODO this hackily guesses if the filer is idle enough to start installing externals

--- a/src/build/svelteBuildHelpers.ts
+++ b/src/build/svelteBuildHelpers.ts
@@ -17,10 +17,11 @@ import type {OmitStrict} from '../index.js';
 export type CreatePreprocessor = (
 	target: EcmaScriptTarget,
 	sourcemap: boolean,
+	dev: boolean,
 ) => PreprocessorGroup | PreprocessorGroup[] | null;
 
-export const createDefaultPreprocessor: CreatePreprocessor = (target, sourcemap) =>
-	sveltePreprocessEsbuild.typescript(getDefaultEsbuildPreprocessOptions(target, sourcemap));
+export const createDefaultPreprocessor: CreatePreprocessor = (target, sourcemap, dev) =>
+	sveltePreprocessEsbuild.typescript(getDefaultEsbuildPreprocessOptions(target, sourcemap, dev));
 
 // TODO type could be improved, not sure how tho
 export interface SvelteCompileStats {

--- a/src/build/svelteBuilder.ts
+++ b/src/build/svelteBuilder.ts
@@ -57,11 +57,12 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 	const getPreprocessor = (
 		sourcemap: boolean,
 		target: EcmaScriptTarget,
+		dev: boolean,
 	): PreprocessorGroup | PreprocessorGroup[] | null => {
 		const key = sourcemap + target;
 		const existingPreprocessor = preprocessorCache.get(key);
 		if (existingPreprocessor !== undefined) return existingPreprocessor;
-		const newPreprocessor = createPreprocessor(target, sourcemap);
+		const newPreprocessor = createPreprocessor(target, sourcemap, dev);
 		preprocessorCache.set(key, newPreprocessor);
 		return newPreprocessor;
 	};
@@ -83,7 +84,7 @@ export const createSvelteBuilder = (opts: InitialOptions = {}): SvelteBuilder =>
 
 		// TODO see rollup-plugin-svelte for how to track deps
 		// let dependencies = [];
-		const preprocessor = getPreprocessor(sourcemap, target);
+		const preprocessor = getPreprocessor(sourcemap, target, dev);
 		if (preprocessor !== null) {
 			const preprocessed = await svelte.preprocess(contents, preprocessor, {filename: id});
 			preprocessedCode = preprocessed.code;

--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -1,4 +1,5 @@
-import {Task, TaskError} from './task/task.js';
+import type {Task} from './task/task.js';
+import {TaskError} from './task/task.js';
 import {findGenModules} from './gen/genModule.js';
 
 export const task: Task = {

--- a/src/cli/invoke.ts
+++ b/src/cli/invoke.ts
@@ -8,9 +8,6 @@ sourcemapSupport.install({
 	handleUncaughtExceptions: false,
 });
 
-// set up the env
-if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development';
-
 import mri from 'mri';
 
 import type {Args} from './types.js';

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,3 +1,4 @@
+import {dev} from '../env.js';
 import {paths, groPaths, toBuildOutPath, CONFIG_BUILD_BASE_PATH, toImportId} from '../paths.js';
 import {
 	BuildConfig,
@@ -113,7 +114,6 @@ Caveats
 export const loadGroConfig = async (): Promise<GroConfig> => {
 	if (cachedConfig !== undefined) return cachedConfig;
 
-	const dev = process.env.NODE_ENV !== 'production'; // TODO should this be a parameter or accessed via a helper?
 	const log = new SystemLogger([magenta('[config]')]);
 	const options: GroConfigCreatorOptions = {log, dev};
 
@@ -195,7 +195,7 @@ const normalizeConfig = (config: PartialGroConfig): GroConfig => {
 	const primaryBrowserBuildConfig =
 		buildConfigs.find((b) => b.primary && b.platform === 'browser') || null;
 	return {
-		sourcemap: process.env.NODE_ENV !== 'production', // TODO hmm where does this come from?
+		sourcemap: true,
 		host: DEFAULT_SERVER_HOST,
 		port: DEFAULT_SERVER_PORT,
 		logLevel: LogLevel.Trace,

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -6,9 +6,6 @@ import {copy, pathExists} from './fs/nodeFs.js';
 import {paths} from './paths.js';
 import {printError, printPath} from './utils/print.js';
 
-// TODO how should this be done?
-process.env.NODE_ENV = 'production';
-
 // TODO customize
 const distDirName = basename(paths.dist);
 const deploymentBranch = 'gh-pages';

--- a/src/dist.task.ts
+++ b/src/dist.task.ts
@@ -1,5 +1,6 @@
-import {copy} from './fs/nodeFs.js';
 import type {Task} from './task/task.js';
+import {dev} from './env.js';
+import {copy} from './fs/nodeFs.js';
 import {paths, toBuildOutPath} from './paths.js';
 import {isTestBuildFile, isTestBuildArtifact} from './fs/testModule.js';
 import {printPath} from './utils/print.js';
@@ -18,7 +19,6 @@ export const task: Task = {
 
 		// This reads the `dist` flag on the build configs to help construct the final dist directory.
 		// See the docs at `./docs/config.md`.
-		const dev = process.env.NODE_ENV !== 'production';
 		const config = await loadGroConfig();
 		configureLogLevel(config.logLevel);
 		const buildConfigsForDist = config.builds.filter((b) => b.dist);

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,12 @@
+declare global {
+	interface ImportMeta {
+		env: {
+			DEV: boolean;
+			SSR: boolean;
+		};
+	}
+}
+
+export const dev = import.meta.env.DEV;
+
+export const ssr = import.meta.env.SSR;

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,12 +1,13 @@
+// mirrors what SvelteKit does
 declare global {
 	interface ImportMeta {
 		env: {
 			DEV: boolean;
-			SSR: boolean;
+			// SSR: boolean;
 		};
 	}
 }
 
 export const dev = import.meta.env.DEV;
 
-export const ssr = import.meta.env.SSR;
+// export const ssr = import.meta.SSR; // default to not-SSR.. BSR?

--- a/src/format.task.ts
+++ b/src/format.task.ts
@@ -1,4 +1,5 @@
-import {Task, TaskError} from './task/task.js';
+import type {Task} from './task/task.js';
+import {TaskError} from './task/task.js';
 import {printKeyValue} from './utils/print.js';
 import {formatDirectory} from './build/formatDirectory.js';
 import {paths} from './paths.js';

--- a/src/gen.task.ts
+++ b/src/gen.task.ts
@@ -1,6 +1,7 @@
+import type {Task} from './task/task.js';
+import {TaskError} from './task/task.js';
 import {red, green, gray} from './utils/terminal.js';
 import {outputFile} from './fs/nodeFs.js';
-import {Task, TaskError} from './task/task.js';
 import {runGen} from './gen/runGen.js';
 import {loadGenModule, checkGenModules, findGenModules} from './gen/genModule.js';
 import {printPath, printMs, printError, printTiming} from './utils/print.js';

--- a/src/project/build.task.ts
+++ b/src/project/build.task.ts
@@ -1,4 +1,5 @@
 import type {Task} from '../task/task.js';
+import {dev} from '../env.js';
 import {printTiming} from '../utils/print.js';
 import {spawnProcess} from '../utils/process.js';
 import {Timings} from '../utils/time.js';
@@ -8,14 +9,7 @@ import {configureLogLevel} from '../utils/log.js';
 
 export const task: Task = {
 	description: 'build, create, and link the distribution',
-	run: async ({invokeTask, args, log}) => {
-		// TODO improve this - maybe this should be a global gro task flag?
-		if (!args.D && !args.dev) {
-			process.env.NODE_ENV = 'production';
-		}
-		const dev = process.env.NODE_ENV !== 'production';
-
-		log.info(`building for ${process.env.NODE_ENV}`);
+	run: async ({invokeTask, log}) => {
 		const timings = new Timings();
 
 		const timeToLoadConfig = timings.start('load config');

--- a/src/project/build.ts
+++ b/src/project/build.ts
@@ -125,7 +125,7 @@ const createInputOptions = (inputFile: string, options: Options, _log: Logger): 
 				addCssBuild: addSvelteCssBuild,
 				preprocessor: [
 					sveltePreprocessEsbuild.typescript(
-						getDefaultEsbuildPreprocessOptions(esbuildOptions.target, sourcemap),
+						getDefaultEsbuildPreprocessOptions(esbuildOptions.target, sourcemap, dev),
 					),
 				],
 				compileOptions: {},

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -3,13 +3,14 @@ import {createDevServer} from './server/server.js';
 import {Filer} from './build/Filer.js';
 import {printPath} from './utils/print.js';
 import {loadHttpsCredentials} from './server/https.js';
+import {numberFromEnv, stringFromEnv} from './utils/env.js';
 
 export const task: Task = {
 	description: 'start static file server',
 	run: async ({log, args}): Promise<void> => {
 		// TODO validate
-		const host: string | undefined = (args.host as string) || process.env.HOST;
-		const port: number | undefined = Number(args.port) || Number(process.env.PORT) || undefined;
+		const host: string | undefined = (args.host as string) || stringFromEnv('HOST');
+		const port: number | undefined = Number(args.port) || numberFromEnv('PORT');
 		const servedDirs: string[] = args._.length ? args._ : ['.'];
 
 		// TODO this is inefficient for just serving files in a directory

--- a/src/server/https.ts
+++ b/src/server/https.ts
@@ -1,5 +1,6 @@
 import {join} from 'path';
 
+import {stringFromEnv} from '../utils/env.js';
 import {pathExists, readFile} from '../fs/nodeFs.js';
 import type {Logger} from '../utils/log.js';
 
@@ -8,10 +9,12 @@ export interface HttpsCredentials {
 	key: string;
 }
 
-const DEFAULT_CERT_FILE: string =
-	process.env.GRO_CERT_FILE || join(process.cwd(), 'localhost-cert.pem');
-const DEFAULT_CERTKEY_FILE: string =
-	process.env.GRO_CERTKEY_FILE || join(process.cwd(), 'localhost-privkey.pem');
+const DEFAULT_CERT_FILE: string = stringFromEnv('GRO_CERT_FILE', () =>
+	join(process.cwd(), 'localhost-cert.pem'),
+);
+const DEFAULT_CERTKEY_FILE: string = stringFromEnv('GRO_CERTKEY_FILE', () =>
+	join(process.cwd(), 'localhost-privkey.pem'),
+);
 
 // Tries to load the given cert and key, returning `null` if unable.
 export const loadHttpsCredentials = async (

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -25,6 +25,7 @@ import {paths} from '../paths.js';
 import {loadPackageJson} from '../project/packageJson.js';
 import type {ProjectState} from './projectState.js';
 import type {Assignable, PartialExcept} from '../index.js';
+import {numberFromEnv, stringFromEnv} from '../utils/env.js';
 
 type Http2StreamHandler = (
 	stream: ServerHttp2Stream,
@@ -39,8 +40,8 @@ export interface DevServer {
 	readonly port: number;
 }
 
-export const DEFAULT_SERVER_HOST: string = process.env.HOST || 'localhost';
-export const DEFAULT_SERVER_PORT: number = Number(process.env.PORT) || 8999;
+export const DEFAULT_SERVER_HOST: string = stringFromEnv('HOST', 'localhost');
+export const DEFAULT_SERVER_PORT: number = numberFromEnv('PORT', 8999);
 
 export interface Options {
 	filer: Filer;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8,6 +8,7 @@ import {
 import {createSecureServer as createHttp2Server, Http2Server, ServerHttp2Stream} from 'http2';
 import type {ListenOptions} from 'net';
 
+import {dev} from '../env.js';
 import {cyan, yellow, gray, red, rainbow, green} from '../utils/terminal.js';
 import {Logger, SystemLogger} from '../utils/log.js';
 import {stripAfter} from '../utils/string.js';
@@ -62,7 +63,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 
 export const createDevServer = (opts: InitialOptions): DevServer => {
 	// We don't want to have to worry about the security of the dev server.
-	if (process.env.NODE_ENV !== 'development') {
+	if (!dev) {
 		throw Error('The dev server may only be run in development for security reasons.');
 	}
 

--- a/src/task/fixtures/testFailingTaskModule.ts
+++ b/src/task/fixtures/testFailingTaskModule.ts
@@ -1,1 +1,2 @@
 throw Error('for testing purposes');
+export {};

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -1,4 +1,6 @@
-import {Task, TaskError} from './task/task.js';
+import type {Task} from './task/task.js';
+import {TaskError} from './task/task.js';
+import {dev} from './env.js';
 import {printTiming} from './utils/print.js';
 import {Timings} from './utils/time.js';
 import {spawnProcess} from './utils/process.js';
@@ -14,7 +16,6 @@ export const task: Task = {
 	run: async ({log}): Promise<void> => {
 		const timings = new Timings();
 
-		const dev = process.env.NODE_ENV !== 'production';
 		const dir = toRootPath(toBuildOutPath(dev, DEFAULT_BUILD_CONFIG_NAME));
 
 		const timeToRunUvu = timings.start('run test with uvu');

--- a/src/typecheck.task.ts
+++ b/src/typecheck.task.ts
@@ -1,4 +1,5 @@
-import {Task, TaskError} from './task/task.js';
+import type {Task} from './task/task.js';
+import {TaskError} from './task/task.js';
 import {spawnProcess} from './utils/process.js';
 import {printKeyValue} from './utils/print.js';
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,20 @@
+import type {Lazy} from './lazy.js';
+import {lazy} from './lazy.js';
+
+// TODO validation?
+
+interface StringFromEnv {
+	(key: string): string | undefined;
+	(key: string, fallback: string | Lazy<string>): string;
+}
+
+export const stringFromEnv: StringFromEnv = (key: string, fallback?: string | Lazy<string>) =>
+	(key in process.env && process.env[key]) || ((fallback && lazy(fallback)) as string); // TODO fix type casting
+
+interface NumberFromEnv {
+	(key: string): number | undefined;
+	(key: string, fallback: number | Lazy<number>): number;
+}
+
+export const numberFromEnv: NumberFromEnv = (key: string, fallback?: number | Lazy<number>) =>
+	(key in process.env && Number(process.env[key])) || (lazy(fallback) as any); // TODO fix type casting

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -17,4 +17,4 @@ interface NumberFromEnv {
 }
 
 export const numberFromEnv: NumberFromEnv = (key: string, fallback?: number | Lazy<number>) =>
-	(key in process.env && Number(process.env[key])) || (lazy(fallback) as any); // TODO fix type casting
+	(key in process.env && Number(process.env[key])) || (fallback && (lazy(fallback) as any)); // TODO fix type casting

--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -1,0 +1,6 @@
+export interface Lazy<T> {
+	(): T;
+}
+
+export const lazy = <T>(value: T | Lazy<T>): T =>
+	typeof value === 'function' ? (value as Function)() : value; // TODO fix type casting

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     // "diagnostics": false, // Show diagnostic information.
     // "incremental": true, // Enable incremental compilation by reading/writing information from prior compilations to a file on disk.
     // TODO turn `isolatedModules` on once TS4.3 lands and `exports` are added and `globals` is redesigned
-    "isolatedModules": false, // Transpile each file as a separate module (similar to 'ts.transpileModule').
+    "isolatedModules": true, // Transpile each file as a separate module (similar to 'ts.transpileModule').
     "importsNotUsedAsValues": "remove", // This flag controls how imports work. When set to `remove`, imports that only reference types are dropped. When set to `preserve`, imports are never dropped. When set to `error`, imports that can be replaced with `import type` will result in a compiler error. Requires TypeScript version 3.8 or later.
     // "listEmittedFiles": false, // Print names of generated files part of the compilation.
     // "listFiles": true, // Print names of files part of the compilation.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,6 @@
     // "composite": true, // Enable project compilation: https://www.typescriptlang.org/docs/handbook/project-references.html
     // "diagnostics": false, // Show diagnostic information.
     // "incremental": true, // Enable incremental compilation by reading/writing information from prior compilations to a file on disk.
-    // TODO turn `isolatedModules` on once TS4.3 lands and `exports` are added and `globals` is redesigned
     "isolatedModules": true, // Transpile each file as a separate module (similar to 'ts.transpileModule').
     "importsNotUsedAsValues": "remove", // This flag controls how imports work. When set to `remove`, imports that only reference types are dropped. When set to `preserve`, imports are never dropped. When set to `error`, imports that can be replaced with `import type` will result in a compiler error. Requires TypeScript version 3.8 or later.
     // "listEmittedFiles": false, // Print names of generated files part of the compilation.


### PR DESCRIPTION
Inspired by SvelteKit, Gro finally made a decision about how to handle the development/production switch, aka `process.env.NODE_ENV` and `import.meta.env.DEV`. It's nice when others make great decisions for you.

Modules should use `import {dev} from '@feltcoop/gro/dist/env.js'` for now. (the `dist/` goes away with TypeScript 4.3 soon) It uses the same pattern as SvelteKit, using `import.meta.env.DEV`. Internally it replaces the values at buildtime using `esbuild`'s [`define`](https://esbuild.github.io/api/#define).