### PR TITLE
improve clean task

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Gro changelog
 
-## 0.8.4
+## 0.8.5
 
 - improve the [clean](https://github.com/feltcoop/gro/blob/main/src/clean.task.ts) task:
   it now accepts `-s` and `-n` options to clear `.svelte/` and `node_modules/`

--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,14 @@
 
 ## 0.8.5
 
-- improve the [clean](https://github.com/feltcoop/gro/blob/main/src/clean.task.ts) task:
-  it now accepts `-s` and `-n` options to clear `.svelte/` and `node_modules/`
+- improve the [clean task](https://github.com/feltcoop/gro/blob/main/src/clean.task.ts)
   ([#130](https://github.com/feltcoop/gro/pull/130))
+  - running `gro clean` with no options behaves the same, deleting `/.gro/` and `/dist/`
+  - `gro clean` now accepts a number of options:
+    - `-s`: delete `/.svelte/`
+    - `-n`: delete `/node_modules/`
+    - `-B`: preserve `/.gro/`, the Gro build directory
+    - `-D`: preserve `/dist/`
 
 ## 0.8.4
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## 0.8.4
 
+- improve the [clean](https://github.com/feltcoop/gro/blob/main/src/clean.task.ts) task:
+  it now accepts `-s` and `-n` options to clear `.svelte/` and `node_modules/`
+  ([#130](https://github.com/feltcoop/gro/pull/130))
+
+## 0.8.4
+
 - add `src/version.task.ts` to automate versioning and publishing
   ([#127](https://github.com/feltcoop/gro/pull/127))
 - change `src/build.task.ts` to work internally for Gro

--- a/src/clean.task.ts
+++ b/src/clean.task.ts
@@ -2,8 +2,14 @@ import type {Task} from './task/task.js';
 import {clean} from './project/clean.js';
 
 export const task: Task = {
-	description: 'remove build and temp files',
-	run: async ({log}): Promise<void> => {
-		await clean(log);
+	description: 'remove files: build, dist, and optionally SvelteKit (-s) and node_modules (-n)',
+	run: async ({log, args}): Promise<void> => {
+		// TODO document with mdsvex
+		await clean(log, {
+			svelteKit: !!(args.s || args.sveltekit),
+			nodeModules: !!(args.n || args.nodemodules),
+			// TODO maybe control `build` and `dist` too? how to do that cleanly,
+			// and maybe improve this interface?
+		});
 	},
 };

--- a/src/clean.task.ts
+++ b/src/clean.task.ts
@@ -2,14 +2,18 @@ import type {Task} from './task/task.js';
 import {clean} from './project/clean.js';
 
 export const task: Task = {
-	description: 'remove files: build, dist, and optionally SvelteKit (-s) and node_modules (-n)',
+	description:
+		'remove files: build/ (unless -B), dist/ (unless -D), and optionally .svelte/ (-s) and node_modules/ (-n)',
 	run: async ({log, args}): Promise<void> => {
 		// TODO document with mdsvex
-		await clean(log, {
-			svelteKit: !!(args.s || args.sveltekit),
-			nodeModules: !!(args.n || args.nodemodules),
-			// TODO maybe control `build` and `dist` too? how to do that cleanly,
-			// and maybe improve this interface?
-		});
+		await clean(
+			{
+				build: !args.B,
+				dist: !args.D,
+				svelteKit: !!args.s,
+				nodeModules: !!args.n,
+			},
+			log,
+		);
 	},
 };

--- a/src/dist.task.ts
+++ b/src/dist.task.ts
@@ -3,7 +3,7 @@ import {copy} from './fs/nodeFs.js';
 import {paths, toBuildOutPath} from './paths.js';
 import {isTestBuildFile, isTestBuildArtifact} from './fs/testModule.js';
 import {printPath} from './utils/print.js';
-import {cleanDist} from './project/clean.js';
+import {clean} from './project/clean.js';
 import {loadGroConfig} from './config/config.js';
 import {configureLogLevel} from './utils/log.js';
 import {printBuildConfig} from './config/buildConfig.js';
@@ -16,7 +16,7 @@ export const task: Task = {
 	run: async ({log}) => {
 		const dev = process.env.NODE_ENV !== 'production';
 
-		await cleanDist(log);
+		await clean({dist: true}, log);
 
 		// This reads the `dist` flag on the build configs to help construct the final dist directory.
 		// See the docs at `./docs/config.md`.

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -9,7 +9,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 - [build](../build.task.ts) - build the project
 - [cert](../cert.task.ts) - creates a self-signed cert for https with openssl
 - [check](../check.task.ts) - check that everything is ready to commit
-- [clean](../clean.task.ts) - remove build and temp files
+- [clean](../clean.task.ts) - remove files: build/ (unless -B), dist/ (unless -D), and optionally .svelte/ (-s) and node_modules/ (-n)
 - [deploy](../deploy.task.ts) - deploy to gh-pages
 - [dev](../dev.task.ts) - start dev server
 - [dist](../dist.task.ts) - create the distribution

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -34,6 +34,9 @@ export const CONFIG_BUILD_BASE_PATH = 'gro.config.js';
 export const EXTERNALS_BUILD_DIR = 'externals'; // TODO breaks the above trailing slash convention - revisit with trailing-slash branch
 export const EXTERNALS_BUILD_DIR_SUBPATH = `/${EXTERNALS_BUILD_DIR}/`;
 
+export const NODE_MODULES_PATH = 'node_modules';
+export const SVELTE_KIT_PATH = '.svelte';
+
 export interface Paths {
 	root: string;
 	source: string;

--- a/src/project/clean.ts
+++ b/src/project/clean.ts
@@ -1,24 +1,27 @@
 import {pathExists, remove} from '../fs/nodeFs.js';
-import {paths} from '../paths.js';
+import {NODE_MODULES_PATH, paths, SVELTE_KIT_PATH} from '../paths.js';
 import type {SystemLogger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 
-export const clean = async (log: SystemLogger) => {
-	await cleanBuild(log);
-	await cleanDist(log);
-};
+export const clean = async (
+	log: SystemLogger,
+	{
+		build = true,
+		dist = true,
+		svelteKit = false,
+		nodeModules = false,
+	}: {build?: boolean; dist?: boolean; svelteKit?: boolean; nodeModules?: boolean},
+) =>
+	Promise.all([
+		build ? cleanDir(paths.build, log) : null,
+		dist ? cleanDir(paths.dist, log) : null,
+		svelteKit ? cleanDir(SVELTE_KIT_PATH, log) : null,
+		nodeModules ? cleanDir(NODE_MODULES_PATH, log) : null,
+	]);
 
-// Checking `pathExists` avoids creating the directory if it doesn't exist.
-export const cleanBuild = async (log: SystemLogger) => {
-	if (await pathExists(paths.build)) {
-		log.info('removing', printPath(paths.build));
-		await remove(paths.build);
-	}
-};
-
-export const cleanDist = async (log: SystemLogger) => {
-	if (await pathExists(paths.dist)) {
-		log.info('removing', printPath(paths.dist));
-		await remove(paths.dist);
+export const cleanDir = async (path: string, log: SystemLogger): Promise<void> => {
+	if (await pathExists(path)) {
+		log.info('removing', printPath(path));
+		await remove(path);
 	}
 };

--- a/src/project/clean.ts
+++ b/src/project/clean.ts
@@ -4,13 +4,13 @@ import type {SystemLogger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 
 export const clean = async (
-	log: SystemLogger,
 	{
-		build = true,
-		dist = true,
+		build = false,
+		dist = false,
 		svelteKit = false,
 		nodeModules = false,
 	}: {build?: boolean; dist?: boolean; svelteKit?: boolean; nodeModules?: boolean},
+	log: SystemLogger,
 ) =>
 	Promise.all([
 		build ? cleanDir(paths.build, log) : null,


### PR DESCRIPTION
This improves the clean task: it now accepts a number of options. Running it with no options keeps the existing behavior, deleting `/.gro/` and `/dist/`.

- `-B`: keep `/.gro/`, the "Gro build directory"
- `-D`: keep `/dist/`
- `-s`: delete `/.svelte/`
- `-n`: delete `/node_modules/`

It also changes the `clean` function to have a nice options interface.