### PR TITLE
add server task and build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ It includes:
 - filesystem-abstracting build system that considers any wasted work a bug,
   unless it's a deliberate tradeoff
 - testing with [uvu](https://github.com/lukeed/uvu)
-- formatting with [Prettier](https://github.com/prettier/prettier)
-  (it's not always pretty, but it's formatted)
+- formatting with [Prettier](https://github.com/prettier/prettier);
+  it's not always pretty, but it's always formatted
 - utilities to fill in the gaps for Node and the browser
 - more to come, exploring what deeply integrated tools enable
   for developer power, ergonomics, and productivity

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Gro changelog
 
+## 0.11.4
+
+- integrate the default Gro API server with SvelteKit
+  ([#145](https://github.com/feltcoop/gro/pull/145))
+- add task `gro server` to support the default API server use case in SvelteKit
+  ([#145](https://github.com/feltcoop/gro/pull/145))
+
 ## 0.11.3
 
 - add `events` to `TaskContext` and its generic type to `Task`,

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.11.4
 
-- integrate the default Gro API server with SvelteKit
+- integrate the default Gro API server with SvelteKit and Gro's build task
   ([#145](https://github.com/feltcoop/gro/pull/145))
 - add task `gro server` to support the default API server use case in SvelteKit
   ([#145](https://github.com/feltcoop/gro/pull/145))

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -18,7 +18,7 @@ export interface TaskArgs {
 	mapInputOptions?: MapInputOptions;
 	mapOutputOptions?: MapOutputOptions;
 	mapWatchOptions?: MapWatchOptions;
-	closeApiServer?: (spawned: SpawnedProcess) => Promise<void>;
+	closeApiServer?: (spawned: SpawnedProcess) => Promise<void>; // let other tasks hang onto the api server
 }
 
 export interface TaskEvents extends ServerTaskEvents {

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -68,8 +68,6 @@ export const task: Task<TaskArgs, TaskEvents> = {
 				events.once('server.spawn', (spawned) => {
 					spawnedApiServer = spawned;
 				});
-				// TODO still broken
-				// await invokeTask('server', undefined, undefined, true);
 				await invokeTask('server');
 			}
 		}

--- a/src/clean.task.ts
+++ b/src/clean.task.ts
@@ -9,8 +9,7 @@ export interface TaskArgs {
 }
 
 export const task: Task<TaskArgs> = {
-	description:
-		'remove files: build/ (unless -B), dist/ (unless -D), and optionally .svelte/ (-s) and node_modules/ (-n)',
+	description: 'remove temporary dev and build files',
 	run: async ({log, args}): Promise<void> => {
 		// TODO document with mdsvex
 		await clean(

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -31,6 +31,9 @@ export const SERVER_BUILD_CONFIG: BuildConfig = {
 	dist: true,
 	input: [SERVER_SOURCE_BASE_PATH],
 };
+// the first of these matches SvelteKit, the second is just close for convenience
+export const SERVER_DEFAULT_PORT_DEV = 3000;
+export const SERVER_DEFAULT_PORT_PROD = 3001;
 
 export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
 	const [hasIndexHtml, hasIndexTs] = await Promise.all([

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -9,7 +9,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 - [build](../build.task.ts) - build the project
 - [cert](../cert.task.ts) - creates a self-signed cert for https with openssl
 - [check](../check.task.ts) - check that everything is ready to commit
-- [clean](../clean.task.ts) - remove files: build/ (unless -B), dist/ (unless -D), and optionally .svelte/ (-s) and node_modules/ (-n)
+- [clean](../clean.task.ts) - remove temporary dev and build files
 - [deploy](../deploy.task.ts) - deploy to gh-pages
 - [dev](../dev.task.ts) - start dev server
 - [dist](../dist.task.ts) - create the distribution
@@ -20,6 +20,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 - [project/echo](../project/echo.task.ts) - diagnostic task that logs CLI args
 - [project/link](../project/link.task.ts) - link the distribution
 - [serve](../serve.task.ts) - start static file server
+- [server](../server.task.ts) - start API server
 - [test](../test.task.ts) - run tests
 - [typecheck](../typecheck.task.ts) - typecheck the project without emitting any files
 - [version](../version.task.ts) - bump version, publish to npm, and sync to GitHub

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -31,6 +31,7 @@ export const DIST_DIR = `${DIST_DIR_NAME}/`;
 export const NODE_MODULES_PATH = 'node_modules';
 export const SVELTE_KIT_DEV_PATH = '.svelte';
 export const SVELTE_KIT_BUILD_PATH = 'build';
+export const SVELTE_KIT_DIST_PATH = 'sveltekit'; // dist/sveltekit/<your_svelte_build>
 
 export const CONFIG_SOURCE_BASE_PATH = 'gro.config.ts';
 export const CONFIG_BUILD_BASE_PATH = 'gro.config.js';

--- a/src/project/build.ts
+++ b/src/project/build.ts
@@ -9,7 +9,6 @@ import {
 } from 'rollup';
 import resolvePlugin from '@rollup/plugin-node-resolve';
 import commonjsPlugin from '@rollup/plugin-commonjs';
-import {resolve} from 'path';
 import * as sveltePreprocessEsbuild from 'svelte-preprocess-esbuild';
 
 import {magenta} from '../utils/terminal.js';
@@ -33,6 +32,7 @@ import {
 	getDefaultEsbuildPreprocessOptions,
 } from '../build/esbuildBuildHelpers.js';
 import type {PartialExcept} from '../index.js';
+import {paths} from '../paths.js';
 
 export interface Options {
 	inputFiles: string[];
@@ -51,8 +51,8 @@ export type InitialOptions = PartialExcept<Options, RequiredOptions>;
 export const initOptions = (opts: InitialOptions): Options => ({
 	dev: true,
 	sourcemap: opts.dev ?? true,
-	outputDir: resolve('dist/'),
-	watch: true,
+	outputDir: paths.dist,
+	watch: false,
 	mapInputOptions: identity,
 	mapOutputOptions: identity,
 	mapWatchOptions: identity,

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -8,7 +8,7 @@ import {numberFromEnv, stringFromEnv} from './utils/env.js';
 export interface TaskArgs {
 	_: string[];
 	host?: string;
-	port?: string;
+	port?: string | number;
 	nocert?: boolean;
 	certfile?: string;
 	certkeyfile?: string;

--- a/src/server.task.ts
+++ b/src/server.task.ts
@@ -1,0 +1,50 @@
+import type {Task} from './task/task.js';
+import {toBuildOutPath, SERVER_BUILD_BASE_PATH} from './paths.js';
+import {SERVER_BUILD_CONFIG_NAME} from './config/defaultBuildConfig.js';
+import {spawn} from './utils/process.js';
+import type {SpawnedProcess} from './utils/process.js';
+import {pathExists} from './fs/nodeFs.js';
+import {red} from './utils/terminal.js';
+
+/*
+
+Normally, you won't use this directly, but it's here
+if you need it, and for educational purposes.
+It's invoked by `src/dev.task.ts` and `src/build.task.ts`
+as a default to support compatibility with SvelteKit.
+
+If you see an error message with 3001 missing or something,
+try running `gro server` to run this task file!
+But it should be handled by the other tasks.
+
+## usage
+
+```bash
+gro server
+```
+
+TODO configure port
+
+*/
+
+// export interface TaskArgs {
+//   port?: string | number;
+// }
+
+export interface TaskEvents {
+	'server.spawn': (spawned: SpawnedProcess) => void;
+}
+
+// TODO what's the best way to give a placeholder for the unused first `TArgs` type argument?
+export const task: Task<{}, TaskEvents> = {
+	description: 'start API server',
+	run: async ({dev, events, log}) => {
+		const serverPath = toBuildOutPath(dev, SERVER_BUILD_CONFIG_NAME, SERVER_BUILD_BASE_PATH);
+		if (!(await pathExists(serverPath))) {
+			log.error(red('server path does not exist:'), serverPath);
+			throw Error(`API server failed to start due to missing file: ${serverPath}`);
+		}
+		const spawned = spawn('node', [serverPath]);
+		events.emit('server.spawn', spawned);
+	},
+};

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,6 +1,8 @@
 import {red, yellow, gray, black, bgYellow, bgRed} from '../utils/terminal.js';
 import {EMPTY_ARRAY} from './array.js';
 
+// TODO could use some refactoring
+
 // TODO track warnings/errors (or anything above a certain threshold)
 // and report at the end of each build (and other tasks)
 

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -63,7 +63,7 @@ export const task: Task = {
 const confirmWithUser = async (versionIncrement: string, log: Logger): Promise<void> => {
 	const readline = createReadlineInterface({input: process.stdin, output: process.stdout});
 	log.info(green(versionIncrement), '← new version');
-	await new Promise(async (resolve) => {
+	await new Promise<void>(async (resolve) => {
 		const [latestChangelogVersion, currentPackageVersion] = await Promise.all([
 			getLatestChangelogHeading(),
 			getCurrentPackageVersion(),
@@ -81,7 +81,7 @@ const confirmWithUser = async (versionIncrement: string, log: Logger): Promise<v
 			}
 			log.info(rainbow('proceeding'));
 			readline.close();
-			resolve(null);
+			resolve();
 		});
 	});
 };


### PR DESCRIPTION
This upstreams the `gro server` task first experimented with [here](https://github.com/ryanatkn/gro-template-sveltekit-polka) to combine SvelteKit and Gro projects. It's just a default and convention for projects that use the standard Gro/SvelteKit API server pattern, and may need to be redesigned to fit nicely.

One thing that still needs to be done is documentation of this emerging Gro API server convention. It's a convenient default to have for SvelteKit, easy to detect. False positives, like with Gro's own server, may be something to fix, or at least configure away properly.