### PR TITLE
make gro build task work for Gro itself

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,4 +29,4 @@ jobs:
       - run: gro check
         env:
           CI: true
-      - run: gro project/build
+      - run: gro build

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ gro dev # starts dev server in watch mode
 gro project/dist # update the `gro` CLI
 
 # release
-gro project/build # builds for release and updates the `gro` CLI
+gro build # builds for release and updates the `gro` CLI
 ```
 
 ## credits :turtle:<sub>:turtle:</sub><sub><sub>:turtle:</sub></sub>

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - add `src/version.task.ts` to automate versioning and publishing
   ([#127](https://github.com/feltcoop/gro/pull/127))
+- change `src/build.task.ts` to work internally for Gro
+  ([#128](https://github.com/feltcoop/gro/pull/128))
 
 ## 0.8.3
 

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "test": "gro test",
     "bootstrap": "rm -rf .gro dist && esbuild src/**/*.ts src/*.ts --outdir=.gro/prod/node/ --define:import.meta.env.DEV=true; cp -r .gro/prod/node/ dist/ && npm link",
     "dev": "clear && npm run bootstrap && gro dev",
-    "build": "clear && npm run bootstrap && gro project/build",
-    "buildprod": "clear && npm run bootstrap && gro project/build && rm -rf .gro",
-    "preversion": "npm run bootstrap && gro check && npm run bootstrap && gro project/build"
+    "build": "clear && npm run bootstrap && gro build",
+    "buildprod": "clear && npm run bootstrap && gro build && rm -rf .gro",
+    "preversion": "npm run bootstrap && gro check && npm run bootstrap && gro build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bootstrap": "rm -rf .gro dist && esbuild src/**/*.ts src/*.ts --outdir=.gro/prod/node/ --define:import.meta.env.DEV=true; cp -r .gro/prod/node/ dist/ && npm link",
     "dev": "clear && npm run bootstrap && gro dev",
     "build": "clear && npm run bootstrap && gro build",
-    "buildprod": "clear && npm run bootstrap && gro build && rm -rf .gro",
+    "buildprod": "npm run build && rm -rf .gro",
     "preversion": "npm run bootstrap && gro check && npm run bootstrap && gro build"
   },
   "repository": {

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -17,7 +17,7 @@ export const task: Task = {
 	run: async ({log, args, invokeTask}): Promise<void> => {
 		// Normal user projects will ignore this code path right here:
 		// in other words, `isThisProjectGro` will always be `false` for your code.
-		// TODO bad task pollution, this is bad for users who want to copy/paste this task.
+		// TODO task pollution, this is bad for users who want to copy/paste this task.
 		// think of a better way - maybe config+defaults?
 		if (isThisProjectGro) {
 			return invokeTask('project/build');

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -3,7 +3,7 @@ import type {Task} from './task/task.js';
 import {createBuild} from './project/build.js';
 import {getDefaultEsbuildOptions} from './build/esbuildBuildHelpers.js';
 import {loadTsconfig, toEcmaScriptTarget} from './build/tsBuildHelpers.js';
-import {toBuildOutPath} from './paths.js';
+import {isThisProjectGro, toBuildOutPath} from './paths.js';
 import {Timings} from './utils/time.js';
 import {loadGroConfig} from './config/config.js';
 import {configureLogLevel} from './utils/log.js';
@@ -14,7 +14,15 @@ const dev = false; // forcing prod builds for now
 
 export const task: Task = {
 	description: 'build the project',
-	run: async ({log, args}): Promise<void> => {
+	run: async ({log, args, invokeTask}): Promise<void> => {
+		// Normal user projects will ignore this code path right here:
+		// in other words, `isThisProjectGro` will always be `false` for your code.
+		// TODO bad task pollution, this is bad for users who want to copy/paste this task.
+		// think of a better way - maybe config+defaults?
+		if (isThisProjectGro) {
+			return invokeTask('build');
+		}
+
 		const timings = new Timings();
 
 		if (dev) {

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -20,7 +20,7 @@ export const task: Task = {
 		// TODO bad task pollution, this is bad for users who want to copy/paste this task.
 		// think of a better way - maybe config+defaults?
 		if (isThisProjectGro) {
-			return invokeTask('build');
+			return invokeTask('project/build');
 		}
 
 		const timings = new Timings();

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -40,7 +40,7 @@ export const task: Task = {
 
 		// Normal user projects will hit this code path right here:
 		// in other words, `isThisProjectGro` will always be `false` for your code.
-		// TODO bad task pollution, this is bad for users who want to copy/paste this task.
+		// TODO task pollution, this is bad for users who want to copy/paste this task.
 		// think of a better way - maybe config+defaults?
 		// I don't want to touch Gro's prod build pipeline right now using package.json `"preversion"`
 		if (!isThisProjectGro) {


### PR DESCRIPTION
This makes `gro build` work inside of Gro. Previously, Gro used `gro project/build` internally, but now it'll invoke `project/build` if we're inside Gro.

Like with `gro version`, this adds some "task pollution", exposing Gro internals to tasks in `src/` that we want to encourage users to copy/paste. The code is easily removed, but it doesn't look great, and might confuse some users.