### PR TITLE
filer event emitter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.8.2
+
+- change `Filer` to extend `EventEmitter` and emit a `'build'` event
+  ([#125](https://github.com/feltcoop/gro/pull/125))
+
 ## 0.8.1
 
 - fix build not filtering out `null` inputs

--- a/package-lock.json
+++ b/package-lock.json
@@ -589,6 +589,12 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
+    "strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "dev": true
+    },
     "svelte": {
       "version": "3.31.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.31.0.tgz",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "@types/fs-extra": "^9.0.8",
     "@types/node": "^14.14.35",
     "@types/prettier": "^2.2.3",
-    "@types/source-map-support": "^0.5.3"
+    "@types/source-map-support": "^0.5.3",
+    "strict-event-emitter-types": "^2.0.0"
   },
   "prettier": {
     "useTabs": true,

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -1,6 +1,7 @@
 import {resolve, extname, join} from 'path';
 import lexer from 'es-module-lexer';
 import {EventEmitter} from 'events';
+import StrictEventEmitter from 'strict-event-emitter-types';
 
 import {FilerDir, FilerDirChangeCallback, createFilerDir} from '../build/FilerDir.js';
 import {MapDependencyToSourceId, mapDependencyToSourceId} from './utils.js';
@@ -62,6 +63,12 @@ TODO
 - probably silence a lot of the logging (or add `debug` log level?) once tests are added
 
 */
+
+// The Filer is an `EventEmitter` with the following events:
+type FilerEmitter = StrictEventEmitter<EventEmitter, FilerEvents>;
+interface FilerEvents {
+	build: {sourceFile: SourceFile; buildConfig: BuildConfig};
+}
 
 export type FilerFile = SourceFile | BuildFile; // TODO or `Directory`?
 
@@ -152,7 +159,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 	};
 };
 
-export class Filer extends EventEmitter implements BuildContext {
+export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements BuildContext {
 	// TODO think about accessors - I'm currently just making things public when I need them here
 	private readonly files: Map<string, FilerFile> = new Map();
 	private readonly fileExists: (id: string) => boolean = (id) => this.files.has(id);


### PR DESCRIPTION
This changes the `Filer` to extend `EventEmitter` and emit a `'build'` event for each source file and build config that gets built.

The motivating usecase is to let usercode implement a server restart feature. This seems like a good API direction for the `Filer` to go to minimally support this. We'll consider more events as they're needed.