### PR TITLE
separate the default server and primary Node builds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,9 @@
 # Gro changelog
 
-## 0.8.5
+## 0.9.0
 
+- **break**: separate the default server and primary Node builds
+  ([#131](https://github.com/feltcoop/gro/pull/131))
 - add server auto-restart to `src/dev.task.ts`
   ([#129](https://github.com/feltcoop/gro/pull/129))
 - improve the [clean task](https://github.com/feltcoop/gro/blob/main/src/clean.task.ts)

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - **break**: separate the default server and primary Node builds
   ([#131](https://github.com/feltcoop/gro/pull/131))
+- **break**: rename `src/utils/createObtainable.ts` to `src/utils/obtainable.ts` to fit convention
+  ([#131](https://github.com/feltcoop/gro/pull/131))
 - add server auto-restart to `src/dev.task.ts`
   ([#129](https://github.com/feltcoop/gro/pull/129))
 - improve the [clean task](https://github.com/feltcoop/gro/blob/main/src/clean.task.ts)

--- a/changelog.md
+++ b/changelog.md
@@ -266,7 +266,7 @@
 ## 0.1.11
 
 - fix `terser` import
-- export `Unobtain` type from `utils/createObtainable.ts`
+- export `Unobtain` type from `utils/obtainable.ts`
 
 ## 0.1.10
 
@@ -319,7 +319,7 @@
 ## 0.1.2
 
 - upgrade TypeScript dep
-- add `utils/createObtainable.ts` for decoupled lifecycle management
+- add `utils/obtainable.ts` for decoupled lifecycle management
 
 ## 0.1.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## 0.9.0
 
 - **break**: separate the default server and primary Node builds
+  in `src/config/gro.config.default.ts`
   ([#131](https://github.com/feltcoop/gro/pull/131))
 - **break**: rename `src/utils/createObtainable.ts` to `src/utils/obtainable.ts` to fit convention
   ([#131](https://github.com/feltcoop/gro/pull/131))

--- a/src/config/buildConfig.ts
+++ b/src/config/buildConfig.ts
@@ -1,7 +1,7 @@
 import {resolve} from 'path';
 
 import {ensureArray} from '../utils/array.js';
-import {PRIMARY_BUILD_CONFIG_NAME} from './defaultBuildConfig.js';
+import {PRIMARY_NODE_BUILD_CONFIG_NAME} from './defaultBuildConfig.js';
 import {paths} from '../paths.js';
 import {blue} from '../utils/terminal.js';
 import type {Result} from '../index.js';
@@ -115,12 +115,12 @@ export const validateBuildConfigs = (buildConfigs: BuildConfig[]): Result<{}, {r
 						` multiple primary items for platform "${buildConfig.platform}".`,
 				};
 			}
-			if (buildConfig.platform === 'node' && buildConfig.name !== PRIMARY_BUILD_CONFIG_NAME) {
+			if (buildConfig.platform === 'node' && buildConfig.name !== PRIMARY_NODE_BUILD_CONFIG_NAME) {
 				return {
 					ok: false,
 					reason:
 						`The field 'gro.builds' in package.json must name` +
-						` its primary Node config '${PRIMARY_BUILD_CONFIG_NAME}'`,
+						` its primary Node config '${PRIMARY_NODE_BUILD_CONFIG_NAME}'`,
 				};
 			}
 			primaryPlatforms.add(buildConfig.platform);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -9,7 +9,7 @@ import {Logger, LogLevel, SystemLogger} from '../utils/log.js';
 import {magenta} from '../utils/terminal.js';
 import {importTs} from '../fs/importTs.js';
 import {pathExists} from '../fs/nodeFs.js';
-import {DEFAULT_BUILD_CONFIG} from './defaultBuildConfig.js';
+import {PRIMARY_NODE_BUILD_CONFIG} from './defaultBuildConfig.js';
 import {DEFAULT_ECMA_SCRIPT_TARGET, EcmaScriptTarget} from '../build/tsBuildHelpers.js';
 import {omitUndefined} from '../utils/object.js';
 import type {ServedDirPartial} from '../build/ServedDir.js';
@@ -51,7 +51,7 @@ export interface GroConfig {
 }
 
 export interface PartialGroConfig {
-	readonly builds: (PartialBuildConfig | null)[]; // allow `null` for convenience
+	readonly builds: readonly (PartialBuildConfig | null)[]; // allow `null` for convenience
 	readonly target?: EcmaScriptTarget;
 	readonly sourcemap?: boolean;
 	readonly host?: string;
@@ -126,7 +126,11 @@ export const loadGroConfig = async (): Promise<GroConfig> => {
 		// The project has a `gro.config.ts`, so import it.
 		// If it's not already built, we need to bootstrap the config and use it to compile everything.
 		modulePath = configSourceId;
-		const configBuildId = toBuildOutPath(dev, DEFAULT_BUILD_CONFIG.name, CONFIG_BUILD_BASE_PATH);
+		const configBuildId = toBuildOutPath(
+			dev,
+			PRIMARY_NODE_BUILD_CONFIG.name,
+			CONFIG_BUILD_BASE_PATH,
+		);
 		if (await pathExists(configBuildId)) {
 			configModule = await import(configBuildId);
 		} else {
@@ -135,7 +139,7 @@ export const loadGroConfig = async (): Promise<GroConfig> => {
 			// to compile the config from TypeScript to importable JavaScript.
 			// Importantly, the build config is typically the default, because it hasn't yet been loaded,
 			// so there could be subtle differences between the actual and bootstrapped configs.
-			configModule = await importTs(configSourceId, DEFAULT_BUILD_CONFIG);
+			configModule = await importTs(configSourceId, PRIMARY_NODE_BUILD_CONFIG);
 		}
 	} else {
 		// The project does not have a `gro.config.ts`, so use Gro's fallback default.
@@ -144,7 +148,7 @@ export const loadGroConfig = async (): Promise<GroConfig> => {
 			toImportId(
 				`${groPaths.source}${FALLBACK_CONFIG_BASE_PATH}`,
 				dev,
-				DEFAULT_BUILD_CONFIG.name,
+				PRIMARY_NODE_BUILD_CONFIG.name,
 				groPaths,
 			)
 		);

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -34,8 +34,8 @@ export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
 	]);
 	return hasIndexHtml && hasIndexTs;
 };
-const assetPaths = ['html', 'css', 'json', 'ico', 'png', 'jpg', 'webp', 'webm', 'mp3'];
-export const toDefaultBrowserBuild = (): PartialBuildConfig => ({
+const DEFAULT_ASSET_PATHS = ['html', 'css', 'json', 'ico', 'png', 'jpg', 'webp', 'webm', 'mp3'];
+export const toDefaultBrowserBuild = (assetPaths = DEFAULT_ASSET_PATHS): PartialBuildConfig => ({
 	name: 'browser',
 	platform: 'browser',
 	input: ['index.ts', createFilter(`**/*.{${assetPaths.join(',')}}`)],

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -1,16 +1,43 @@
-import type {BuildConfig} from './buildConfig.js';
-import {paths} from '../paths.js';
+import {createFilter} from '@rollup/pluginutils';
+
+import type {BuildConfig, PartialBuildConfig} from './buildConfig.js';
+import {SERVER_SOURCE_BASE_PATH, SERVER_SOURCE_ID} from '../paths.js';
+import {pathExists} from '../fs/nodeFs.js';
 
 // Gro currently enforces that the primary build config
 // for the Node platform has this value as its name.
 // This convention speeds up running tasks by standardizing where Gro can look for built files.
 // This restriction could be relaxed by using cached metadata, but this keeps things simple for now.
-export const DEFAULT_BUILD_CONFIG_NAME = 'node';
-
-export const DEFAULT_BUILD_CONFIG: BuildConfig = {
-	name: DEFAULT_BUILD_CONFIG_NAME,
+export const PRIMARY_BUILD_CONFIG_NAME = 'node';
+export const PRIMARY_NODE_BUILD_CONFIG: BuildConfig = {
+	name: PRIMARY_BUILD_CONFIG_NAME,
 	platform: 'node',
 	primary: true,
 	dist: false,
-	input: [paths.source],
+	input: [createFilter(['**/*.{task,test,config,gen}*.ts', '**/fixtures/**'])],
 };
+
+export const hasGroServer = (): Promise<boolean> => pathExists(SERVER_SOURCE_ID);
+export const SERVER_BUILD_CONFIG_NAME = 'server';
+export const SERVER_BUILD_CONFIG: BuildConfig = {
+	name: SERVER_BUILD_CONFIG_NAME,
+	platform: 'node',
+	primary: false,
+	dist: true,
+	input: [SERVER_SOURCE_BASE_PATH],
+};
+
+export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
+	const [hasIndexHtml, hasIndexTs] = await Promise.all([
+		pathExists('src/index.html'),
+		pathExists('src/index.ts'),
+	]);
+	return hasIndexHtml && hasIndexTs;
+};
+const assetPaths = ['html', 'css', 'json', 'ico', 'png', 'jpg', 'webp', 'webm', 'mp3'];
+export const toDefaultBrowserBuild = (): PartialBuildConfig => ({
+	name: 'browser',
+	platform: 'browser',
+	input: ['index.ts', createFilter(`**/*.{${assetPaths.join(',')}}`)],
+	dist: true,
+});

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -8,9 +8,9 @@ import {pathExists} from '../fs/nodeFs.js';
 // for the Node platform has this value as its name.
 // This convention speeds up running tasks by standardizing where Gro can look for built files.
 // This restriction could be relaxed by using cached metadata, but this keeps things simple for now.
-export const PRIMARY_BUILD_CONFIG_NAME = 'node';
+export const PRIMARY_NODE_BUILD_CONFIG_NAME = 'node';
 export const PRIMARY_NODE_BUILD_CONFIG: BuildConfig = {
-	name: PRIMARY_BUILD_CONFIG_NAME,
+	name: PRIMARY_NODE_BUILD_CONFIG_NAME,
 	platform: 'node',
 	primary: true,
 	dist: false,
@@ -18,10 +18,15 @@ export const PRIMARY_NODE_BUILD_CONFIG: BuildConfig = {
 };
 
 export const hasGroServer = (): Promise<boolean> => pathExists(SERVER_SOURCE_ID);
+export const hasGroServerConfig = (buildConfigs: BuildConfig[]): boolean =>
+	buildConfigs.some(
+		(b) => b.name === SERVER_BUILD_CONFIG_NAME && b.platform === SERVER_BUILD_CONFIG_PLATFORM,
+	);
 export const SERVER_BUILD_CONFIG_NAME = 'server';
+export const SERVER_BUILD_CONFIG_PLATFORM = 'node';
 export const SERVER_BUILD_CONFIG: BuildConfig = {
 	name: SERVER_BUILD_CONFIG_NAME,
-	platform: 'node',
+	platform: SERVER_BUILD_CONFIG_PLATFORM,
 	primary: false,
 	dist: true,
 	input: [SERVER_SOURCE_BASE_PATH],

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -25,7 +25,7 @@ const createConfig: GroConfigCreator = async () => {
 		builds: [
 			PRIMARY_NODE_BUILD_CONFIG,
 			(await hasGroServer()) ? SERVER_BUILD_CONFIG : null,
-			(await hasDeprecatedGroFrontend()) ? toDefaultBrowserBuild() : null,
+			(await hasDeprecatedGroFrontend()) ? toDefaultBrowserBuild() : null, // TODO configure asset paths
 		],
 		logLevel: LogLevel.Trace,
 	};

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -24,7 +24,7 @@ const createConfig: GroConfigCreator = async () => {
 	const config: PartialGroConfig = {
 		builds: [
 			PRIMARY_NODE_BUILD_CONFIG,
-			(await hasGroServer()) ? SERVER_BUILD_CONFIG : null,
+			hasGroServer() ? SERVER_BUILD_CONFIG : null,
 			(await hasDeprecatedGroFrontend()) ? toDefaultBrowserBuild() : null, // TODO configure asset paths
 		],
 		logLevel: LogLevel.Trace,

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -1,10 +1,13 @@
-import {createFilter} from '@rollup/pluginutils';
-
 import type {GroConfigCreator, PartialGroConfig} from './config.js';
 import {LogLevel} from '../utils/log.js';
-import {PartialBuildConfig} from './buildConfig.js';
-import {pathExists} from '../fs/nodeFs.js';
 import {basePathToSourceId, toBuildExtension} from '../paths.js';
+import {
+	hasDeprecatedGroFrontend,
+	hasGroServer,
+	PRIMARY_NODE_BUILD_CONFIG,
+	SERVER_BUILD_CONFIG,
+	toDefaultBrowserBuild,
+} from './defaultBuildConfig.js';
 
 // This is the default config that's used if the current project does not define one.
 // The default config detects
@@ -21,14 +24,8 @@ const createConfig: GroConfigCreator = async () => {
 	const config: PartialGroConfig = {
 		builds: [
 			(await hasDeprecatedGroFrontend()) ? toDefaultBrowserBuild() : null,
-			{
-				name: 'node',
-				platform: 'node',
-				input: [
-					(await hasGroServer()) ? SERVER_SOURCE_BASE_PATH : null!,
-					createFilter('**/*.{task,test,config,gen}*.ts'),
-				].filter(Boolean),
-			},
+			PRIMARY_NODE_BUILD_CONFIG,
+			(await hasGroServer()) ? SERVER_BUILD_CONFIG : null,
 		],
 		logLevel: LogLevel.Trace,
 	};
@@ -36,24 +33,3 @@ const createConfig: GroConfigCreator = async () => {
 };
 
 export default createConfig;
-
-const assetPaths = ['html', 'css', 'json', 'ico', 'png', 'jpg', 'webp', 'webm', 'mp3'];
-
-const toDefaultBrowserBuild = (): PartialBuildConfig => ({
-	name: 'browser',
-	platform: 'browser',
-	input: ['index.ts', createFilter(`**/*.{${assetPaths.join(',')}}`)],
-	dist: true,
-});
-
-// TODO extract helper? or is this default config file its actual home?
-export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
-	const [hasIndexHtml, hasIndexTs] = await Promise.all([
-		pathExists('src/index.html'),
-		pathExists('src/index.ts'),
-	]);
-	return hasIndexHtml && hasIndexTs;
-};
-
-// TODO extract helper? or is this default config file its actual home?
-export const hasGroServer = (): Promise<boolean> => pathExists(SERVER_SOURCE_ID);

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -23,9 +23,9 @@ export const SERVER_SOURCE_ID = basePathToSourceId(SERVER_SOURCE_BASE_PATH); // 
 const createConfig: GroConfigCreator = async () => {
 	const config: PartialGroConfig = {
 		builds: [
-			(await hasDeprecatedGroFrontend()) ? toDefaultBrowserBuild() : null,
 			PRIMARY_NODE_BUILD_CONFIG,
 			(await hasGroServer()) ? SERVER_BUILD_CONFIG : null,
+			(await hasDeprecatedGroFrontend()) ? toDefaultBrowserBuild() : null,
 		],
 		logLevel: LogLevel.Trace,
 	};

--- a/src/fs/modules.ts
+++ b/src/fs/modules.ts
@@ -6,7 +6,7 @@ import {Timings} from '../utils/time.js';
 import type {PathStats, PathData} from './pathData.js';
 import {toImportId, pathsFromId} from '../paths.js';
 import {UnreachableError} from '../utils/error.js';
-import {PRIMARY_BUILD_CONFIG_NAME} from '../config/defaultBuildConfig.js';
+import {PRIMARY_NODE_BUILD_CONFIG_NAME} from '../config/defaultBuildConfig.js';
 import type {Obj, Result} from '../index.js';
 
 /*
@@ -35,7 +35,7 @@ export const loadModule = async <T>(
 	id: string,
 	validate?: (mod: Obj) => mod is T,
 	dev = true,
-	buildConfigName = PRIMARY_BUILD_CONFIG_NAME,
+	buildConfigName = PRIMARY_NODE_BUILD_CONFIG_NAME,
 ): Promise<LoadModuleResult<ModuleMeta<T>>> => {
 	let mod;
 	try {

--- a/src/fs/modules.ts
+++ b/src/fs/modules.ts
@@ -6,7 +6,7 @@ import {Timings} from '../utils/time.js';
 import type {PathStats, PathData} from './pathData.js';
 import {toImportId, pathsFromId} from '../paths.js';
 import {UnreachableError} from '../utils/error.js';
-import {DEFAULT_BUILD_CONFIG_NAME} from '../config/defaultBuildConfig.js';
+import {PRIMARY_BUILD_CONFIG_NAME} from '../config/defaultBuildConfig.js';
 import type {Obj, Result} from '../index.js';
 
 /*
@@ -35,7 +35,7 @@ export const loadModule = async <T>(
 	id: string,
 	validate?: (mod: Obj) => mod is T,
 	dev = true,
-	buildConfigName = DEFAULT_BUILD_CONFIG_NAME,
+	buildConfigName = PRIMARY_BUILD_CONFIG_NAME,
 ): Promise<LoadModuleResult<ModuleMeta<T>>> => {
 	let mod;
 	try {

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -2,7 +2,6 @@ import {createFilter} from '@rollup/pluginutils';
 
 // import {createDirectoryFilter} from './build/utils.js';
 import type {GroConfigCreator, PartialGroConfig} from './config/config.js';
-import {SERVER_BUILD_CONFIG} from './config/defaultBuildConfig.js';
 import {toBuildOutPath} from './paths.js';
 import {LogLevel} from './utils/log.js';
 
@@ -14,6 +13,8 @@ const createConfig: GroConfigCreator = async () => {
 	const BROWSER_BUILD_CONFIG_NAME = 'browser';
 	const config: PartialGroConfig = {
 		builds: [
+			// TODO think about this
+			// {...SERVER_BUILD_CONFIG, dist: false},
 			{
 				name: 'node',
 				platform: 'node',
@@ -26,7 +27,6 @@ const createConfig: GroConfigCreator = async () => {
 					createFilter(['**/*.{task,test,config,gen}*.ts', '**/fixtures/**']),
 				],
 			},
-			{...SERVER_BUILD_CONFIG, dist: false},
 			{
 				name: BROWSER_BUILD_CONFIG_NAME,
 				platform: 'browser',

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -2,6 +2,7 @@ import {createFilter} from '@rollup/pluginutils';
 
 // import {createDirectoryFilter} from './build/utils.js';
 import type {GroConfigCreator, PartialGroConfig} from './config/config.js';
+import {SERVER_BUILD_CONFIG} from './config/defaultBuildConfig.js';
 import {toBuildOutPath} from './paths.js';
 import {LogLevel} from './utils/log.js';
 
@@ -25,6 +26,7 @@ const createConfig: GroConfigCreator = async () => {
 					createFilter(['**/*.{task,test,config,gen}*.ts', '**/fixtures/**']),
 				],
 			},
+			{...SERVER_BUILD_CONFIG, dist: false},
 			{
 				name: BROWSER_BUILD_CONFIG_NAME,
 				platform: 'browser',

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -34,9 +34,6 @@ export const CONFIG_BUILD_BASE_PATH = 'gro.config.js';
 export const EXTERNALS_BUILD_DIR = 'externals'; // TODO breaks the above trailing slash convention - revisit with trailing-slash branch
 export const EXTERNALS_BUILD_DIR_SUBPATH = `/${EXTERNALS_BUILD_DIR}/`;
 
-export const NODE_MODULES_PATH = 'node_modules';
-export const SVELTE_KIT_PATH = '.svelte';
-
 export interface Paths {
 	root: string;
 	source: string;
@@ -233,3 +230,10 @@ export const groDirBasename = `${basename(groDir)}/`;
 export const paths = createPaths(`${process.cwd()}/`);
 export const isThisProjectGro = groDir === paths.root;
 export const groPaths = isThisProjectGro ? paths : createPaths(groDir);
+
+export const SERVER_SOURCE_BASE_PATH = 'server/server.ts';
+export const SERVER_BUILD_BASE_PATH = toBuildExtension(SERVER_SOURCE_BASE_PATH); // 'server/server.js'
+export const SERVER_SOURCE_ID = basePathToSourceId(SERVER_SOURCE_BASE_PATH); // '/home/to/your/src/server/server.ts'
+
+export const NODE_MODULES_PATH = 'node_modules';
+export const SVELTE_KIT_PATH = '.svelte';

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -21,7 +21,7 @@ import {findFiles, pathExists} from '../fs/nodeFs.js';
 import {plural} from '../utils/string.js';
 import {loadTaskModule} from './taskModule.js';
 import {loadGroPackageJson} from '../project/packageJson.js';
-import {PRIMARY_BUILD_CONFIG_NAME} from '../config/defaultBuildConfig.js';
+import {PRIMARY_NODE_BUILD_CONFIG_NAME} from '../config/defaultBuildConfig.js';
 
 /*
 
@@ -240,6 +240,6 @@ const shouldBuildProject = async (sourceId: string): Promise<boolean> => {
 	// if this is Gro, ensure the build directory exists, because tests aren't in dist/
 	if (isThisProjectGro && !(await pathExists(paths.build))) return true;
 	// ensure the build file for the source id exists in the default dev build
-	const buildId = toImportId(sourceId, true, PRIMARY_BUILD_CONFIG_NAME);
+	const buildId = toImportId(sourceId, true, PRIMARY_NODE_BUILD_CONFIG_NAME);
 	return !(await pathExists(buildId));
 };

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -21,7 +21,7 @@ import {findFiles, pathExists} from '../fs/nodeFs.js';
 import {plural} from '../utils/string.js';
 import {loadTaskModule} from './taskModule.js';
 import {loadGroPackageJson} from '../project/packageJson.js';
-import {DEFAULT_BUILD_CONFIG_NAME} from '../config/defaultBuildConfig.js';
+import {PRIMARY_BUILD_CONFIG_NAME} from '../config/defaultBuildConfig.js';
 
 /*
 
@@ -240,6 +240,6 @@ const shouldBuildProject = async (sourceId: string): Promise<boolean> => {
 	// if this is Gro, ensure the build directory exists, because tests aren't in dist/
 	if (isThisProjectGro && !(await pathExists(paths.build))) return true;
 	// ensure the build file for the source id exists in the default dev build
-	const buildId = toImportId(sourceId, true, DEFAULT_BUILD_CONFIG_NAME);
+	const buildId = toImportId(sourceId, true, PRIMARY_BUILD_CONFIG_NAME);
 	return !(await pathExists(buildId));
 };

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -4,7 +4,7 @@ import {printTiming} from './utils/print.js';
 import {Timings} from './utils/time.js';
 import {spawnProcess} from './utils/process.js';
 import {toBuildOutPath, toRootPath} from './paths.js';
-import {PRIMARY_BUILD_CONFIG_NAME} from './config/defaultBuildConfig.js';
+import {PRIMARY_NODE_BUILD_CONFIG_NAME} from './config/defaultBuildConfig.js';
 
 // Runs the project's tests: `gro test [...args]`
 // Args are passed through directly to `uvu`'s CLI:
@@ -16,7 +16,7 @@ export const task: Task = {
 		const timings = new Timings();
 
 		const dev = process.env.NODE_ENV !== 'production';
-		const dir = toRootPath(toBuildOutPath(dev, PRIMARY_BUILD_CONFIG_NAME));
+		const dir = toRootPath(toBuildOutPath(dev, PRIMARY_NODE_BUILD_CONFIG_NAME));
 
 		const timeToRunUvu = timings.start('run test with uvu');
 		const testRunResult = await spawnProcess('npx', [

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -4,7 +4,7 @@ import {printTiming} from './utils/print.js';
 import {Timings} from './utils/time.js';
 import {spawnProcess} from './utils/process.js';
 import {toBuildOutPath, toRootPath} from './paths.js';
-import {DEFAULT_BUILD_CONFIG_NAME} from './config/defaultBuildConfig.js';
+import {PRIMARY_BUILD_CONFIG_NAME} from './config/defaultBuildConfig.js';
 
 // Runs the project's tests: `gro test [...args]`
 // Args are passed through directly to `uvu`'s CLI:
@@ -16,7 +16,7 @@ export const task: Task = {
 		const timings = new Timings();
 
 		const dev = process.env.NODE_ENV !== 'production';
-		const dir = toRootPath(toBuildOutPath(dev, DEFAULT_BUILD_CONFIG_NAME));
+		const dir = toRootPath(toBuildOutPath(dev, PRIMARY_BUILD_CONFIG_NAME));
 
 		const timeToRunUvu = timings.start('run test with uvu');
 		const testRunResult = await spawnProcess('npx', [

--- a/src/utils/obtainable.test.ts
+++ b/src/utils/obtainable.test.ts
@@ -1,7 +1,7 @@
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
 
-import {createObtainable} from './createObtainable.js';
+import {createObtainable} from './obtainable.js';
 
 /* test_createObtainable */
 const test_createObtainable = suite('createObtainable');

--- a/src/utils/obtainable.ts
+++ b/src/utils/obtainable.ts
@@ -11,7 +11,7 @@ It can also be used to create lazily instantiated references.
 
 The motivating use case was reusing a database connection across multiple tasks.
 
-See the tests for usage examples - ./createObtainable.test.ts
+See the tests for usage examples - ./obtainable.test.ts
 
 */
 export const createObtainable = <T>(


### PR DESCRIPTION
When we set up the builds for our projects with Gro, I wanted to keep things simple, with a single Node build. I designed Gro's build system to be able to hand multiple kinds of builds, even multiple of the same platform, and now it seems we want to use them: specifically, in `src/config/gro.config.default.ts`, we want a Node build with our tasks, tests, etc, and a different Node build with our server, if there is a server.

This allows us to change the API server restart implementation in #129 to no longer wastefully restart when you edit a task, a task dependency, or something or the sort for tests, and other things that are in the primary Node build, but do not cause a change in the API server to warrant restarting it. See the `src/config/gro.config.default.ts` for more.

This is a **breaking change** because it changes output artifacts considerably. The production build still needs work.

I slipped in a second breaking change - renaming `src/utils/createObtainable.ts` to `src/utils/obtainable.ts` to fit convention.