### PR TITLE
add the optional dev arg to invokeTask and runTask

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.9.4
+
+- add the `dev` property to `invokeTask` and `runTask`
+  ([#135](https://github.com/feltcoop/gro/pull/135))
+
 ## 0.9.3
 
 - add the optional `dev` property to `Task` definitions to fix the inherited context

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.9.4
 
-- add the `dev` property to `invokeTask` and `runTask`
+- add the optional `dev` arg to `invokeTask` and `runTask`
   ([#135](https://github.com/feltcoop/gro/pull/135))
 
 ## 0.9.3

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.9.4
 
-- add the optional `dev` arg to `invokeTask` and `runTask`
+- forward the optional `dev` arg through the task invocation tree via `invokeTask` and `runTask`
   ([#135](https://github.com/feltcoop/gro/pull/135))
 
 ## 0.9.3

--- a/src/task/README.md
+++ b/src/task/README.md
@@ -175,8 +175,11 @@ This lets projects fully customize every task.
 
 ### throwing errors
 
-If a task encounters an error, it should throw rather than exiting the process.
+If a task encounters an error, normally it should throw rather than exiting the process.
 This defers control to the caller, like your own parent tasks.
+
+> TODO add support for `FatalError`
+
 Often, errors that tasks encounter do not need a stack trace,
 and we don't want the added noise to be logged.
 To suppress logging the stack trace for an error,

--- a/src/task/README.md
+++ b/src/task/README.md
@@ -194,6 +194,22 @@ export const task: Task = {
 };
 ```
 
+### `dev` task invocation tree forwarding
+
+```ts
+// src/some/file.task.ts
+import type {Task} from '@feltcoop/gro';
+
+export const task: Task = {
+	dev: false,
+	run: async ({dev, invokeTask}) => {
+		// `dev` is `false` because it's defined two lines up in the task definition,
+		// unless an ancestor task called `invokeTask` with a `true` value, like this:
+		invokeTask('descendentTaskWithFlippedDevValue', undefined, !dev);
+	},
+};
+```
+
 ## future improvements
 
 - [ ] consider a pattern for declaring and validating CLI args

--- a/src/task/README.md
+++ b/src/task/README.md
@@ -194,7 +194,7 @@ export const task: Task = {
 };
 ```
 
-### `dev` task invocation tree forwarding
+### `dev` forwarding through the task invocation tree
 
 ```ts
 // src/some/file.task.ts

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -43,7 +43,7 @@ The comments describe each condition.
 
 */
 
-export const invokeTask = async (taskName: string, args: Args): Promise<void> => {
+export const invokeTask = async (taskName: string, args: Args, dev?: boolean): Promise<void> => {
 	const log = new SystemLogger([`${gray('[')}${magenta(taskName || 'gro')}${gray(']')}`]);
 
 	// Check if the caller just wants to see the version.
@@ -82,7 +82,7 @@ export const invokeTask = async (taskName: string, args: Args): Promise<void> =>
 				log.info('building project to run task');
 				const timingToLoadConfig = timings.start('load config');
 				const {loadGroConfig} = await import('../config/config.js');
-				const config = await loadGroConfig(process.env.NODE_ENV !== 'production'); // TODO is this the right `dev` value?
+				const config = await loadGroConfig(dev ?? process.env.NODE_ENV !== 'production');
 				configureLogLevel(config.logLevel);
 				timingToLoadConfig();
 				const timingToBuildProject = timings.start('build project');
@@ -107,7 +107,7 @@ export const invokeTask = async (taskName: string, args: Args): Promise<void> =>
 					}`,
 				);
 				const timingToRunTask = timings.start('run task');
-				const result = await runTask(task, args, invokeTask);
+				const result = await runTask(task, args, invokeTask, dev);
 				timingToRunTask();
 				if (result.ok) {
 					log.info(`✓ ${cyan(task.name)}`);

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -27,8 +27,8 @@ export const runTask = async (
 			dev,
 			args,
 			log: new SystemLogger([`${gray('[')}${magenta(task.name)}${gray(':log')}${gray(']')}`]),
-			invokeTask: (invokedTaskName, invokedArgs = args, _dev = dev) =>
-				invokeTask(invokedTaskName, invokedArgs, _dev),
+			invokeTask: (invokedTaskName, invokedArgs = args, invokedDev = dev) =>
+				invokeTask(invokedTaskName, invokedArgs, invokedDev),
 		});
 	} catch (err) {
 		return {

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -18,15 +18,17 @@ export type RunTaskResult =
 export const runTask = async (
 	task: TaskModuleMeta,
 	args: Args,
-	invokeTask: (taskName: string, args: Args) => Promise<void>,
+	invokeTask: (taskName: string, args: Args, dev: boolean) => Promise<void>,
+	dev = task.mod.task.dev ?? process.env.NODE_ENV !== 'production',
 ): Promise<RunTaskResult> => {
 	let output;
 	try {
 		output = await task.mod.task.run({
-			dev: task.mod.task.dev ?? process.env.NODE_ENV !== 'production',
+			dev,
 			args,
 			log: new SystemLogger([`${gray('[')}${magenta(task.name)}${gray(':log')}${gray(']')}`]),
-			invokeTask: (invokedTaskName, invokedArgs = args) => invokeTask(invokedTaskName, invokedArgs),
+			invokeTask: (invokedTaskName, invokedArgs = args, _dev = dev) =>
+				invokeTask(invokedTaskName, invokedArgs, _dev),
 		});
 	} catch (err) {
 		return {

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -11,7 +11,7 @@ export interface TaskContext {
 	dev: boolean;
 	log: Logger;
 	args: Args;
-	invokeTask: (taskName: string, args?: Args) => Promise<void>;
+	invokeTask: (taskName: string, args?: Args, dev?: boolean) => Promise<void>;
 }
 
 export const TASK_FILE_PATTERN = /\.task\.ts$/;


### PR DESCRIPTION
This adds the optional `dev` arg to both `invokeTask` and `runTask`. It's inherited but can be overridden by any branch in the task invocation tree.