### PR TITLE
fix build options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Gro changelog
 
+## 0.9.1
+
+- fix `src/build.task.ts` to correctly use `sourcemap` and `target` Gro config options
+  ([#131](https://github.com/feltcoop/gro/pull/131))
+- turn sourcemaps off by default in production
+  ([#131](https://github.com/feltcoop/gro/pull/131))
+
 ## 0.9.0
 
 - **break**: separate the default server and primary Node builds

--- a/changelog.md
+++ b/changelog.md
@@ -3,9 +3,9 @@
 ## 0.9.1
 
 - fix `src/build.task.ts` to correctly use `sourcemap` and `target` Gro config options
-  ([#131](https://github.com/feltcoop/gro/pull/131))
+  ([#132](https://github.com/feltcoop/gro/pull/132))
 - turn sourcemaps off by default in production
-  ([#131](https://github.com/feltcoop/gro/pull/131))
+  ([#132](https://github.com/feltcoop/gro/pull/132))
 
 ## 0.9.0
 

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -2,7 +2,6 @@ import {pathExists} from './fs/nodeFs.js';
 import type {Task} from './task/task.js';
 import {createBuild} from './project/build.js';
 import {getDefaultEsbuildOptions} from './build/esbuildBuildHelpers.js';
-import {loadTsconfig, toEcmaScriptTarget} from './build/tsBuildHelpers.js';
 import {isThisProjectGro, toBuildOutPath} from './paths.js';
 import {Timings} from './utils/time.js';
 import {loadGroConfig} from './config/config.js';
@@ -39,13 +38,7 @@ export const task: Task = {
 		timingToLoadConfig();
 		args.oncreateconfig && (args as any).oncreateconfig(config);
 
-		// TODO this is outdated - needs to be updated with the Gro config (see `dev.task.ts`)
-		const tsconfigPath = undefined; // TODO parameterized options?
-		const basePath = undefined; // TODO parameterized options?
-		const tsconfig = loadTsconfig(log, tsconfigPath, basePath);
-		const target = toEcmaScriptTarget(tsconfig.compilerOptions?.target);
-		const sourcemap = tsconfig.compilerOptions?.sourceMap ?? true;
-		const esbuildOptions = getDefaultEsbuildOptions(target, sourcemap);
+		const esbuildOptions = getDefaultEsbuildOptions(config.target, config.sourcemap);
 
 		// For each build config, infer which of the inputs
 		// are actual source files, and therefore belong in the default Rollup build.
@@ -59,7 +52,7 @@ export const task: Task = {
 					const outputDir = toBuildOutPath(dev, buildConfig.name);
 					const build = createBuild({
 						dev,
-						sourcemap,
+						sourcemap: config.sourcemap,
 						inputFiles,
 						outputDir,
 						watch,

--- a/src/build/tsBuildHelpers.ts
+++ b/src/build/tsBuildHelpers.ts
@@ -17,32 +17,33 @@ export type EcmaScriptTarget =
 
 export const DEFAULT_ECMA_SCRIPT_TARGET: EcmaScriptTarget = 'es2020';
 
-export const toEcmaScriptTarget = (target: ts.ScriptTarget | undefined): EcmaScriptTarget => {
-	switch (target) {
-		case 0: // ES3 = 0,
-			return 'es3';
-		case 1: // ES5 = 1,
-			return 'es5';
-		case 2: // ES2015 = 2,
-			return 'es2015';
-		case 3: // ES2016 = 3,
-			return 'es2016';
-		case 4: // ES2017 = 4,
-			return 'es2017';
-		case 5: // ES2018 = 5,
-			return 'es2018';
-		case 6: // ES2019 = 6,
-			return 'es2019';
-		case 7: // ES2020 = 7,
-			return 'es2020';
-		case 99: // ESNext = 99,
-			return 'esnext';
-		// JSON = 100,
-		// Latest = 99
-		default:
-			return DEFAULT_ECMA_SCRIPT_TARGET;
-	}
-};
+// TODO remove eventually. might want to default the Gro config target to the
+// export const toEcmaScriptTarget = (target: ts.ScriptTarget | undefined): EcmaScriptTarget => {
+// 	switch (target) {
+// 		case 0: // ES3 = 0,
+// 			return 'es3';
+// 		case 1: // ES5 = 1,
+// 			return 'es5';
+// 		case 2: // ES2015 = 2,
+// 			return 'es2015';
+// 		case 3: // ES2016 = 3,
+// 			return 'es2016';
+// 		case 4: // ES2017 = 4,
+// 			return 'es2017';
+// 		case 5: // ES2018 = 5,
+// 			return 'es2018';
+// 		case 6: // ES2019 = 6,
+// 			return 'es2019';
+// 		case 7: // ES2020 = 7,
+// 			return 'es2020';
+// 		case 99: // ESNext = 99,
+// 			return 'esnext';
+// 		// JSON = 100,
+// 		// Latest = 99
+// 		default:
+// 			return DEFAULT_ECMA_SCRIPT_TARGET;
+// 	}
+// };
 
 // confusingly, TypeScript doesn't seem to be a good type for this
 export interface TsConfig {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -199,7 +199,7 @@ const normalizeConfig = (config: PartialGroConfig): GroConfig => {
 	const primaryBrowserBuildConfig =
 		buildConfigs.find((b) => b.primary && b.platform === 'browser') || null;
 	return {
-		sourcemap: true,
+		sourcemap: process.env.NODE_ENV !== 'production', // TODO maybe default to tsconfig?
 		host: DEFAULT_SERVER_HOST,
 		port: DEFAULT_SERVER_PORT,
 		logLevel: LogLevel.Trace,


### PR DESCRIPTION
This fixes `src/build.task.ts` to correctly use the `sourcemap` and `target` options from the Gro config. It was using the `tsconfig.json` values instead.

I can't tell if we should default to `tsconfig.json` values if there's no Gro config set for `sourcemap` and `target`, or just go with the production toggle and Gro-wide default, respectively. I think I'm fine with the latter on both for now. In case we need it, I'm keeping some relevant code around that's now dead, but would be needed if we use the `tsconfig.json` for more defaults.

This can get weird if you try to use `tsc` for build outputs, but we're not doing that except in Gro itself, and we always ship sourcemaps there, so no worries.

The PR also turns off sourcemaps by default in production. This is the better default for most libraries and servers, so we can just let everyone opt in to keep things simple.