### PR TITLE
change config to export a named config identifer instead of default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.10.0
+
+- **break**: change `src/gro.config.ts` to export a `config` identifer instead of `default`
+  ([#137](https://github.com/feltcoop/gro/pull/137))
+
 ## 0.9.5
 
 - set `process.env.NODE_ENV` when running tasks with explicit `dev` values

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -61,7 +61,7 @@ export interface PartialGroConfig {
 }
 
 export interface GroConfigModule {
-	readonly default: PartialGroConfig | GroConfigCreator;
+	readonly config: PartialGroConfig | GroConfigCreator;
 }
 
 export interface GroConfigCreator {
@@ -157,7 +157,7 @@ export const loadGroConfig = async (dev: boolean): Promise<GroConfig> => {
 	if (!validated.ok) {
 		throw Error(`Invalid Gro config module at '${modulePath}': ${validated.reason}`);
 	}
-	cachedConfig = await toConfig(configModule.default, options, modulePath);
+	cachedConfig = await toConfig(configModule.config, options, modulePath);
 	return cachedConfig;
 };
 
@@ -180,8 +180,8 @@ export const toConfig = async (
 };
 
 const validateConfigModule = (configModule: any): Result<{}, {reason: string}> => {
-	if (!(typeof configModule.default === 'function' || typeof configModule.default === 'object')) {
-		throw Error(`Invalid Gro config module. Expected a default export.`);
+	if (!(typeof configModule.config === 'function' || typeof configModule.config === 'object')) {
+		throw Error(`Invalid Gro config module. Expected a 'config' export.`);
 	}
 	return {ok: true};
 };

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -15,8 +15,8 @@ import {
 // It also looks for a primary Node server entry point at `src/server/server.ts`.
 // Both are no-ops if not detected.
 
-const createConfig: GroConfigCreator = async () => {
-	const config: PartialGroConfig = {
+export const config: GroConfigCreator = async () => {
+	const partial: PartialGroConfig = {
 		builds: [
 			PRIMARY_NODE_BUILD_CONFIG,
 			hasGroServer() ? SERVER_BUILD_CONFIG : null,
@@ -24,7 +24,5 @@ const createConfig: GroConfigCreator = async () => {
 		],
 		logLevel: LogLevel.Trace,
 	};
-	return config;
+	return partial;
 };
-
-export default createConfig;

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -28,13 +28,11 @@ Here's a config for a simple Node project:
 ```ts
 import {GroConfigCreator} from '@feltcoop/gro/dist/config/config.js';
 
-const createConfig: GroConfigCreator = async () => {
+export const config: GroConfigCreator = async () => {
 	return {
 		builds: [{name: 'node', platform: 'node', input: 'index.ts'}],
 	};
 };
-
-export default createConfig;
 ```
 
 Here's what a frontend-only project with both desktop and mobile builds may look like:
@@ -43,7 +41,7 @@ Here's what a frontend-only project with both desktop and mobile builds may look
 import {GroConfigCreator} from '@feltcoop/gro/dist/config/config.js';
 import {createFilter} from '@rollup/pluginutils';
 
-const createConfig: GroConfigCreator = async () => {
+export const config: GroConfigCreator = async () => {
 	return {
 		builds: [
 			{name: 'browser_mobile', platform: 'browser', input: 'index.ts', dist: true},
@@ -52,8 +50,6 @@ const createConfig: GroConfigCreator = async () => {
 		],
 	};
 };
-
-export default createConfig;
 ```
 
 Here's [Gro's own internal config](/src/gro.config.ts) and

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -8,7 +8,7 @@ import {LogLevel} from './utils/log.js';
 // This is the config for the Gro project itself.
 // The default config for dependent projects is located at `./config/gro.config.default.ts`.
 
-const createConfig: GroConfigCreator = async () => {
+export const config: GroConfigCreator = async () => {
 	const ASSET_PATHS = ['html', 'css', 'json', 'ico', 'png', 'jpg', 'webp', 'webm', 'mp3'];
 	const BROWSER_BUILD_CONFIG_NAME = 'browser';
 	const config: PartialGroConfig = {
@@ -45,5 +45,3 @@ const createConfig: GroConfigCreator = async () => {
 	};
 	return config;
 };
-
-export default createConfig;


### PR DESCRIPTION
This changes `src/gro.config.ts` to export a `config` identifer instead of a `default` export.

It's breaking. Yay, 0.10.0! We've broken through!