### PR TITLE
add the optional dev property to task definitions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.9.3
 
-- add the optional `dev` property to `Task` definitions to set the inherited context
+- add the optional `dev` property to `Task` definitions to fix the inherited context
   ([#134](https://github.com/feltcoop/gro/pull/134))
 
 ## 0.9.2

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.9.3
+
+- add the optional `dev` property to `Task` definitions to set the inherited context
+  ([#134](https://github.com/feltcoop/gro/pull/134))
+
 ## 0.9.2
 
 - fix `src/build.task.ts` ([#133](https://github.com/feltcoop/gro/pull/133)):

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -31,7 +31,7 @@ export const task: Task = {
 		const mapWatchOptions = args.mapWatchOptions as any;
 
 		const timingToLoadConfig = timings.start('load config');
-		const config = await loadGroConfig();
+		const config = await loadGroConfig(dev);
 		configureLogLevel(config.logLevel);
 		timingToLoadConfig();
 		args.oncreateconfig && (args as any).oncreateconfig(config);

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -8,12 +8,10 @@ import {loadGroConfig} from './config/config.js';
 import {configureLogLevel} from './utils/log.js';
 import type {BuildConfig} from './config/buildConfig.js';
 
-process.env.NODE_ENV = 'production';
-const dev = false; // forcing prod builds for now
-
 export const task: Task = {
 	description: 'build the project',
-	run: async ({log, args, invokeTask}): Promise<void> => {
+	dev: false,
+	run: async ({dev, log, args, invokeTask}): Promise<void> => {
 		// Normal user projects will ignore this code path right here:
 		// in other words, `isThisProjectGro` will always be `false` for your code.
 		// TODO task pollution, this is bad for users who want to copy/paste this task.

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -4,7 +4,7 @@ import * as t from 'uvu/assert';
 import {loadGroConfig} from './config.js';
 
 test('loadGroConfig', async () => {
-	const config = await loadGroConfig();
+	const config = await loadGroConfig(true);
 	t.ok(config);
 });
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -110,10 +110,9 @@ Caveats
 
 */
 
-export const loadGroConfig = async (): Promise<GroConfig> => {
+export const loadGroConfig = async (dev: boolean): Promise<GroConfig> => {
 	if (cachedConfig !== undefined) return cachedConfig;
 
-	const dev = process.env.NODE_ENV !== 'production';
 	const log = new SystemLogger([magenta('[config]')]);
 	const options: GroConfigCreatorOptions = {log, dev};
 

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -14,7 +14,7 @@ import {hasGroServerConfig, SERVER_BUILD_CONFIG_NAME} from './config/defaultBuil
 
 export const task: Task = {
 	description: 'start dev server',
-	run: async ({log, args}) => {
+	run: async ({dev, log, args}) => {
 		// TODO handle these properly
 		// args.oncreateconfig
 		// args.oncreatefiler
@@ -25,7 +25,7 @@ export const task: Task = {
 		const timings = new Timings();
 
 		const timingToLoadConfig = timings.start('load config');
-		const config = await loadGroConfig();
+		const config = await loadGroConfig(dev);
 		configureLogLevel(config.logLevel);
 		timingToLoadConfig();
 		args.oncreateconfig && (args as any).oncreateconfig(config);

--- a/src/dist.task.ts
+++ b/src/dist.task.ts
@@ -13,9 +13,8 @@ export const isDistFile = (path: string): boolean =>
 
 export const task: Task = {
 	description: 'create the distribution',
-	run: async ({log}) => {
-		const dev = process.env.NODE_ENV !== 'production';
-
+	dev: false,
+	run: async ({dev, log}) => {
 		await clean({dist: true}, log);
 
 		// This reads the `dist` flag on the build configs to help construct the final dist directory.

--- a/src/dist.task.ts
+++ b/src/dist.task.ts
@@ -19,7 +19,7 @@ export const task: Task = {
 
 		// This reads the `dist` flag on the build configs to help construct the final dist directory.
 		// See the docs at `./docs/config.md`.
-		const config = await loadGroConfig();
+		const config = await loadGroConfig(dev);
 		configureLogLevel(config.logLevel);
 		const buildConfigsForDist = config.builds.filter((b) => b.dist);
 		await Promise.all(

--- a/src/project/build.task.ts
+++ b/src/project/build.task.ts
@@ -13,7 +13,7 @@ export const task: Task = {
 		const timings = new Timings();
 
 		const timeToLoadConfig = timings.start('load config');
-		const config = await loadGroConfig();
+		const config = await loadGroConfig(dev);
 		configureLogLevel(config.logLevel);
 		timeToLoadConfig();
 

--- a/src/project/build.task.ts
+++ b/src/project/build.task.ts
@@ -6,12 +6,10 @@ import {buildSourceDirectory} from '../build/buildSourceDirectory.js';
 import {loadGroConfig} from '../config/config.js';
 import {configureLogLevel} from '../utils/log.js';
 
-process.env.NODE_ENV = 'production';
-const dev = false; // forcing prod builds for now
-
 export const task: Task = {
 	description: 'build, create, and link the distribution',
-	run: async ({invokeTask, log}) => {
+	dev: false,
+	run: async ({dev, invokeTask, log}) => {
 		const timings = new Timings();
 
 		const timeToLoadConfig = timings.start('load config');

--- a/src/task/README.md
+++ b/src/task/README.md
@@ -101,7 +101,8 @@ export const task: Task = {
 // `@feltcoop/gro`
 export interface Task {
 	run: (ctx: TaskContext) => Promise<unknown>;
-	description?: string;
+	description?: string; // optional text describing the task - TODO should this be required?
+	dev?: boolean; // optionally set the `dev` value in the inherited context
 }
 ```
 

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -82,7 +82,7 @@ export const invokeTask = async (taskName: string, args: Args): Promise<void> =>
 				log.info('building project to run task');
 				const timingToLoadConfig = timings.start('load config');
 				const {loadGroConfig} = await import('../config/config.js');
-				const config = await loadGroConfig();
+				const config = await loadGroConfig(process.env.NODE_ENV !== 'production'); // TODO is this the right `dev` value?
 				configureLogLevel(config.logLevel);
 				timingToLoadConfig();
 				const timingToBuildProject = timings.start('build project');

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -23,6 +23,7 @@ export const runTask = async (
 	let output;
 	try {
 		output = await task.mod.task.run({
+			dev: task.mod.task.dev ?? process.env.NODE_ENV !== 'production',
 			args,
 			log: new SystemLogger([`${gray('[')}${magenta(task.name)}${gray(':log')}${gray(']')}`]),
 			invokeTask: (invokedTaskName, invokedArgs = args) => invokeTask(invokedTaskName, invokedArgs),

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -4,9 +4,11 @@ import type {Args} from '../cli/types.js';
 export interface Task {
 	run: (ctx: TaskContext) => Promise<unknown>;
 	description?: string;
+	dev?: boolean;
 }
 
 export interface TaskContext {
+	dev: boolean;
 	log: Logger;
 	args: Args;
 	invokeTask: (taskName: string, args?: Args) => Promise<void>;

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -12,10 +12,9 @@ import {PRIMARY_NODE_BUILD_CONFIG_NAME} from './config/defaultBuildConfig.js';
 
 export const task: Task = {
 	description: 'run tests',
-	run: async ({log}): Promise<void> => {
+	run: async ({dev, log}): Promise<void> => {
 		const timings = new Timings();
 
-		const dev = process.env.NODE_ENV !== 'production';
 		const dir = toRootPath(toBuildOutPath(dev, PRIMARY_NODE_BUILD_CONFIG_NAME));
 
 		const timeToRunUvu = timings.start('run test with uvu');


### PR DESCRIPTION
This changes the `dev` value to be optionally declared by `Task`s, and defaults to detecting from `process.env.NODE_ENV` in a single place in `runTask`. I'm not sure this is the final form, but I think it'll fix some issues and be an overall win.