### PR TITLE
remove import.meta.env.DEV support and improve process.env.NODE_ENV with tasks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.9.5
+
+- remove `import.meta.env.DEV` support for now despite SvelteKit alignment
+  ([#136](https://github.com/feltcoop/gro/pull/136))
+
 ## 0.9.4
 
 - forward the optional `dev` arg through the task invocation tree via `invokeTask` and `runTask`

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.9.5
 
+- set `process.env.NODE_ENV` when running tasks with explicit `dev` values
+  ([#136](https://github.com/feltcoop/gro/pull/136))
 - remove `import.meta.env.DEV` support for now despite SvelteKit alignment
   ([#136](https://github.com/feltcoop/gro/pull/136))
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "start": "gro",
     "test": "gro test",
-    "bootstrap": "rm -rf .gro dist && esbuild src/**/*.ts src/*.ts --outdir=.gro/prod/node/ --define:import.meta.env.DEV=true; cp -r .gro/prod/node/ dist/ && npm link",
+    "bootstrap": "rm -rf .gro dist && esbuild src/**/*.ts src/*.ts --outdir=.gro/prod/node/; cp -r .gro/prod/node/ dist/ && npm link",
     "dev": "clear && npm run bootstrap && gro dev",
     "build": "clear && npm run bootstrap && gro build",
     "buildprod": "npm run build && rm -rf .gro",

--- a/src/build/esbuildBuildHelpers.ts
+++ b/src/build/esbuildBuildHelpers.ts
@@ -11,7 +11,7 @@ export interface EsbuildTransformOptions extends esbuild.TransformOptions {
 export const getDefaultEsbuildOptions = (
 	target: EcmaScriptTarget = DEFAULT_ECMA_SCRIPT_TARGET,
 	sourcemap = true,
-	dev = true,
+	_dev = true,
 ): EsbuildTransformOptions => ({
 	target,
 	sourcemap,
@@ -19,22 +19,16 @@ export const getDefaultEsbuildOptions = (
 	loader: 'ts',
 	charset: 'utf8', // following `svelte-preprocess-esbuild` here
 	tsconfigRaw: {compilerOptions: {importsNotUsedAsValues: 'remove'}},
-	define: {
-		'import.meta.env.DEV': JSON.stringify(dev),
-		// 'import.meta.env.SSR': 'false', // TODO (when implemented, also add to bootstrap npm script)
-	},
+	define: {},
 });
 
 export const getDefaultEsbuildPreprocessOptions = (
 	target: EcmaScriptTarget = DEFAULT_ECMA_SCRIPT_TARGET,
 	sourcemap = true,
-	dev = true,
+	_dev = true,
 ): Partial<sveltePreprocessEsbuild.Options> => ({
 	target,
 	sourcemap,
 	tsconfigRaw: {compilerOptions: {}}, // pass an empty object so the preprocessor doesn't load the tsconfig
-	define: {
-		'import.meta.env.DEV': JSON.stringify(dev),
-		// 'import.meta.env.SSR': 'false', // TODO (when implemented, also add to bootstrap npm script)
-	},
+	define: {},
 });

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -19,15 +19,23 @@ export const runTask = async (
 	task: TaskModuleMeta,
 	args: Args,
 	invokeTask: (taskName: string, args: Args, dev: boolean) => Promise<void>,
-	dev = task.mod.task.dev ?? process.env.NODE_ENV !== 'production',
+	dev?: boolean,
 ): Promise<RunTaskResult> => {
+	if (dev === undefined) {
+		if (task.mod.task.dev !== undefined) {
+			dev = task.mod.task.dev;
+			process.env.NODE_ENV = dev ? 'development' : 'production';
+		} else {
+			dev = process.env.NODE_ENV !== 'production';
+		}
+	}
 	let output;
 	try {
 		output = await task.mod.task.run({
 			dev,
 			args,
 			log: new SystemLogger([`${gray('[')}${magenta(task.name)}${gray(':log')}${gray(']')}`]),
-			invokeTask: (invokedTaskName, invokedArgs = args, invokedDev = dev) =>
+			invokeTask: (invokedTaskName, invokedArgs = args, invokedDev = dev!) =>
 				invokeTask(invokedTaskName, invokedArgs, invokedDev),
 		});
 	} catch (err) {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,16 +1,6 @@
 import type {Lazy} from './lazy.js';
 import {lazy} from './lazy.js';
 
-declare global {
-	interface ImportMeta {
-		env: {
-			DEV: boolean;
-		};
-	}
-}
-
-export const dev = import.meta.env.DEV; // TODO hmm
-
 // TODO validation?
 
 interface StringFromEnv {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,6 +1,16 @@
 import type {Lazy} from './lazy.js';
 import {lazy} from './lazy.js';
 
+declare global {
+	interface ImportMeta {
+		env: {
+			DEV: boolean;
+		};
+	}
+}
+
+export const dev = import.meta.env.DEV; // TODO hmm
+
 // TODO validation?
 
 interface StringFromEnv {


### PR DESCRIPTION
This needs better support or none at all, so for now, none. We'll revisit `import.meta.env.DEV` at another time, and hopefully by then we have figured out `dev` and `process.env.NODE_ENV` once and for all.

This also sets `process.env.NODE_ENV` when running tasks with explicit `dev` values. This was intended but unimplemented, so just very buggy, but technically not breaking? I'm probably wrong.