### PR TITLE
add server auto-restart to dev task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,7 @@
 {
   "version": "0.2.0",
   "configurations": [
-    // TODO having a launch config breaks f11 fullscreen - wat
+    // TODO having a launch config now breaks f11 fullscreen - wat
     // {
     //   "type": "node",
     //   "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,22 +1,23 @@
 {
   "version": "0.2.0",
   "configurations": [
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "gro",
-      "program": "${workspaceFolder}/dist/cli/gro.js",
-      "args": ["dev"],
-      "runtimeArgs": [],
-      "outFiles": [
-        "${workspaceRoot}/.gro/dev/node/**/*.js",
-        "${workspaceRoot}/.gro/prod/node/**/*.js"
-      ], // enables breakpoints in TS source
-      "env": {
-        // "NODE_ENV": "production"
-        "NODE_ENV": "development"
-      },
-      "skipFiles": ["${workspaceFolder}/node_modules/**/*.js", "<node_internals>/**/*.js"]
-    }
+    // TODO having a launch config breaks f11 fullscreen - wat
+    // {
+    //   "type": "node",
+    //   "request": "launch",
+    //   "name": "gro",
+    //   "program": "${workspaceFolder}/dist/cli/gro.js",
+    //   "args": ["dev"],
+    //   "runtimeArgs": [],
+    //   "outFiles": [
+    //     "${workspaceRoot}/.gro/dev/node/**/*.js",
+    //     "${workspaceRoot}/.gro/prod/node/**/*.js"
+    //   ], // enables breakpoints in TS source
+    //   "env": {
+    //     // "NODE_ENV": "production"
+    //     "NODE_ENV": "development"
+    //   },
+    //   "skipFiles": ["${workspaceFolder}/node_modules/**/*.js", "<node_internals>/**/*.js"]
+    // }
   ]
 }

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.8.5
 
-- add server auto-restart to /src/dev.task.ts
+- add server auto-restart to `src/dev.task.ts`
   ([#129](https://github.com/feltcoop/gro/pull/129))
 - improve the [clean task](https://github.com/feltcoop/gro/blob/main/src/clean.task.ts)
   ([#130](https://github.com/feltcoop/gro/pull/130))

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.8.5
 
+- add server auto-restart to /src/dev.task.ts
+  ([#129](https://github.com/feltcoop/gro/pull/129))
 - improve the [clean task](https://github.com/feltcoop/gro/blob/main/src/clean.task.ts)
   ([#130](https://github.com/feltcoop/gro/pull/130))
   - running `gro clean` with no options behaves the same, deleting `/.gro/` and `/dist/`

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -15,7 +15,7 @@ import {basePathToSourceId, toBuildExtension} from '../paths.js';
 
 export const SERVER_SOURCE_BASE_PATH = 'server/server.ts';
 export const SERVER_BUILD_BASE_PATH = toBuildExtension(SERVER_SOURCE_BASE_PATH); // 'server/server.js'
-export const SERVER_SOURCE_ID = basePathToSourceId(SERVER_SOURCE_BASE_PATH); // '/home/to/your/src/server/server.js'
+export const SERVER_SOURCE_ID = basePathToSourceId(SERVER_SOURCE_BASE_PATH); // '/home/to/your/src/server/server.ts'
 
 const createConfig: GroConfigCreator = async () => {
 	const config: PartialGroConfig = {

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -14,8 +14,8 @@ import {basePathToSourceId, toBuildExtension} from '../paths.js';
 // Both are no-ops if not detected.
 
 export const SERVER_SOURCE_BASE_PATH = 'server/server.ts';
-export const SERVER_BUILD_BASE_PATH = toBuildExtension(SERVER_SOURCE_BASE_PATH);
-export const SERVER_SOURCE_ID = basePathToSourceId(SERVER_SOURCE_BASE_PATH); // absolute path
+export const SERVER_BUILD_BASE_PATH = toBuildExtension(SERVER_SOURCE_BASE_PATH); // 'server/server.js'
+export const SERVER_SOURCE_ID = basePathToSourceId(SERVER_SOURCE_BASE_PATH); // '/home/to/your/src/server/server.js'
 
 const createConfig: GroConfigCreator = async () => {
 	const config: PartialGroConfig = {

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -46,7 +46,7 @@ const toDefaultBrowserBuild = (): PartialBuildConfig => ({
 	dist: true,
 });
 
-// TODO extract helper?
+// TODO extract helper? or is this default config file its actual home?
 export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
 	const [hasIndexHtml, hasIndexTs] = await Promise.all([
 		pathExists('src/index.html'),
@@ -55,5 +55,5 @@ export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
 	return hasIndexHtml && hasIndexTs;
 };
 
-// TODO extract helper?
+// TODO extract helper? or is this default config file its actual home?
 export const hasGroServer = (): Promise<boolean> => pathExists(SERVER_SOURCE_ID);

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -20,7 +20,7 @@ const createConfig: GroConfigCreator = async () => {
 				name: 'node',
 				platform: 'node',
 				input: [
-					(await pathExists('src/server/server.ts')) ? 'server/server.ts' : null!,
+					(await hasGroServer()) ? 'server/server.ts' : null!,
 					createFilter('**/*.{task,test,config,gen}*.ts'),
 				].filter(Boolean),
 			},
@@ -42,10 +42,13 @@ const toDefaultBrowserBuild = (): PartialBuildConfig => ({
 });
 
 // TODO extract helper?
-const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
+export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
 	const [hasIndexHtml, hasIndexTs] = await Promise.all([
 		pathExists('src/index.html'),
 		pathExists('src/index.ts'),
 	]);
 	return hasIndexHtml && hasIndexTs;
 };
+
+// TODO extract helper?
+export const hasGroServer = (): Promise<boolean> => pathExists('src/server/server.ts');

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -4,6 +4,7 @@ import type {GroConfigCreator, PartialGroConfig} from './config.js';
 import {LogLevel} from '../utils/log.js';
 import {PartialBuildConfig} from './buildConfig.js';
 import {pathExists} from '../fs/nodeFs.js';
+import {basePathToSourceId, toBuildExtension} from '../paths.js';
 
 // This is the default config that's used if the current project does not define one.
 // The default config detects
@@ -11,6 +12,10 @@ import {pathExists} from '../fs/nodeFs.js';
 // if it sees both a `src/index.html` and `src/index.ts`.
 // It also looks for a primary Node server entry point at `src/server/server.ts`.
 // Both are no-ops if not detected.
+
+export const SERVER_SOURCE_BASE_PATH = 'server/server.ts';
+export const SERVER_BUILD_BASE_PATH = toBuildExtension(SERVER_SOURCE_BASE_PATH);
+export const SERVER_SOURCE_ID = basePathToSourceId(SERVER_SOURCE_BASE_PATH); // absolute path
 
 const createConfig: GroConfigCreator = async () => {
 	const config: PartialGroConfig = {
@@ -20,7 +25,7 @@ const createConfig: GroConfigCreator = async () => {
 				name: 'node',
 				platform: 'node',
 				input: [
-					(await hasGroServer()) ? 'server/server.ts' : null!,
+					(await hasGroServer()) ? SERVER_SOURCE_BASE_PATH : null!,
 					createFilter('**/*.{task,test,config,gen}*.ts'),
 				].filter(Boolean),
 			},
@@ -51,4 +56,4 @@ export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
 };
 
 // TODO extract helper?
-export const hasGroServer = (): Promise<boolean> => pathExists('src/server/server.ts');
+export const hasGroServer = (): Promise<boolean> => pathExists(SERVER_SOURCE_ID);

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -100,6 +100,7 @@ export const task: Task = {
 					// Without more granular detection, the API server will restart
 					// when files like this dev task change. That's fine, but it's not nice.
 					if (buildConfig.name === DEFAULT_BUILD_CONFIG_NAME) {
+						// TODO throttle
 						restartServer();
 					}
 				});

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -101,6 +101,7 @@ const getDefaultServedDirs = (config: GroConfig): ServedDirPartial[] => {
 	return [buildOutDirToServe];
 };
 
+// TODO extract to a util? redesign
 const createServerProcess = (serverPath: string) => {
 	let serverProcess: ChildProcess | null = null;
 	let serverClosed: Promise<void> | null = null; // `kill` is sync; this resolves when it's done

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -84,10 +84,7 @@ export const task: Task = {
 				// when files like this dev task change. That's fine, but it's not nice.
 				// so this will probably be `DEFAULT_SERVER_BUILD_CONFIG_NAME`
 				if (buildConfig.name === DEFAULT_BUILD_CONFIG_NAME) {
-					for (let i = 0; i < 10; i++) {
-						console.log('restarting');
-						serverProcess.restart();
-					}
+					serverProcess.restart();
 				}
 			});
 		}

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -75,6 +75,7 @@ export const task: Task = {
 		if (await hasGroServer()) {
 			// the API server process: kill'd and restarted every time a dependency changes
 			const serverProcess = createServerProcess(
+				// TODO link `'server/server.js'` programmatically with `'src/server/server.ts' elsewhere
 				toBuildOutPath(true, DEFAULT_BUILD_CONFIG_NAME, 'server/server.js'),
 			);
 			// When `src/server/server.ts` or any of its dependencies change, restart the API server.

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -11,7 +11,7 @@ import {GroConfig, loadGroConfig} from './config/config.js';
 import {configureLogLevel} from './utils/log.js';
 import type {ServedDirPartial} from './build/ServedDir.js';
 import {loadHttpsCredentials} from './server/https.js';
-import {hasGroServer} from './config/gro.config.default.js';
+import {hasGroServer, SERVER_BUILD_BASE_PATH} from './config/gro.config.default.js';
 import {DEFAULT_BUILD_CONFIG_NAME} from './config/defaultBuildConfig.js';
 
 export const task: Task = {
@@ -76,7 +76,7 @@ export const task: Task = {
 			// the API server process: kill'd and restarted every time a dependency changes
 			const serverProcess = createServerProcess(
 				// TODO link `'server/server.js'` programmatically with `'src/server/server.ts' elsewhere
-				toBuildOutPath(true, DEFAULT_BUILD_CONFIG_NAME, 'server/server.js'),
+				toBuildOutPath(true, DEFAULT_BUILD_CONFIG_NAME, SERVER_BUILD_BASE_PATH),
 			);
 			// When `src/server/server.ts` or any of its dependencies change, restart the API server.
 			filer.on('build', ({buildConfig}) => {

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -70,21 +70,20 @@ export const task: Task = {
 		args.onready && (args as any).onready(filer, server);
 
 		// Support the Gro server pattern by default.
-		// TODO make this more reusable
 		if (await hasGroServer()) {
-			// the API server process: kill'd and restarted every time a dependency changes
-			const serverProcess = createRestartableProcess(
-				// TODO link `'server/server.js'` programmatically with `'src/server/server.ts' elsewhere
-				toBuildOutPath(true, DEFAULT_BUILD_CONFIG_NAME, SERVER_BUILD_BASE_PATH),
-			);
 			// When `src/server/server.ts` or any of its dependencies change, restart the API server.
+			const serverBuildPath = toBuildOutPath(
+				true,
+				DEFAULT_BUILD_CONFIG_NAME,
+				SERVER_BUILD_BASE_PATH,
+			);
+			const serverProcess = createRestartableProcess(serverBuildPath);
 			filer.on('build', ({buildConfig}) => {
 				// TODO to avoid false positives, probably split apart the default Node and server builds.
 				// Without more granular detection, the API server will restart
 				// when files like this dev task change. That's fine, but it's not nice.
 				// so this will probably be `DEFAULT_SERVER_BUILD_CONFIG_NAME`
 				if (buildConfig.name === DEFAULT_BUILD_CONFIG_NAME) {
-					// TODO throttle
 					serverProcess.restart();
 				}
 			});

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -84,7 +84,10 @@ export const task: Task = {
 				// when files like this dev task change. That's fine, but it's not nice.
 				// so this will probably be `DEFAULT_SERVER_BUILD_CONFIG_NAME`
 				if (buildConfig.name === DEFAULT_BUILD_CONFIG_NAME) {
-					serverProcess.restart();
+					for (let i = 0; i < 10; i++) {
+						console.log('restarting');
+						serverProcess.restart();
+					}
 				}
 			});
 		}

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -78,15 +78,18 @@ export const task: Task = {
 			let serverClosed: Promise<void> | null = null; // `kill` is sync; this resolves when it's done
 			const serverPath = toBuildOutPath(true, DEFAULT_BUILD_CONFIG_NAME, 'server/server.js');
 			const restartServer = async (): Promise<void> => {
-				if (serverProcess) {
-					serverProcess.kill();
+				if (serverClosed) {
+					if (serverProcess) {
+						serverProcess.kill();
+						serverProcess = null;
+					}
 					await serverClosed;
 				}
 				serverProcess = spawn('node', [serverPath], {stdio: 'inherit'});
 				let resolve: () => void;
 				serverClosed = new Promise((r) => (resolve = r));
+				// TODO handle errors
 				serverProcess.on('close', () => {
-					serverProcess = null;
 					resolve();
 				});
 			};

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -77,7 +77,7 @@ export const task: Task = {
 				DEFAULT_BUILD_CONFIG_NAME,
 				SERVER_BUILD_BASE_PATH,
 			);
-			const serverProcess = createRestartableProcess(serverBuildPath);
+			const serverProcess = createRestartableProcess('node', [serverBuildPath]);
 			filer.on('build', ({buildConfig}) => {
 				// TODO to avoid false positives, probably split apart the default Node and server builds.
 				// Without more granular detection, the API server will restart

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -82,6 +82,7 @@ export const task: Task = {
 				// TODO to avoid false positives, probably split apart the default Node and server builds.
 				// Without more granular detection, the API server will restart
 				// when files like this dev task change. That's fine, but it's not nice.
+				// so this will probably be `DEFAULT_SERVER_BUILD_CONFIG_NAME`
 				if (buildConfig.name === DEFAULT_BUILD_CONFIG_NAME) {
 					// TODO throttle
 					serverProcess.restart();

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -92,19 +92,16 @@ export const task: Task = {
 			};
 
 			// When `src/server/server.ts` or any of its dependencies change, restart the API server.
-			// TODO type? it's for *downstream* tasks, so maybe just import its interface?
-			(args as any).oninitfiler = (filer: Filer) => {
-				restartServer(); // start on init
-				filer.on('build', ({buildConfig}) => {
-					// TODO to avoid false positives, probably split apart the default Node and server builds.
-					// Without more granular detection, the API server will restart
-					// when files like this dev task change. That's fine, but it's not nice.
-					if (buildConfig.name === DEFAULT_BUILD_CONFIG_NAME) {
-						// TODO throttle
-						restartServer();
-					}
-				});
-			};
+			restartServer(); // start on init
+			filer.on('build', ({buildConfig}) => {
+				// TODO to avoid false positives, probably split apart the default Node and server builds.
+				// Without more granular detection, the API server will restart
+				// when files like this dev task change. That's fine, but it's not nice.
+				if (buildConfig.name === DEFAULT_BUILD_CONFIG_NAME) {
+					// TODO throttle
+					restartServer();
+				}
+			});
 		}
 
 		for (const [key, timing] of timings.getAll()) {

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,6 +1,6 @@
 export type AsyncStatus = 'initial' | 'pending' | 'success' | 'failure';
 
-export const wait = (duration = 0) => new Promise((resolve) => setTimeout(resolve, duration));
+export const wait = (duration = 0) => new Promise<void>((resolve) => setTimeout(resolve, duration));
 
 interface WrapAfter {
 	(cb: WrapAfterCallback): void;

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -60,10 +60,12 @@ export const createRestartableProcess = (
 	let child: ChildProcess | null = null;
 	let restarting: Promise<void> | null = null;
 	let restarted: (() => void) | null = null;
+	let queuedRestart = false; // do we have a queued trailing restart?
 	const restart = async (): Promise<void> => {
+		console.log('[restart] enter');
 		if (restarting) console.log('[restart] already restarting');
 		if (restarting) {
-			// TODO queue another for the final restart
+			queuedRestart = true;
 			return restarting;
 		}
 		if (child) {
@@ -78,9 +80,16 @@ export const createRestartableProcess = (
 		child.on('close', () => {
 			console.log('[restart] close');
 			restarting = null;
-			if (restarted) console.log('[restart] close restarting');
+			if (restarted) console.log('[restart] close restarted()');
 			if (restarted) restarted();
 		});
+		if (queuedRestart) {
+			queuedRestart = false;
+			console.log('[restart] queued restarting');
+			await restart();
+			console.log('[restart] queued restarted');
+		}
+		console.log('[restart] exit');
 	};
 	restart(); // start on init
 	return {restart};

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -50,7 +50,8 @@ export interface RestartableProcess {
 // It's slightly more complex because `kill` is sync, so we tie things up with promises.
 export const createRestartableProcess = (
 	command: string,
-	args: readonly string[],
+	args: readonly string[] = [],
+	options?: SpawnOptions,
 ): RestartableProcess => {
 	let child: ChildProcess | null = null;
 	let restarting: Promise<void> | null = null;
@@ -63,7 +64,7 @@ export const createRestartableProcess = (
 			child = null;
 			await restarting;
 		}
-		child = spawn(command, args, {stdio: 'inherit'});
+		child = spawn(command, args, {stdio: 'inherit', ...options});
 		child.on('close', () => {
 			restarting = null;
 			if (restarted) restarted();

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -62,8 +62,6 @@ export const createRestartableProcess = (
 	let restarted: (() => void) | null = null;
 	let queuedRestart = false; // do we have a queued trailing restart?
 	const restart = async (): Promise<void> => {
-		console.log('[restart] enter');
-		if (restarting) console.log('[restart] already restarting');
 		if (restarting) {
 			queuedRestart = true;
 			return restarting;
@@ -72,24 +70,17 @@ export const createRestartableProcess = (
 			restarting = new Promise<void>((resolve) => (restarted = resolve)).then(() => wait(delay));
 			child.kill();
 			child = null;
-			console.log('[restart] awaiting');
 			await restarting;
-			console.log('[restart] awaited');
 		}
 		child = spawn(command, args, {stdio: 'inherit', ...options});
 		child.on('close', () => {
-			console.log('[restart] close');
 			restarting = null;
-			if (restarted) console.log('[restart] close restarted()');
 			if (restarted) restarted();
 		});
 		if (queuedRestart) {
 			queuedRestart = false;
-			console.log('[restart] queued restarting');
 			await restart();
-			console.log('[restart] queued restarted');
 		}
-		console.log('[restart] exit');
 	};
 	restart(); // start on init
 	return {restart};

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -48,8 +48,8 @@ export interface RestartableProcess {
 
 const DEFAULT_RESTART_DELAY = 5; // milliseconds
 
-// This needs to handle many concurrent `restart` calls gracefully,
-// and restart after the trailing call.
+// This handles many concurrent `restart` calls gracefully,
+// and restarts ones after the trailing call, waiting some `delay` in between.
 // It's slightly more complex because `kill` is sync, so we tie things up with promises.
 export const createRestartableProcess = (
 	command: string,

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -48,7 +48,10 @@ export interface RestartableProcess {
 // This needs to handle many concurrent `restart` calls gracefully,
 // and restart after the trailing call.
 // It's slightly more complex because `kill` is sync, so we tie things up with promises.
-export const createRestartableProcess = (serverPath: string): RestartableProcess => {
+export const createRestartableProcess = (
+	command: string,
+	args: readonly string[],
+): RestartableProcess => {
 	let child: ChildProcess | null = null;
 	let restarting: Promise<void> | null = null;
 	let restarted: () => void;
@@ -60,7 +63,7 @@ export const createRestartableProcess = (serverPath: string): RestartableProcess
 			child = null;
 			await restarting;
 		}
-		child = spawn('node', [serverPath], {stdio: 'inherit'});
+		child = spawn(command, args, {stdio: 'inherit'});
 		child.on('close', () => {
 			restarting = null;
 			if (restarted) restarted();

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -45,7 +45,9 @@ export interface RestartableProcess {
 	restart: () => void;
 }
 
-// `kill` is sync, so we tie things up with promises
+// This needs to handle many concurrent `restart` calls gracefully,
+// and restart after the trailing call.
+// It's slightly more complex because `kill` is sync, so we tie things up with promises.
 export const createRestartableProcess = (serverPath: string): RestartableProcess => {
 	let child: ChildProcess | null = null;
 	let restarting: Promise<void> | null = null;


### PR DESCRIPTION
This adds more functionality for the default Gro server, at `src/server/server.ts`. 

First, let's start with moving the server auto-restart behavior from ryanatkn/gro-template-sveltekit-polka to the default Gro task. It is a no-op if no server is detected.

- [x] basic behavior
- [x] It needs to be smarter than the proof of concept and debounce/throttle. I'll think about the best way to do that - feel free to offer something.
- [x] add trailing restart
- [x] add retry padding, a few ms
- [x] programmatically link the paths related to `server.ts`
- [x] might have a bug with concurrent restart calls