### PR TITLE
add start task and refactor api server names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Gro changelog
 
+## 0.12.0
+
+- add `gro start` as an alias for `npm start`
+  ([#147](https://github.com/feltcoop/gro/pull/147))
+- **break**: rename some things around the API server
+  ([#147](https://github.com/feltcoop/gro/pull/147))
+
 ## 0.11.4
 
 - integrate the default Gro API server with SvelteKit and Gro's build task

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -13,6 +13,7 @@ import {buildSourceDirectory} from './build/buildSourceDirectory.js';
 import type {SpawnedProcess} from './utils/process.js';
 import type {TaskEvents as ServerTaskEvents} from './server.task.js';
 import {hasApiServerConfig} from './config/defaultBuildConfig.js';
+import {printTiming} from './utils/print.js';
 
 export interface TaskArgs {
 	mapInputOptions?: MapInputOptions;
@@ -86,13 +87,16 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		await Promise.all(
 			buildConfigsToBuild.map(async (buildConfig) => {
 				const inputFiles = await resolveInputFiles(buildConfig);
+				// TODO ok wait, does `outputDir` need to be at the output dir path?
+				const outputDir = paths.dist;
+				// const outputDir = paths.dist;
 				log.info(`building "${buildConfig.name}"`, inputFiles);
 				if (inputFiles.length) {
 					const build = createBuild({
 						dev,
 						sourcemap: config.sourcemap,
 						inputFiles,
-						outputDir: paths.dist,
+						outputDir,
 						mapInputOptions,
 						mapOutputOptions,
 						mapWatchOptions,
@@ -114,6 +118,10 @@ export const task: Task<TaskArgs, TaskEvents> = {
 				spawnedApiServer!.child.kill();
 				await spawnedApiServer!.closed;
 			}
+		}
+
+		for (const [key, timing] of timings.getAll()) {
+			log.trace(printTiming(key, timing));
 		}
 	},
 };

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -12,7 +12,7 @@ import type {BuildConfig} from './config/buildConfig.js';
 import {buildSourceDirectory} from './build/buildSourceDirectory.js';
 import type {SpawnedProcess} from './utils/process.js';
 import type {TaskEvents as ServerTaskEvents} from './server.task.js';
-import {hasGroServerConfig} from './config/defaultBuildConfig.js';
+import {hasApiServerConfig} from './config/defaultBuildConfig.js';
 
 export interface TaskArgs {
 	mapInputOptions?: MapInputOptions;
@@ -64,7 +64,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 			events.emit('build.prebuild');
 
 			// now that the prebuild is ready, we can start the API server, if it exists
-			if (hasGroServerConfig(config.builds)) {
+			if (hasApiServerConfig(config.builds)) {
 				events.once('server.spawn', (spawned) => {
 					spawnedApiServer = spawned;
 				});

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -2,7 +2,7 @@ import type {Task} from './task/task.js';
 import {createBuild} from './project/build.js';
 import type {MapInputOptions, MapOutputOptions, MapWatchOptions} from './project/build.js';
 import {getDefaultEsbuildOptions} from './build/esbuildBuildHelpers.js';
-import {isThisProjectGro, paths} from './paths.js';
+import {DIST_DIR, isThisProjectGro, sourceIdToBasePath, toBuildExtension} from './paths.js';
 import {Timings} from './utils/time.js';
 import {loadGroConfig} from './config/config.js';
 import type {GroConfig} from './config/config.js';
@@ -14,6 +14,7 @@ import {hasApiServerConfig} from './config/defaultBuildConfig.js';
 import {printTiming} from './utils/print.js';
 import {resolveInputFiles} from './build/utils.js';
 import {green} from './utils/terminal.js';
+import {toCommonBaseDir} from './utils/path.js';
 
 export interface TaskArgs {
 	mapInputOptions?: MapInputOptions;
@@ -88,9 +89,11 @@ export const task: Task<TaskArgs, TaskEvents> = {
 			buildConfigsToBuild.map(async (buildConfig) => {
 				const inputFiles = await resolveInputFiles(buildConfig);
 				// TODO ok wait, does `outputDir` need to be at the output dir path?
-				const outputDir = paths.dist;
+				const outputDir = `${DIST_DIR}${toBuildExtension(
+					sourceIdToBasePath(toCommonBaseDir(inputFiles)),
+				)}`;
 				// const outputDir = paths.dist;
-				log.info(`building ${green(buildConfig.name)}`, inputFiles);
+				log.info(`building ${green(buildConfig.name)}`, outputDir, inputFiles);
 				if (inputFiles.length) {
 					const build = createBuild({
 						dev,

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -1,4 +1,3 @@
-import {pathExists} from './fs/nodeFs.js';
 import type {Task} from './task/task.js';
 import {createBuild} from './project/build.js';
 import type {MapInputOptions, MapOutputOptions, MapWatchOptions} from './project/build.js';
@@ -8,12 +7,13 @@ import {Timings} from './utils/time.js';
 import {loadGroConfig} from './config/config.js';
 import type {GroConfig} from './config/config.js';
 import {configureLogLevel} from './utils/log.js';
-import type {BuildConfig} from './config/buildConfig.js';
 import {buildSourceDirectory} from './build/buildSourceDirectory.js';
 import type {SpawnedProcess} from './utils/process.js';
 import type {TaskEvents as ServerTaskEvents} from './server.task.js';
 import {hasApiServerConfig} from './config/defaultBuildConfig.js';
 import {printTiming} from './utils/print.js';
+import {resolveInputFiles} from './build/utils.js';
+import {green} from './utils/terminal.js';
 
 export interface TaskArgs {
 	mapInputOptions?: MapInputOptions;
@@ -90,7 +90,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 				// TODO ok wait, does `outputDir` need to be at the output dir path?
 				const outputDir = paths.dist;
 				// const outputDir = paths.dist;
-				log.info(`building "${buildConfig.name}"`, inputFiles);
+				log.info(`building ${green(buildConfig.name)}`, inputFiles);
 				if (inputFiles.length) {
 					const build = createBuild({
 						dev,
@@ -125,13 +125,3 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		}
 	},
 };
-
-// TODO use `resolveRawInputPaths`? consider the virtual fs - use the `Filer` probably
-const resolveInputFiles = async (buildConfig: BuildConfig): Promise<string[]> =>
-	(
-		await Promise.all(
-			buildConfig.input.map(async (input) =>
-				typeof input === 'string' && (await pathExists(input)) ? input : null!,
-			),
-		)
-	).filter(Boolean);

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -13,7 +13,7 @@ import {
 } from '../paths.js';
 import type {Build, BuildContext, BuildResult, BuildSource, BuildDependency} from './builder.js';
 import {stripStart} from '../utils/string.js';
-import {getIsExternalModule} from '../utils/module.js';
+import {toIsExternalModule} from '../utils/module.js';
 import {EXTERNALS_SOURCE_ID, isExternalBuildId} from './externalsBuildHelpers.js';
 
 // TODO this is all hacky and should be refactored
@@ -35,7 +35,7 @@ export const postprocess = (
 
 		// Map import paths to the built versions.
 		if (build.extension === JS_EXTENSION) {
-			const isExternalModule = getIsExternalModule(isBrowser);
+			const isExternalModule = toIsExternalModule(isBrowser);
 			let transformedContents = '';
 			let index = 0;
 			// TODO what should we pass as the second arg to parse? the id? nothing? `lexer.parse(code, id);`

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -1,9 +1,11 @@
 import {createHash} from 'crypto';
 import {resolve} from 'path';
 
+import type {BuildConfig} from '../config/buildConfig.js';
 import {basePathToSourceId, paths, toBuildBasePath, toSourceExtension} from '../paths.js';
 import type {BuildDependency} from './builder.js';
 import {EXTERNALS_SOURCE_ID} from './externalsBuildHelpers.js';
+import {pathExists} from '../fs/nodeFs.js';
 
 // Note that this uses md5 and therefore is not cryptographically secure.
 // It's fine for now, but some use cases may need security.
@@ -41,3 +43,13 @@ export const addJsSourcemapFooter = (code: string, sourcemapPath: string): strin
 
 export const addCssSourcemapFooter = (code: string, sourcemapPath: string): string =>
 	`${code}\n/*# sourceMappingURL=${sourcemapPath} */`;
+
+// TODO use `resolveRawInputPaths`? consider the virtual fs - use the `Filer` probably
+export const resolveInputFiles = async (buildConfig: BuildConfig): Promise<string[]> =>
+	(
+		await Promise.all(
+			buildConfig.input.map(async (input) =>
+				typeof input === 'string' && (await pathExists(input)) ? input : null!,
+			),
+		)
+	).filter(Boolean);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,7 +5,7 @@ import {
 	PartialBuildConfig,
 	validateBuildConfigs,
 } from './buildConfig.js';
-import {Logger, LogLevel, SystemLogger} from '../utils/log.js';
+import {Logger, LogLevel, SystemLogger, configureLogLevel} from '../utils/log.js';
 import {magenta} from '../utils/terminal.js';
 import {importTs} from '../fs/importTs.js';
 import {pathExists} from '../fs/nodeFs.js';
@@ -110,7 +110,10 @@ Caveats
 
 */
 
-export const loadGroConfig = async (dev: boolean): Promise<GroConfig> => {
+export const loadGroConfig = async (
+	dev: boolean,
+	applyConfigToSystem = true,
+): Promise<GroConfig> => {
 	if (cachedConfig !== undefined) return cachedConfig;
 
 	const log = new SystemLogger([magenta('[config]')]);
@@ -158,6 +161,10 @@ export const loadGroConfig = async (dev: boolean): Promise<GroConfig> => {
 		throw Error(`Invalid Gro config module at '${modulePath}': ${validated.reason}`);
 	}
 	cachedConfig = await toConfig(configModule.config, options, modulePath);
+	if (applyConfigToSystem) {
+		// other things?
+		configureLogLevel(cachedConfig.logLevel);
+	}
 	return cachedConfig;
 };
 

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -1,7 +1,7 @@
 import {createFilter} from '@rollup/pluginutils';
 
 import type {BuildConfig, PartialBuildConfig} from './buildConfig.js';
-import {SERVER_SOURCE_BASE_PATH, SERVER_SOURCE_ID} from '../paths.js';
+import {toBuildExtension, basePathToSourceId} from '../paths.js';
 import {pathExists} from '../fs/nodeFs.js';
 
 // Gro currently enforces that the primary build config
@@ -17,23 +17,27 @@ export const PRIMARY_NODE_BUILD_CONFIG: BuildConfig = {
 	input: [createFilter(['**/*.{task,test,config,gen}*.ts', '**/fixtures/**'])],
 };
 
-export const hasGroServer = (): Promise<boolean> => pathExists(SERVER_SOURCE_ID);
-export const hasGroServerConfig = (buildConfigs: BuildConfig[]): boolean =>
+export const API_SERVER_SOURCE_BASE_PATH = 'server/server.ts';
+export const API_SERVER_BUILD_BASE_PATH = toBuildExtension(API_SERVER_SOURCE_BASE_PATH); // 'server/server.js'
+export const API_SERVER_SOURCE_ID = basePathToSourceId(API_SERVER_SOURCE_BASE_PATH); // '/home/to/your/src/server/server.ts'
+export const hasApiServer = (): Promise<boolean> => pathExists(API_SERVER_SOURCE_ID);
+export const hasApiServerConfig = (buildConfigs: BuildConfig[]): boolean =>
 	buildConfigs.some(
-		(b) => b.name === SERVER_BUILD_CONFIG_NAME && b.platform === SERVER_BUILD_CONFIG_PLATFORM,
+		(b) =>
+			b.name === API_SERVER_BUILD_CONFIG_NAME && b.platform === API_SERVER_BUILD_CONFIG_PLATFORM,
 	);
-export const SERVER_BUILD_CONFIG_NAME = 'server';
-export const SERVER_BUILD_CONFIG_PLATFORM = 'node';
-export const SERVER_BUILD_CONFIG: BuildConfig = {
-	name: SERVER_BUILD_CONFIG_NAME,
-	platform: SERVER_BUILD_CONFIG_PLATFORM,
+export const API_SERVER_BUILD_CONFIG_NAME = 'server';
+export const API_SERVER_BUILD_CONFIG_PLATFORM = 'node';
+export const API_SERVER_BUILD_CONFIG: BuildConfig = {
+	name: API_SERVER_BUILD_CONFIG_NAME,
+	platform: API_SERVER_BUILD_CONFIG_PLATFORM,
 	primary: false,
 	dist: true,
-	input: [SERVER_SOURCE_BASE_PATH],
+	input: [API_SERVER_SOURCE_BASE_PATH],
 };
 // the first of these matches SvelteKit, the second is just close for convenience
-export const SERVER_DEFAULT_PORT_DEV = 3000;
-export const SERVER_DEFAULT_PORT_PROD = 3001;
+export const API_SERVER_DEFAULT_PORT_DEV = 3000;
+export const API_SERVER_DEFAULT_PORT_PROD = 3001;
 
 export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
 	const [hasIndexHtml, hasIndexTs] = await Promise.all([

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -1,7 +1,7 @@
 import {createFilter} from '@rollup/pluginutils';
 
 import type {BuildConfig, PartialBuildConfig} from './buildConfig.js';
-import {toBuildExtension, basePathToSourceId, toBuildOutPath} from '../paths.js';
+import {toBuildExtension, basePathToSourceId, toBuildOutPath, paths} from '../paths.js';
 import {pathExists} from '../fs/nodeFs.js';
 
 // Gro currently enforces that the primary build config
@@ -20,7 +20,6 @@ export const PRIMARY_NODE_BUILD_CONFIG: BuildConfig = {
 export const API_SERVER_SOURCE_BASE_PATH = 'server/server.ts';
 export const API_SERVER_BUILD_BASE_PATH = toBuildExtension(API_SERVER_SOURCE_BASE_PATH); // 'server/server.js'
 export const API_SERVER_SOURCE_ID = basePathToSourceId(API_SERVER_SOURCE_BASE_PATH); // '/home/to/your/src/server/server.ts'
-// export const API_SERVER_DIST_ROOT_PATH = `${DIST_DIR_NAME}/server.js`; // TODO calculate this, how? should we change the server build out?
 export const hasApiServer = (): Promise<boolean> => pathExists(API_SERVER_SOURCE_ID);
 export const hasApiServerConfig = (buildConfigs: BuildConfig[]): boolean =>
 	buildConfigs.some(
@@ -37,10 +36,11 @@ export const API_SERVER_BUILD_CONFIG: BuildConfig = {
 	input: [API_SERVER_SOURCE_BASE_PATH],
 };
 // the first of these matches SvelteKit, the second is just close for convenience
+// TODO change to remove the second, search upwards for an open port
 export const API_SERVER_DEFAULT_PORT_DEV = 3000;
 export const API_SERVER_DEFAULT_PORT_PROD = 3001;
-export const toApiServerBuildPath = (dev: boolean): string =>
-	toBuildOutPath(dev, API_SERVER_BUILD_CONFIG_NAME, API_SERVER_BUILD_BASE_PATH);
+export const toApiServerBuildPath = (dev: boolean, buildDir = paths.build): string =>
+	toBuildOutPath(dev, API_SERVER_BUILD_CONFIG_NAME, API_SERVER_BUILD_BASE_PATH, buildDir);
 
 export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
 	const [hasIndexHtml, hasIndexTs] = await Promise.all([

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -1,7 +1,7 @@
 import {createFilter} from '@rollup/pluginutils';
 
 import type {BuildConfig, PartialBuildConfig} from './buildConfig.js';
-import {toBuildExtension, basePathToSourceId} from '../paths.js';
+import {toBuildExtension, basePathToSourceId, toBuildOutPath, DIST_DIR_NAME} from '../paths.js';
 import {pathExists} from '../fs/nodeFs.js';
 
 // Gro currently enforces that the primary build config
@@ -20,6 +20,7 @@ export const PRIMARY_NODE_BUILD_CONFIG: BuildConfig = {
 export const API_SERVER_SOURCE_BASE_PATH = 'server/server.ts';
 export const API_SERVER_BUILD_BASE_PATH = toBuildExtension(API_SERVER_SOURCE_BASE_PATH); // 'server/server.js'
 export const API_SERVER_SOURCE_ID = basePathToSourceId(API_SERVER_SOURCE_BASE_PATH); // '/home/to/your/src/server/server.ts'
+// export const API_SERVER_DIST_ROOT_PATH = `${DIST_DIR_NAME}/server.js`; // TODO calculate this, how? should we change the server build out?
 export const hasApiServer = (): Promise<boolean> => pathExists(API_SERVER_SOURCE_ID);
 export const hasApiServerConfig = (buildConfigs: BuildConfig[]): boolean =>
 	buildConfigs.some(
@@ -38,6 +39,8 @@ export const API_SERVER_BUILD_CONFIG: BuildConfig = {
 // the first of these matches SvelteKit, the second is just close for convenience
 export const API_SERVER_DEFAULT_PORT_DEV = 3000;
 export const API_SERVER_DEFAULT_PORT_PROD = 3001;
+export const toApiServerBuildPath = (dev: boolean): string =>
+	toBuildOutPath(dev, API_SERVER_BUILD_CONFIG_NAME, API_SERVER_BUILD_BASE_PATH);
 
 export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
 	const [hasIndexHtml, hasIndexTs] = await Promise.all([

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -1,7 +1,7 @@
 import {createFilter} from '@rollup/pluginutils';
 
 import type {BuildConfig, PartialBuildConfig} from './buildConfig.js';
-import {toBuildExtension, basePathToSourceId, toBuildOutPath, DIST_DIR_NAME} from '../paths.js';
+import {toBuildExtension, basePathToSourceId, toBuildOutPath} from '../paths.js';
 import {pathExists} from '../fs/nodeFs.js';
 
 // Gro currently enforces that the primary build config

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -2,9 +2,9 @@ import type {GroConfigCreator, PartialGroConfig} from './config.js';
 import {LogLevel} from '../utils/log.js';
 import {
 	hasDeprecatedGroFrontend,
-	hasGroServer,
+	hasApiServer,
 	PRIMARY_NODE_BUILD_CONFIG,
-	SERVER_BUILD_CONFIG,
+	API_SERVER_BUILD_CONFIG,
 	toDefaultBrowserBuild,
 } from './defaultBuildConfig.js';
 
@@ -19,7 +19,7 @@ export const config: GroConfigCreator = async () => {
 	const partial: PartialGroConfig = {
 		builds: [
 			PRIMARY_NODE_BUILD_CONFIG,
-			hasGroServer() ? SERVER_BUILD_CONFIG : null,
+			hasApiServer() ? API_SERVER_BUILD_CONFIG : null,
 			(await hasDeprecatedGroFrontend()) ? toDefaultBrowserBuild() : null, // TODO configure asset paths
 		],
 		logLevel: LogLevel.Trace,

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -3,7 +3,7 @@ import {Filer} from './build/Filer.js';
 import {printTiming} from './utils/print.js';
 import {Timings} from './utils/time.js';
 import {createDefaultBuilder} from './build/defaultBuilder.js';
-import {paths, toBuildOutPath, SERVER_BUILD_BASE_PATH, isThisProjectGro} from './paths.js';
+import {paths, toBuildOutPath, isThisProjectGro} from './paths.js';
 import {createGroServer} from './server/server.js';
 import type {GroServer} from './server/server.js';
 import {GroConfig, loadGroConfig} from './config/config.js';
@@ -11,7 +11,11 @@ import {configureLogLevel} from './utils/log.js';
 import type {ServedDirPartial} from './build/ServedDir.js';
 import {loadHttpsCredentials} from './server/https.js';
 import {createRestartableProcess} from './utils/process.js';
-import {hasGroServerConfig, SERVER_BUILD_CONFIG_NAME} from './config/defaultBuildConfig.js';
+import {
+	hasApiServerConfig,
+	API_SERVER_BUILD_BASE_PATH,
+	API_SERVER_BUILD_CONFIG_NAME,
+} from './config/defaultBuildConfig.js';
 
 export interface TaskArgs {
 	nocert?: boolean;
@@ -78,22 +82,22 @@ export const task: Task<TaskArgs, TaskEvents> = {
 
 		events.emit('dev.ready', server, filer, config);
 
-		// Support the Gro server pattern by default.
+		// Support the API server pattern by default.
 		// Normal user projects will hit this code path right here:
 		// in other words, `isThisProjectGro` will always be `false` for your code.
 		// TODO task pollution, this is bad for users who want to copy/paste this task.
 		// think of a better way - maybe config+defaults?
 		// I don't want to touch Gro's prod build pipeline right now using package.json `"preversion"`
-		if (!isThisProjectGro && hasGroServerConfig(config.builds)) {
+		if (!isThisProjectGro && hasApiServerConfig(config.builds)) {
 			// When `src/server/server.ts` or any of its dependencies change, restart the API server.
 			const serverBuildPath = toBuildOutPath(
 				true,
-				SERVER_BUILD_CONFIG_NAME,
-				SERVER_BUILD_BASE_PATH,
+				API_SERVER_BUILD_CONFIG_NAME,
+				API_SERVER_BUILD_BASE_PATH,
 			);
 			const serverProcess = createRestartableProcess('node', [serverBuildPath]);
 			filer.on('build', ({buildConfig}) => {
-				if (buildConfig.name === SERVER_BUILD_CONFIG_NAME) {
+				if (buildConfig.name === API_SERVER_BUILD_CONFIG_NAME) {
 					serverProcess.restart();
 				}
 			});

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -6,8 +6,8 @@ import {createDefaultBuilder} from './build/defaultBuilder.js';
 import {paths, toBuildOutPath, isThisProjectGro} from './paths.js';
 import {createGroServer} from './server/server.js';
 import type {GroServer} from './server/server.js';
-import {GroConfig, loadGroConfig} from './config/config.js';
-import {configureLogLevel} from './utils/log.js';
+import type {GroConfig} from './config/config.js';
+import {loadGroConfig} from './config/config.js';
 import type {ServedDirPartial} from './build/ServedDir.js';
 import {loadHttpsCredentials} from './server/https.js';
 import {createRestartableProcess} from './utils/process.js';
@@ -39,7 +39,6 @@ export const task: Task<TaskArgs, TaskEvents> = {
 
 		const timingToLoadConfig = timings.start('load config');
 		const config = await loadGroConfig(dev);
-		configureLogLevel(config.logLevel);
 		timingToLoadConfig();
 		events.emit('dev.createConfig', config);
 

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -20,7 +20,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 - [project/link](../project/link.task.ts) - link the distribution
 - [serve](../serve.task.ts) - start static file server
 - [server](../server.task.ts) - start API server
-- [start](../start.task.ts) - alias for npm start that builds if needed
+- [start](../start.task.ts) - runs the dist/ builds for production
 - [test](../test.task.ts) - run tests
 - [typecheck](../typecheck.task.ts) - typecheck the project without emitting any files
 - [version](../version.task.ts) - bump version, publish to npm, and sync to GitHub

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -20,6 +20,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 - [project/link](../project/link.task.ts) - link the distribution
 - [serve](../serve.task.ts) - start static file server
 - [server](../server.task.ts) - start API server
+- [start](../start.task.ts) - alias for npm start
 - [test](../test.task.ts) - run tests
 - [typecheck](../typecheck.task.ts) - typecheck the project without emitting any files
 - [version](../version.task.ts) - bump version, publish to npm, and sync to GitHub

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -20,7 +20,7 @@ What is a task? See [`src/tasks/README.md`](../task).
 - [project/link](../project/link.task.ts) - link the distribution
 - [serve](../serve.task.ts) - start static file server
 - [server](../server.task.ts) - start API server
-- [start](../start.task.ts) - alias for npm start
+- [start](../start.task.ts) - alias for npm start that builds if needed
 - [test](../test.task.ts) - run tests
 - [typecheck](../typecheck.task.ts) - typecheck the project without emitting any files
 - [version](../version.task.ts) - bump version, publish to npm, and sync to GitHub

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -235,7 +235,3 @@ export const groDirBasename = `${basename(groDir)}/`;
 export const paths = createPaths(`${process.cwd()}/`);
 export const isThisProjectGro = groDir === paths.root;
 export const groPaths = isThisProjectGro ? paths : createPaths(groDir);
-
-export const SERVER_SOURCE_BASE_PATH = 'server/server.ts';
-export const SERVER_BUILD_BASE_PATH = toBuildExtension(SERVER_SOURCE_BASE_PATH); // 'server/server.js'
-export const SERVER_SOURCE_ID = basePathToSourceId(SERVER_SOURCE_BASE_PATH); // '/home/to/your/src/server/server.ts'

--- a/src/project/packageJson.ts
+++ b/src/project/packageJson.ts
@@ -17,6 +17,7 @@ export type PackageJson = Obj<Json>; // TODO generate one day
 export type GroPackageJson = Obj<Json>; // TODO generate one day
 
 let packageJson: PackageJson | undefined;
+let groPackageJson: GroPackageJson | undefined;
 
 export const loadPackageJson = async (forceRefresh = false): Promise<PackageJson> => {
 	if (isThisProjectGro) return loadGroPackageJson(forceRefresh);
@@ -25,9 +26,6 @@ export const loadPackageJson = async (forceRefresh = false): Promise<PackageJson
 	}
 	return packageJson!;
 };
-
-let groPackageJson: GroPackageJson | undefined;
-
 export const loadGroPackageJson = async (forceRefresh = false): Promise<GroPackageJson> => {
 	if (!groPackageJson || forceRefresh) {
 		groPackageJson = await readJson(join(groPaths.root, 'package.json'));

--- a/src/server.task.ts
+++ b/src/server.task.ts
@@ -1,6 +1,9 @@
 import type {Task} from './task/task.js';
-import {toBuildOutPath, SERVER_BUILD_BASE_PATH} from './paths.js';
-import {SERVER_BUILD_CONFIG_NAME} from './config/defaultBuildConfig.js';
+import {toBuildOutPath} from './paths.js';
+import {
+	API_SERVER_BUILD_BASE_PATH,
+	API_SERVER_BUILD_CONFIG_NAME,
+} from './config/defaultBuildConfig.js';
 import {spawn} from './utils/process.js';
 import type {SpawnedProcess} from './utils/process.js';
 import {pathExists} from './fs/nodeFs.js';
@@ -39,7 +42,11 @@ export interface TaskEvents {
 export const task: Task<{}, TaskEvents> = {
 	description: 'start API server',
 	run: async ({dev, events, log}) => {
-		const serverPath = toBuildOutPath(dev, SERVER_BUILD_CONFIG_NAME, SERVER_BUILD_BASE_PATH);
+		const serverPath = toBuildOutPath(
+			dev,
+			API_SERVER_BUILD_CONFIG_NAME,
+			API_SERVER_BUILD_BASE_PATH,
+		);
 		if (!(await pathExists(serverPath))) {
 			log.error(red('server path does not exist:'), serverPath);
 			throw Error(`API server failed to start due to missing file: ${serverPath}`);

--- a/src/server.task.ts
+++ b/src/server.task.ts
@@ -43,6 +43,9 @@ export const task: Task<{}, TaskEvents> = {
 			log.error(red('server path does not exist:'), serverPath);
 			throw Error(`API server failed to start due to missing file: ${serverPath}`);
 		}
+		// TODO what if we wrote out the port and
+		// also, retried if it conflicted ports, have some affordance here to increment and write to disk
+		// on disk, we can check for that file in `svelte.config.cjs`
 		const spawned = spawn('node', [serverPath]);
 		events.emit('server.spawn', spawned);
 	},

--- a/src/server.task.ts
+++ b/src/server.task.ts
@@ -1,9 +1,5 @@
 import type {Task} from './task/task.js';
-import {toBuildOutPath} from './paths.js';
-import {
-	API_SERVER_BUILD_BASE_PATH,
-	API_SERVER_BUILD_CONFIG_NAME,
-} from './config/defaultBuildConfig.js';
+import {toApiServerBuildPath} from './config/defaultBuildConfig.js';
 import {spawn} from './utils/process.js';
 import type {SpawnedProcess} from './utils/process.js';
 import {pathExists} from './fs/nodeFs.js';
@@ -42,11 +38,7 @@ export interface TaskEvents {
 export const task: Task<{}, TaskEvents> = {
 	description: 'start API server',
 	run: async ({dev, events, log}) => {
-		const serverPath = toBuildOutPath(
-			dev,
-			API_SERVER_BUILD_CONFIG_NAME,
-			API_SERVER_BUILD_BASE_PATH,
-		);
+		const serverPath = toApiServerBuildPath(dev);
 		if (!(await pathExists(serverPath))) {
 			log.error(red('server path does not exist:'), serverPath);
 			throw Error(`API server failed to start due to missing file: ${serverPath}`);

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -1,18 +1,60 @@
 import type {Task} from './task/task.js';
 import {pathExists} from './fs/nodeFs.js';
-import {DIST_DIR} from './paths.js';
-import {spawnProcess} from './utils/process.js';
+import {Timings} from './utils/time.js';
+import {paths, sourceIdToBasePath, toBuildExtension} from './paths.js';
+import type {GroConfig} from './config/config.js';
+import {loadGroConfig} from './config/config.js';
+import {spawn} from './utils/process.js';
+import type {SpawnedProcess} from './utils/process.js';
+import {green} from './utils/terminal.js';
+import type {BuildConfig} from './config/buildConfig.js';
+import {printTiming} from './utils/print.js';
 
-export const task: Task = {
-	description: 'alias for npm start that builds if needed',
+export interface TaskEvents {
+	'start.spawned': (spawneds: SpawnedProcess[], config: GroConfig) => void;
+}
+
+export const task: Task<{}, TaskEvents> = {
+	description: 'runs the dist/ builds for production',
 	dev: false,
-	run: async ({invokeTask}) => {
-		if (!(await pathExists(DIST_DIR))) {
+	run: async ({log, invokeTask, dev, events}) => {
+		const timings = new Timings();
+		if (!(await pathExists(paths.dist))) {
+			log.info(green('dist not detected; building'));
+			const timingToBuild = timings.start('build');
 			await invokeTask('build');
+			timingToBuild();
 		}
-		// TODO should we try to start the server, or whatever the best guess is?
-		// or actually defer to npm like this, which is hardcoded but more Node-friendly?
-		// maybe put passthrough behind a flag?
-		await spawnProcess('npm', ['start', ...process.argv.slice(3)]);
+		const timingToLoadConfig = timings.start('load config');
+		const config = await loadGroConfig(dev);
+		timingToLoadConfig();
+		const spawneds: SpawnedProcess[] = config.builds
+			.map((buildConfig) => {
+				if (!buildConfig.dist) return null!;
+				const path = toEntryPath(buildConfig);
+				console.log('entry path', path);
+				if (!path) {
+					// TODO is this an error? warning? hmm?
+					log.error('unable to find path for build config', buildConfig);
+					return null!;
+				}
+				return spawn('node', [path]);
+			})
+			.filter(Boolean);
+		events.emit('start.spawned', spawneds, config);
+
+		for (const [key, timing] of timings.getAll()) {
+			log.trace(printTiming(key, timing));
+		}
 	},
+};
+
+const toEntryPath = (buildConfig: BuildConfig): string | null => {
+	// TODO this just looks for the first one - need better control, *if* this pattern is stabilized
+	const sourceId = buildConfig.input.find((input) => typeof input === 'string') as
+		| string
+		| undefined;
+	if (!sourceId) return null;
+	console.log('sourceId', sourceId);
+	return `${paths.dist}${toBuildExtension(sourceIdToBasePath(sourceId))}`;
 };

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -1,9 +1,17 @@
 import type {Task} from './task/task.js';
+import {pathExists} from './fs/nodeFs.js';
+import {DIST_DIR} from './paths.js';
 import {spawnProcess} from './utils/process.js';
 
 export const task: Task = {
-	description: 'alias for npm start',
-	run: async () => {
+	description: 'alias for npm start that builds if needed',
+	run: async ({invokeTask}) => {
+		if (!(await pathExists(DIST_DIR))) {
+			await invokeTask('build');
+		}
+		// TODO should we try to start the server, or whatever the best guess is?
+		// or actually defer to npm like this, which is hardcoded but more Node-friendly?
+		// maybe put passthrough behind a flag?
 		await spawnProcess('npm', ['start', ...process.argv.slice(3)]);
 	},
 };

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -5,6 +5,7 @@ import {spawnProcess} from './utils/process.js';
 
 export const task: Task = {
 	description: 'alias for npm start that builds if needed',
+	dev: false,
 	run: async ({invokeTask}) => {
 		if (!(await pathExists(DIST_DIR))) {
 			await invokeTask('build');

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -1,0 +1,9 @@
+import type {Task} from './task/task.js';
+import {spawnProcess} from './utils/process.js';
+
+export const task: Task = {
+	description: 'alias for npm start',
+	run: async () => {
+		await spawnProcess('npm', ['start', ...process.argv.slice(3)]);
+	},
+};

--- a/src/utils/module.ts
+++ b/src/utils/module.ts
@@ -1,5 +1,5 @@
 // convenience helper
-export const getIsExternalModule = (isBrowser: boolean): IsExternalModule =>
+export const toIsExternalModule = (isBrowser: boolean): IsExternalModule =>
 	isBrowser ? isExternalBrowserModule : isExternalNodeModule;
 
 interface IsExternalModule {

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,7 +1,13 @@
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
 
-import {replaceExtension, toPathStem, toPathParts, toPathSegments} from './path.js';
+import {
+	replaceExtension,
+	toPathStem,
+	toPathParts,
+	toPathSegments,
+	toCommonBaseDir,
+} from './path.js';
 
 /* test_replaceExtension */
 const test_replaceExtension = suite('replaceExtension');
@@ -77,3 +83,13 @@ test_toPathParts('trailing slash', () => {
 
 test_toPathParts.run();
 /* /test_toPathParts */
+
+/* test_toCommonBaseDir */
+const test_toCommonBaseDir = suite('toCommonBaseDir');
+
+test_toCommonBaseDir('basic behavior', () => {
+	t.is(toCommonBaseDir(['a/b/c.ts', 'a/b/c/d.ts', 'a/b/c/e.ts', 'a/b/c/e/f']), 'a/b');
+});
+
+test_toCommonBaseDir.run();
+/* /test_toCommonBaseDir */


### PR DESCRIPTION
This adds the `gro start` task. If you know Gro you know that means there's now a `src/start.task.ts` file, assuming you didn't forget, which happens to everyone, even the best of robots. For now, `gro start` just tries to build if needed, and otherwise, it spawns an `npm start` with your args. I may change this before merging; I'm thinking of making it check for a series of paths to start (paths like the API server, the Node SvelteKit adapter, or really, paths derived from the config, and *not* being lazy with hardcoded defaults), then if none is found, bail with an error, never deferring to `npm start`, so users don't get used to that.

This PR also refactors some things around the API server. Previously we called it the "Gro server", now it's the "API server". I don't like the port handling but I'm not sure the best way to handle that with the Vite proxy being configured in `svelte.config.cjs`. What if we had the config attempt to query for the port? What if Gro wrote to a file, to keep things fast and off the network?

Anyway, the API server stuff is technically breaking since we're exposing so much API. That's uh, maybe unsustainable for user experience reasons.

We have another breaking change: the way builds are handled in `dist/`. It now tries to mirror the source tree as much as possible.