### PR TITLE
change type deps to regular deps

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.8.3
+
+- change `strict-event-emitter-types` to a regular dependency
+  ([#126](https://github.com/feltcoop/gro/pull/126))
+
 ## 0.8.2
 
 - change `Filer` to extend `EventEmitter` and emit a `'build'` event

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.8.3
 
-- change `strict-event-emitter-types` to a regular dependency
+- change type deps exposed to users to regular dependencies
   ([#126](https://github.com/feltcoop/gro/pull/126))
 
 ## 0.8.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -202,6 +202,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.3.tgz",
       "integrity": "sha512-fvjMjVH8Rmokw2dWh1dkj90iX5R8FPjeZzjNH+6eFXReh0QnHFf1YBl3B0CF0RohIAA3SDRJsGeeUWKl6d7HqA==",
+      "dev": true,
       "requires": {
         "source-map": "^0.6.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,24 +173,22 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "@types/fs-extra": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.8.tgz",
-      "integrity": "sha512-bnlTVTwq03Na7DpWxFJ1dvnORob+Otb8xHyUqUWhqvz/Ksg8+JXPlR52oeMSZ37YEOa5PyccbgUNutiQdi13TA==",
-      "dev": true,
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.9.tgz",
+      "integrity": "sha512-5TqDycCl0oMzwzd1cIjSJWMKMvLCDVErle4ZTjU4EmHDURR/+yZghe6GDHMCpHtcVfq0x0gMoOM546/5TbYHrg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "14.14.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
+      "version": "14.14.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
+      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
     },
     "@types/prettier": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
-      "integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
-      "dev": true
+      "integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA=="
     },
     "@types/resolve": {
       "version": "1.17.1",
@@ -204,7 +202,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.3.tgz",
       "integrity": "sha512-fvjMjVH8Rmokw2dWh1dkj90iX5R8FPjeZzjNH+6eFXReh0QnHFf1YBl3B0CF0RohIAA3SDRJsGeeUWKl6d7HqA==",
-      "dev": true,
       "requires": {
         "source-map": "^0.6.0"
       }
@@ -592,8 +589,7 @@
     "strict-event-emitter-types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
-      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
-      "dev": true
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
     },
     "svelte": {
       "version": "3.31.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,10 @@
     "@rollup/plugin-commonjs": "^16.0.0",
     "@rollup/plugin-node-resolve": "^10.0.0",
     "@rollup/pluginutils": "^4.1.0",
+    "@types/fs-extra": "^9.0.9",
+    "@types/node": "^14.14.37",
+    "@types/prettier": "^2.2.3",
+    "@types/source-map-support": "^0.5.3",
     "cheap-watch": "^1.0.3",
     "dequal": "^2.0.2",
     "es-module-lexer": "^0.4.1",
@@ -66,6 +70,7 @@
     "rollup": "^2.37.1",
     "source-map-support": "^0.5.19",
     "sourcemap-codec": "^1.4.8",
+    "strict-event-emitter-types": "^2.0.0",
     "svelte": "^3.31.0",
     "svelte-preprocess-esbuild": "^2.0.0",
     "terser": "^5.6.1",
@@ -73,13 +78,7 @@
     "typescript": "^4.2.3",
     "uvu": "^0.5.1"
   },
-  "devDependencies": {
-    "@types/fs-extra": "^9.0.8",
-    "@types/node": "^14.14.35",
-    "@types/prettier": "^2.2.3",
-    "@types/source-map-support": "^0.5.3",
-    "strict-event-emitter-types": "^2.0.0"
-  },
+  "devDependencies": {},
   "prettier": {
     "useTabs": true,
     "printWidth": 100,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@types/fs-extra": "^9.0.9",
     "@types/node": "^14.14.37",
     "@types/prettier": "^2.2.3",
-    "@types/source-map-support": "^0.5.3",
     "cheap-watch": "^1.0.3",
     "dequal": "^2.0.2",
     "es-module-lexer": "^0.4.1",
@@ -78,7 +77,9 @@
     "typescript": "^4.2.3",
     "uvu": "^0.5.1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@types/source-map-support": "^0.5.3"
+  },
   "prettier": {
     "useTabs": true,
     "printWidth": 100,


### PR DESCRIPTION
This changes Gro's type definition dependencies to be regular dependencies, not dev only. User code sometimes needs these types when they're transitively exposed, so I'm doing the safe thing and shipping all of them unless I know for sure it won't be exposed to users.