### PR TITLE
filter build configs for the dist

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Gro changelog
 
+## 0.11.3
+
+- `gro build` now correctly builds only `BuildConfig`s that have `dist: true`,
+  allowing users to customize the `dist/` output in each `gro build`
+  ([#143](https://github.com/feltcoop/gro/pull/143))
+
 ## 0.11.2
 
 - add a generic parameter to `Task` to type its `TaskArgs`

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.11.3
 
 - `gro build` now correctly builds only `BuildConfig`s that have `dist: true`,
-  allowing users to customize the `dist/` output in each `gro build`
+  allowing users to customize the `dist/` output in each `gro build` via `src/gro.config.ts`
   ([#143](https://github.com/feltcoop/gro/pull/143))
 
 ## 0.11.2

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 - `gro build` now correctly builds only `BuildConfig`s that have `dist: true`,
   allowing users to customize the `dist/` output in each `gro build` via `src/gro.config.ts`
-  ([#143](https://github.com/feltcoop/gro/pull/143))
+  ([#144](https://github.com/feltcoop/gro/pull/144))
 
 ## 0.11.2
 

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -46,12 +46,18 @@ export const task: Task<TaskArgs> = {
 
 		const esbuildOptions = getDefaultEsbuildOptions(config.target, config.sourcemap, dev);
 
-		// For each build config, infer which of the inputs
-		// are actual source files, and therefore belong in the default Rollup build.
+		// Not every build config is built for the final `dist/`!
+		// Only those that currently have `dist: true` are output.
+		// This allows a project's `src/gro.config.ts`
+		// to control the "last mile" each time `gro build` is run.
+		const buildConfigsToBuild = config.builds.filter((buildConfig) => buildConfig.dist);
+		// For each build config that has `dist: true`,
+		// infer which of the inputs are actual source files,
+		// and therefore belong in the default Rollup build.
 		// If more customization is needed, users should implement their own `src/build.task.ts`,
 		// which can be bootstrapped by copy/pasting this one. (and updating the imports)
 		await Promise.all(
-			config.builds.map(async (buildConfig) => {
+			buildConfigsToBuild.map(async (buildConfig) => {
 				const inputFiles = await resolveInputFiles(buildConfig);
 				log.info(`building "${buildConfig.name}"`, inputFiles);
 				if (inputFiles.length) {


### PR DESCRIPTION
This fixes `gro build` to operate on only those build configs that have `dist true`. This allows a project's `src/gro.config.ts` to control the "last mile" each time `gro build` is run.

This was the documented behavior (see the config docs) but it wasn't properly implemented, so I'm considering it a patch fix.