### PR TITLE
add version task confirmation prompt

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Gro changelog
 
+## 0.11.1
+
+- add a confirmation prompt to `gro version`
+  with version validations between `changelog.md` and `package.json`
+  ([#140](https://github.com/feltcoop/gro/pull/140))
+
 ## 0.11.0
 
 - **break**: update dependencies

--- a/src/client/GroDevtools.ts
+++ b/src/client/GroDevtools.ts
@@ -7,6 +7,7 @@ export class GroDevtools {
 		this.head = document.getElementsByTagName('head')[0];
 	}
 
+	// TODO redesign this completely, this was just the first hack that came to mind
 	registerCss(path: string) {
 		if (this.styleElementsByPath.has(path)) {
 			// TODO should this do reference counting and remove unused CSS?

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,7 +9,8 @@ import {createSecureServer as createHttp2Server, Http2Server, ServerHttp2Stream}
 import type {ListenOptions} from 'net';
 
 import {cyan, yellow, gray, red, rainbow, green} from '../utils/terminal.js';
-import {Logger, SystemLogger} from '../utils/log.js';
+import {SystemLogger} from '../utils/log.js';
+import type {Logger} from '../utils/log.js';
 import {stripAfter} from '../utils/string.js';
 import {omitUndefined} from '../utils/object.js';
 import type {Filer} from '../build/Filer.js';

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -81,6 +81,7 @@ export const task: Task = {
 	},
 };
 
+// TODO document this better
 // TODO move where?
 // TODO refactor? this code is quick & worky
 const changelogMatcher = /##(.+)/;

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -8,7 +8,7 @@ import {readFile} from './fs/nodeFs.js';
 import {loadPackageJson} from './project/packageJson.js';
 import type {Logger} from './utils/log.js';
 
-const rl = createReadlineInterface({input: process.stdin, output: process.stdout});
+const readline = createReadlineInterface({input: process.stdin, output: process.stdout});
 
 // version.task.ts
 // - usage: `gro version patch`
@@ -74,14 +74,14 @@ const confirmWithUser = async (versionIncrement: string, log: Logger): Promise<v
 		if (latestChangelogVersion === currentPackageVersion) {
 			throw Error('Changelog version matches package version. Is the changelog updated?');
 		}
-		rl.question(bgBlack('does this look correct? y/n') + ' ', (answer) => {
+		readline.question(bgBlack('does this look correct? y/n') + ' ', (answer) => {
 			const lowercasedAnswer = answer.toLowerCase();
 			if (!(lowercasedAnswer === 'y' || lowercasedAnswer === 'yes')) {
 				log.info(green('exiting task with no changes'));
 				process.exit();
 			}
 			log.info(rainbow('proceeding'));
-			rl.close();
+			readline.close();
 			resolve(null);
 		});
 	});

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -38,6 +38,7 @@ export const task: Task = {
 		validateVersionIncrement(versionIncrement);
 		log.info(green(versionIncrement), '← new version');
 
+		// Confirm with the user that we're doing what they expect.
 		await new Promise(async (resolve) => {
 			const [latestChangelogVersion, currentPackageVersion] = await Promise.all([
 				getLatestChangelogHeading(),

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -36,15 +36,15 @@ export const task: Task = {
 	run: async ({args, log, invokeTask}): Promise<void> => {
 		const versionIncrement = args._[0];
 		validateVersionIncrement(versionIncrement);
-		log.info('new version:', green(versionIncrement));
+		log.info(green(versionIncrement), '← new version');
 
 		await new Promise(async (resolve) => {
 			const [latestChangelogVersion, currentPackageVersion] = await Promise.all([
 				getLatestChangelogHeading(),
 				getCurrentPackageVersion(),
 			]);
-			log.info('latest changelog version:', green(latestChangelogVersion));
-			log.info('current package version:', green(currentPackageVersion));
+			log.info(green(latestChangelogVersion), '← latest changelog version');
+			log.info(green(currentPackageVersion), '← current package version');
 			if (latestChangelogVersion === currentPackageVersion) {
 				throw Error('Changelog version matches package version. Is the changelog updated?');
 			}

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -37,10 +37,9 @@ export const task: Task = {
 	run: async ({args, log, invokeTask}): Promise<void> => {
 		const versionIncrement = args._[0];
 		validateVersionIncrement(versionIncrement);
-		log.info(green(versionIncrement), '← new version');
 
 		// Confirm with the user that we're doing what they expect.
-		await confirmWithUser(log);
+		await confirmWithUser(versionIncrement, log);
 
 		// Make sure we're on the main branch:
 		await spawnProcess('git', ['checkout', 'main']); // TODO allow configuring `'main'`
@@ -63,7 +62,8 @@ export const task: Task = {
 	},
 };
 
-const confirmWithUser = async (log: Logger): Promise<void> => {
+const confirmWithUser = async (versionIncrement: string, log: Logger): Promise<void> => {
+	log.info(green(versionIncrement), '← new version');
 	await new Promise(async (resolve) => {
 		const [latestChangelogVersion, currentPackageVersion] = await Promise.all([
 			getLatestChangelogHeading(),


### PR DESCRIPTION
This adds a confirmation prompt to the `gro version` task.

![gro-version-prompt](https://user-images.githubusercontent.com/2608646/113487731-8c887a80-946e-11eb-913f-cfa13725e16f.png)

### constraints

- expects a consistent subheading style in `/changelog.md`, e.g. `"## 0.1.9"` at the top should be the target of the version bump
- expects a valid version key in `package.json` (`npm init` and other tools add this key by default)
- expects the changelog version to be different than the package version

### possible improvements 

- add flags to override checks (problem is it currently forwards all args to `npm version`: "force" conflicts for example)
- check that the version increment matches the different between the changelog and package, when it's one of the normally computable kinds (the tiny library [lukeed/semiver](https://github.com/lukeed/semiver) could check that it's larger at least)