### PR TITLE
add version task

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ gro serve some/dir and/another/dir # serves some directories
 ```
 
 ```bash
+gro version patch # bump version, publish to npm, and sync to GitHub
+gro version major --and args --are forwarded --to 'npm version'
+```
+
+```bash
 gro --version # or `-v` prints the Gro version
 ```
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.8.4
 
-- add `src/version.task.ts` to avoid errors bumping the version and publishing
+- add `src/version.task.ts` to automate versioning and publishing
   ([#127](https://github.com/feltcoop/gro/pull/127))
 
 ## 0.8.3

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Gro changelog
 
-## 0.8.3
+## 0.8.4
 
 - add `src/version.task.ts` to avoid errors bumping the version and publishing
   ([#127](https://github.com/feltcoop/gro/pull/127))

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## 0.8.3
 
+- add `src/version.task.ts` to avoid errors bumping the version and publishing
+  ([#127](https://github.com/feltcoop/gro/pull/127))
+
+## 0.8.3
+
 - change type deps exposed to users to regular dependencies
   ([#126](https://github.com/feltcoop/gro/pull/126))
 

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -22,6 +22,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 - [serve](../serve.task.ts) - start static file server
 - [test](../test.task.ts) - run tests
 - [typecheck](../typecheck.task.ts) - typecheck the project without emitting any files
+- [version](../version.task.ts) - bump version and publish
 
 ## usage
 

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -22,7 +22,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 - [serve](../serve.task.ts) - start static file server
 - [test](../test.task.ts) - run tests
 - [typecheck](../typecheck.task.ts) - typecheck the project without emitting any files
-- [version](../version.task.ts) - bump version and publish
+- [version](../version.task.ts) - bump version, publish to npm, and sync to GitHub
 
 ## usage
 

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -37,7 +37,8 @@ export const task: Task = {
 
 		// Normal user projects will hit this code path right here:
 		// in other words, `isThisProjectGro` will always be `false` for your code.
-		// TODO bad task pollution, think of a better way - maybe config+defaults
+		// TODO bad task pollution, this is bad for users who want to copy/paste this task.
+		// think of a better way - maybe config+defaults?
 		// I don't want to touch Gro's prod build pipeline right now using package.json `"preversion"`
 		if (!isThisProjectGro) {
 			await invokeTask('clean');

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -1,0 +1,51 @@
+import {isThisProjectGro} from './paths.js';
+import type {Task} from './task/task.js';
+import {spawnProcess} from './utils/process.js';
+import {green} from './utils/terminal.js';
+
+// version.task.ts
+// - usage: `gro version patch`
+// - forwards args to `npm version`: https://docs.npmjs.com/cli/v6/commands/npm-version
+// - runs the production build
+// - publishes to npm from the `main` branch (TODO configure)
+// - syncs commits and tags to GitHub `main` branch
+
+type VersionIncrement = string;
+const validateVersionIncrement: ValidateVersionIncrement = (v) => {
+	if (!v) {
+		throw Error(
+			`Expected a version increment like one of patch|minor|major, e.g. gro version patch`,
+		);
+	}
+};
+interface ValidateVersionIncrement {
+	(v: unknown): asserts v is VersionIncrement;
+}
+
+export const task: Task = {
+	description: 'bump version, publish to npm, and sync to GitHub',
+	run: async ({args, log, invokeTask}): Promise<void> => {
+		const versionIncrement = args._[0];
+		validateVersionIncrement(versionIncrement);
+		log.info('new version:', green(versionIncrement));
+
+		// Make sure we're on the main branch:
+		await spawnProcess('git', ['checkout', 'main']); // TODO allow configuring `'main'`
+
+		// And updated to the latest:
+		await spawnProcess('git', ['pull']);
+
+		// Normal user projects will hit this code path right here:
+		// in other words, `isThisProjectGro` will always be `true` for your code.
+		// TODO bad task pollution, think of a better way - maybe config+defaults
+		// I don't want to touch Gro's prod build pipeline right now using package.json `"preversion"`
+		if (!isThisProjectGro) {
+			await invokeTask('clean');
+			await invokeTask('build');
+		}
+		await spawnProcess('npm', ['version', ...process.argv.slice(3)]);
+		await spawnProcess('npm', ['publish']);
+		await spawnProcess('git', ['push']);
+		await spawnProcess('git', ['push', '--tags']);
+	},
+};

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -12,7 +12,7 @@ import {green} from './utils/terminal.js';
 
 type VersionIncrement = string;
 const validateVersionIncrement: ValidateVersionIncrement = (v) => {
-	if (!v) {
+	if (!v || typeof v !== 'string') {
 		throw Error(
 			`Expected a version increment like one of patch|minor|major, e.g. gro version patch`,
 		);

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -36,7 +36,7 @@ export const task: Task = {
 		await spawnProcess('git', ['pull']);
 
 		// Normal user projects will hit this code path right here:
-		// in other words, `isThisProjectGro` will always be `true` for your code.
+		// in other words, `isThisProjectGro` will always be `false` for your code.
 		// TODO bad task pollution, think of a better way - maybe config+defaults
 		// I don't want to touch Gro's prod build pipeline right now using package.json `"preversion"`
 		if (!isThisProjectGro) {

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -10,6 +10,9 @@ import {green} from './utils/terminal.js';
 // - publishes to npm from the `main` branch (TODO configure)
 // - syncs commits and tags to GitHub `main` branch
 
+// TODO configure branch
+// TODO add `dry` option so it can be tested
+
 type VersionIncrement = string;
 const validateVersionIncrement: ValidateVersionIncrement = (v) => {
 	if (!v || typeof v !== 'string') {


### PR DESCRIPTION
This implements a basic `gro version` task. So you might run `gro version patch` to sweep a bug under the rug.

The idea is that it defers to [npm version](https://docs.npmjs.com/cli/v6/commands/npm-version) as much as possible, adding simple scripting around it without getting in the way. (see the line where it forwards raw args)

In short, it runs the production build, publishes to npm, and syncs commits and tags to GitHub. It could be improved, but probably through the `gro.config.ts` in addition to CLI args. Something to think through another day.

It was motivated by a sleepy developer (me) forgetting to switch to the `main` branch when bumping up to 0.7.1. (I think) I fixed it the next day by force pushing, but I believe npm and GitHub will have different version hashes for that tagged release. Whatever. Probably flagged by security algorithms at npm. I'm incompetent not malice! Now, all that cannot happen, one command should be good.

This is one of many examples of lacking documentation. I'm thinking through what that'll look like and I should make something simple soon. It includes the important part in the main readme: that it forwards CLI args to `npm version`.