### PR TITLE
update node engine to >=14.16.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,9 @@
 # Gro changelog
 
-## 0.12.2
+## 0.13.0
 
+- **break**: require Node >=14.16.0
+  ([#150](https://github.com/feltcoop/gro/pull/150))
 - add `getMimeTypes` and `getExtensions` returning iterators to `src/fs/mime.ts`
   ([#149](https://github.com/feltcoop/gro/pull/149))
 - improve default asset paths to use registered mime types

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "type": "module",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14.16.0"
   },
   "dependencies": {
     "@lukeed/uuid": "^2.0.0",


### PR DESCRIPTION
This updates the `package.json` engines property to `>=14.16.0`. We discovered some older v14 versions are broken, so we're standardizing here until the next version bump.