### PR TITLE
add optional filer filter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Gro changelog
 
+## 0.10.1
+
+- add the `Filer` option `filter` with type `PathFilter`
+  and ignore directories like `.git` by default
+  ([#138](https://github.com/feltcoop/gro/pull/138))
+
 ## 0.10.0
 
 - **break**: change `src/gro.config.ts` to export a `config` identifer instead of `default`

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -47,7 +47,7 @@ import {queueExternalsBuild} from './externalsBuilder.js';
 import type {SourceMeta} from './sourceMeta.js';
 import {deleteSourceMeta, updateSourceMeta, cleanSourceMeta, initSourceMeta} from './sourceMeta.js';
 import type {OmitStrict, Assignable} from '../index.js';
-import {PathFilter} from '../fs/pathData.js';
+import type {PathFilter} from '../fs/pathData.js';
 
 /*
 

--- a/src/build/FilerDir.ts
+++ b/src/build/FilerDir.ts
@@ -33,16 +33,16 @@ export const createFilerDir = (
 	dir: string,
 	buildable: boolean,
 	onChange: FilerDirChangeCallback,
+	filter: PathFilter | undefined,
 	watch: boolean,
 	watcherDebounce: number = DEBOUNCE_DEFAULT,
-	filter?: PathFilter,
 ): FilerDir => {
 	const watcher = watchNodeFs({
 		dir,
 		onChange: (change) => onChange(change, filerDir),
+		filter,
 		watch,
 		debounce: watcherDebounce,
-		filter,
 	});
 	const close = () => {
 		watcher.close();

--- a/src/build/FilerDir.ts
+++ b/src/build/FilerDir.ts
@@ -1,7 +1,7 @@
 import {ensureDir} from '../fs/nodeFs.js';
 import {DEBOUNCE_DEFAULT, watchNodeFs} from '../fs/watchNodeFs.js';
 import type {WatchNodeFs} from '../fs/watchNodeFs.js';
-import type {PathStats} from '../fs/pathData.js';
+import type {PathFilter, PathStats} from '../fs/pathData.js';
 
 // Buildable filer dirs are watched, built, and written to disk.
 // For non-buildable dirs, the `dir` is only watched and nothing is written to the filesystem.
@@ -35,12 +35,14 @@ export const createFilerDir = (
 	onChange: FilerDirChangeCallback,
 	watch: boolean,
 	watcherDebounce: number = DEBOUNCE_DEFAULT,
+	filter?: PathFilter,
 ): FilerDir => {
 	const watcher = watchNodeFs({
 		dir,
 		onChange: (change) => onChange(change, filerDir),
-		debounce: watcherDebounce,
 		watch,
+		debounce: watcherDebounce,
+		filter,
 	});
 	const close = () => {
 		watcher.close();

--- a/src/fs/watchNodeFs.ts
+++ b/src/fs/watchNodeFs.ts
@@ -36,16 +36,16 @@ const defaultFilter: PathFilter = (file) => !ignoredPaths.has(file.path);
 export interface Options {
 	dir: string;
 	onChange: WatcherChangeCallback;
+	filter: PathFilter | null;
 	watch: boolean;
 	debounce: number;
-	filter: PathFilter | null;
 }
 export type RequiredOptions = 'dir' | 'onChange';
 export type InitialOptions = PartialExcept<Options, RequiredOptions>;
 export const initOptions = (opts: InitialOptions): Options => ({
+	filter: defaultFilter,
 	watch: true,
 	debounce: DEBOUNCE_DEFAULT,
-	filter: defaultFilter,
 	...omitUndefined(opts),
 });
 


### PR DESCRIPTION
This adds the `Filer` option `filter` with type `PathFilter`. The idea is that we want to ignore certain things by default, like `node_modules` when running `gro serve`, so now that happens, without changing other external behavior.