### PR TITLE
improve logging readability

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.13.1
 
-- improve logging aesthetics
+- improve logging readability
   ([#152](https://github.com/feltcoop/gro/pull/152))
 
 ## 0.13.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.13.1
+
+- improve logging aesthetics
+  ([#152](https://github.com/feltcoop/gro/pull/152))
+
 ## 0.13.0
 
 - **break**: require Node >=14.16.0

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -9,8 +9,8 @@ import {remove, outputFile, pathExists} from '../fs/nodeFs.js';
 import {EXTERNALS_BUILD_DIR_SUBPATH, JS_EXTENSION, paths, toBuildOutPath} from '../paths.js';
 import {nulls, omitUndefined} from '../utils/object.js';
 import {UnreachableError} from '../utils/error.js';
-import {Logger, SystemLogger} from '../utils/log.js';
-import {gray, magenta, red, cyan} from '../utils/terminal.js';
+import {Logger, printLogLabel, SystemLogger} from '../utils/log.js';
+import {gray, red, cyan} from '../utils/terminal.js';
 import {printError} from '../utils/print.js';
 import type {
 	Build,
@@ -153,7 +153,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 		filter: undefined,
 		cleanOutputDirs: true,
 		...omitUndefined(opts),
-		log: opts.log || new SystemLogger([magenta('[filer]')]),
+		log: opts.log || new SystemLogger([printLogLabel('filer')]),
 		builder,
 		buildConfigs,
 		buildDir,

--- a/src/build/esbuildBuilder.ts
+++ b/src/build/esbuildBuilder.ts
@@ -2,7 +2,7 @@ import esbuild from 'esbuild';
 
 import type {EcmaScriptTarget} from './tsBuildHelpers.js';
 import {getDefaultEsbuildOptions} from './esbuildBuildHelpers.js';
-import {Logger, SystemLogger} from '../utils/log.js';
+import {Logger, SystemLogger, printLogLabel} from '../utils/log.js';
 import {JS_EXTENSION, SOURCEMAP_EXTENSION, toBuildOutPath, TS_EXTENSION} from '../paths.js';
 import {omitUndefined} from '../utils/object.js';
 import type {Builder, BuildResult, TextBuild, TextBuildSource} from './builder.js';
@@ -20,7 +20,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 	return {
 		createEsbuildOptions: createDefaultEsbuildOptions,
 		...omitUndefined(opts),
-		log: opts.log || new SystemLogger([cyan('[esbuildBuilder]')]),
+		log: opts.log || new SystemLogger([printLogLabel('esbuildBuilder', cyan)]),
 	};
 };
 

--- a/src/build/externalsBuilder.ts
+++ b/src/build/externalsBuilder.ts
@@ -2,7 +2,7 @@ import {basename, dirname, join} from 'path';
 import {install as installWithEsinstall, InstallResult} from 'esinstall';
 import type {Plugin as RollupPlugin} from 'rollup';
 
-import {Logger, SystemLogger} from '../utils/log.js';
+import {Logger, printLogLabel, SystemLogger} from '../utils/log.js';
 import {EXTERNALS_BUILD_DIR, JS_EXTENSION, toBuildOutPath} from '../paths.js';
 import {omitUndefined} from '../utils/object.js';
 import type {Builder, BuildResult, BuildContext, TextBuildSource, TextBuild} from './builder.js';
@@ -45,7 +45,7 @@ export interface Options {
 }
 export type InitialOptions = Partial<Options>;
 export const initOptions = (opts: InitialOptions): Options => {
-	const log = opts.log || new SystemLogger([cyan('[externalsBuilder]')]);
+	const log = opts.log || new SystemLogger([printLogLabel('externalsBuilder', cyan)]);
 	return {
 		install: installWithEsinstall,
 		basePath: EXTERNALS_BUILD_DIR,

--- a/src/build/svelteBuilder.ts
+++ b/src/build/svelteBuilder.ts
@@ -11,7 +11,7 @@ import {
 	handleWarn,
 	SvelteCompilation,
 } from './svelteBuildHelpers.js';
-import {Logger, SystemLogger} from '../utils/log.js';
+import {Logger, printLogLabel, SystemLogger} from '../utils/log.js';
 import {
 	CSS_EXTENSION,
 	JS_EXTENSION,
@@ -43,7 +43,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 		onstats: null,
 		createPreprocessor: createDefaultPreprocessor,
 		...omitUndefined(opts),
-		log: opts.log || new SystemLogger([cyan('[svelteBuilder]')]),
+		log: opts.log || new SystemLogger([printLogLabel('svelteBuilder', cyan)]),
 		svelteCompileOptions: opts.svelteCompileOptions || {},
 	};
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,8 +5,7 @@ import {
 	PartialBuildConfig,
 	validateBuildConfigs,
 } from './buildConfig.js';
-import {Logger, LogLevel, SystemLogger, configureLogLevel} from '../utils/log.js';
-import {magenta} from '../utils/terminal.js';
+import {Logger, LogLevel, SystemLogger, configureLogLevel, printLogLabel} from '../utils/log.js';
 import {importTs} from '../fs/importTs.js';
 import {pathExists} from '../fs/nodeFs.js';
 import {PRIMARY_NODE_BUILD_CONFIG} from './defaultBuildConfig.js';
@@ -116,7 +115,7 @@ export const loadGroConfig = async (
 ): Promise<GroConfig> => {
 	if (cachedConfig !== undefined) return cachedConfig;
 
-	const log = new SystemLogger([magenta('[config]')]);
+	const log = new SystemLogger([printLogLabel('config')]);
 	const options: GroConfigCreatorOptions = {log, dev};
 
 	const {configSourceId} = paths;

--- a/src/fs/importTs.ts
+++ b/src/fs/importTs.ts
@@ -11,7 +11,7 @@ import {basename, dirname, join} from 'path';
 import {stripStart} from '../utils/string.js';
 import {isExternalNodeModule} from '../utils/module.js';
 import {replaceExtension} from '../utils/path.js';
-import {SystemLogger} from '../utils/log.js';
+import {printLogLabel, SystemLogger} from '../utils/log.js';
 import {cyan} from '../utils/terminal.js';
 
 /*
@@ -48,7 +48,7 @@ export const importTs = async (
 	const ctx: BuildContext = {
 		buildConfigs: [],
 		sourceMetaById: new Map(),
-		log: new SystemLogger([cyan('[importTs]')]),
+		log: new SystemLogger([printLogLabel('importTs', cyan)]),
 		buildDir: tempDir,
 		dev: true,
 		sourcemap: false,

--- a/src/project/build.ts
+++ b/src/project/build.ts
@@ -11,9 +11,8 @@ import resolvePlugin from '@rollup/plugin-node-resolve';
 import commonjsPlugin from '@rollup/plugin-commonjs';
 import * as sveltePreprocessEsbuild from 'svelte-preprocess-esbuild';
 
-import {magenta} from '../utils/terminal.js';
 import {rainbow} from '../utils/terminal.js';
-import {SystemLogger, Logger} from '../utils/log.js';
+import {SystemLogger, Logger, printLogLabel} from '../utils/log.js';
 import {diagnosticsPlugin} from './rollup-plugin-diagnostics.js';
 import {deindent} from '../utils/string.js';
 import {plainCssPlugin} from './rollup-plugin-plain-css.js';
@@ -70,7 +69,7 @@ export type MapWatchOptions = (o: RollupWatchOptions, b: Options) => RollupWatch
 export const createBuild = (opts: InitialOptions): Build => {
 	const options = initOptions(opts);
 
-	const log = new SystemLogger([magenta('[build]')]);
+	const log = new SystemLogger([printLogLabel('build')]);
 
 	log.trace('build options', options);
 

--- a/src/project/cssCache.ts
+++ b/src/project/cssCache.ts
@@ -1,5 +1,5 @@
 import {green} from '../utils/terminal.js';
-import {SystemLogger} from '../utils/log.js';
+import {printLogLabel, SystemLogger} from '../utils/log.js';
 import {printKeyValue, printPath} from '../utils/print.js';
 
 export interface CssBuild {
@@ -20,7 +20,7 @@ export interface CssCache<T extends CssBuild = CssBuild> {
 }
 
 export const createCssCache = <T extends CssBuild = CssBuild>(): CssCache<T> => {
-	const log = new SystemLogger([green('[cssCache]')]);
+	const log = new SystemLogger([printLogLabel('cssCache', green)]);
 
 	// `bundles` key is an output bundle file name
 	const bundles = new Map<string, CssBundle<T>>();

--- a/src/project/rollup-plugin-gro-esbuild.ts
+++ b/src/project/rollup-plugin-gro-esbuild.ts
@@ -3,7 +3,7 @@ import type {Plugin, PluginContext} from 'rollup';
 import {resolve} from 'path';
 import {createFilter} from '@rollup/pluginutils';
 
-import {magenta, red} from '../utils/terminal.js';
+import {red} from '../utils/terminal.js';
 import {createStopwatch} from '../utils/time.js';
 import {SystemLogger, Logger, printLogLabel} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';

--- a/src/project/rollup-plugin-gro-esbuild.ts
+++ b/src/project/rollup-plugin-gro-esbuild.ts
@@ -5,7 +5,7 @@ import {createFilter} from '@rollup/pluginutils';
 
 import {magenta, red} from '../utils/terminal.js';
 import {createStopwatch} from '../utils/time.js';
-import {SystemLogger, Logger} from '../utils/log.js';
+import {SystemLogger, Logger, printLogLabel} from '../utils/log.js';
 import {printKeyValue, printMs, printPath} from '../utils/print.js';
 import {toRootPath, isSourceId, TS_EXTENSION} from '../paths.js';
 import {omitUndefined} from '../utils/object.js';
@@ -42,7 +42,7 @@ export const name = 'gro-esbuild';
 export const groEsbuildPlugin = (opts: InitialOptions): Plugin => {
 	const {include, exclude, esbuildOptions, onstats} = initOptions(opts);
 
-	const log = new SystemLogger([magenta(`[${name}]`)]);
+	const log = new SystemLogger([printLogLabel(name)]);
 
 	const filter = createFilter(include, exclude);
 

--- a/src/project/rollup-plugin-gro-json.ts
+++ b/src/project/rollup-plugin-gro-json.ts
@@ -1,8 +1,7 @@
 import type {Plugin} from 'rollup';
 import {createFilter, dataToEsm} from '@rollup/pluginutils';
 
-import {magenta} from '../utils/terminal.js';
-import {SystemLogger} from '../utils/log.js';
+import {printLogLabel, SystemLogger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 import {omitUndefined} from '../utils/object.js';
 
@@ -33,7 +32,7 @@ export const name = 'gro-json';
 export const groJsonPlugin = (opts: InitialOptions = {}): Plugin => {
 	const {include, exclude, compact, indent, namedExports, preferConst} = initOptions(opts);
 
-	const log = new SystemLogger([magenta(`[${name}]`)]);
+	const log = new SystemLogger([printLogLabel(name)]);
 
 	const filter = createFilter(include, exclude);
 

--- a/src/project/rollup-plugin-gro-svelte.ts
+++ b/src/project/rollup-plugin-gro-svelte.ts
@@ -4,9 +4,9 @@ import type {CompileOptions as SvelteCompileOptions} from 'svelte/types/compiler
 import type {Plugin} from 'rollup';
 import {createFilter} from '@rollup/pluginutils';
 
-import {magenta, red} from '../utils/terminal.js';
+import {red} from '../utils/terminal.js';
 import {toPathStem} from '../utils/path.js';
-import {SystemLogger} from '../utils/log.js';
+import {printLogLabel, SystemLogger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 import type {GroCssBuild} from './types.js';
 import {omitUndefined} from '../utils/object.js';
@@ -72,7 +72,7 @@ export const groSveltePlugin = (opts: InitialOptions): GroSveltePlugin => {
 		onstats,
 	} = initOptions(opts);
 
-	const log = new SystemLogger([magenta(`[${name}]`)]);
+	const log = new SystemLogger([printLogLabel(name)]);
 
 	const getCompilation = (id: string): GroSvelteCompilation | undefined => compilations.get(id);
 

--- a/src/project/rollup-plugin-gro-terser.ts
+++ b/src/project/rollup-plugin-gro-terser.ts
@@ -2,8 +2,7 @@ import * as terser from 'terser';
 import type {Plugin} from 'rollup';
 import {createFilter} from '@rollup/pluginutils';
 
-import {magenta} from '../utils/terminal.js';
-import {SystemLogger} from '../utils/log.js';
+import {printLogLabel, SystemLogger} from '../utils/log.js';
 import {printPath, printError} from '../utils/print.js';
 import {omitUndefined} from '../utils/object.js';
 
@@ -27,7 +26,7 @@ export const name = 'gro-terser';
 export const groTerserPlugin = (opts: InitialOptions = {}): Plugin => {
 	const {include, exclude, minifyOptions} = initOptions(opts);
 
-	const log = new SystemLogger([magenta(`[${name}]`)]);
+	const log = new SystemLogger([printLogLabel(name)]);
 
 	const filter = createFilter(include, exclude);
 

--- a/src/project/rollup-plugin-output-css.ts
+++ b/src/project/rollup-plugin-output-css.ts
@@ -4,7 +4,7 @@ import sourcemapCodec from 'sourcemap-codec';
 
 import {blue, gray} from '../utils/terminal.js';
 import {outputFile} from '../fs/nodeFs.js';
-import {SystemLogger, Logger} from '../utils/log.js';
+import {SystemLogger, Logger, printLogLabel} from '../utils/log.js';
 import type {GroCssBuild, GroCssBundle} from './types.js';
 import {omitUndefined} from '../utils/object.js';
 import type {PartialExcept} from '../index.js';
@@ -27,7 +27,7 @@ export const name = 'output-css';
 export const outputCssPlugin = (opts: InitialOptions): Plugin => {
 	const {getCssBundles, toFinalCss, sourcemap} = initOptions(opts);
 
-	const log = new SystemLogger([blue(`[${name}]`)]);
+	const log = new SystemLogger([printLogLabel(name, blue)]);
 
 	return {
 		name,

--- a/src/project/rollup-plugin-plain-css.ts
+++ b/src/project/rollup-plugin-plain-css.ts
@@ -4,7 +4,7 @@ import {existsSync} from 'fs';
 import {createFilter} from '@rollup/pluginutils';
 
 import {green} from '../utils/terminal.js';
-import {SystemLogger} from '../utils/log.js';
+import {printLogLabel, SystemLogger} from '../utils/log.js';
 import type {GroCssBuild} from './types.js';
 import {omitUndefined} from '../utils/object.js';
 import type {PartialExcept} from '../index.js';
@@ -35,7 +35,7 @@ export const name = 'plain-css';
 export const plainCssPlugin = (opts: InitialOptions): Plugin => {
 	const {addCssBuild, extensions, include, exclude} = initOptions(opts);
 
-	const log = new SystemLogger([green(`[${name}]`)]);
+	const log = new SystemLogger([printLogLabel(name, green)]);
 
 	const filter = createFilter(include, exclude);
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,7 +9,7 @@ import {createSecureServer as createHttp2Server, Http2Server, ServerHttp2Stream}
 import type {ListenOptions} from 'net';
 
 import {cyan, yellow, gray, red, rainbow, green} from '../utils/terminal.js';
-import {SystemLogger} from '../utils/log.js';
+import {printLogLabel, SystemLogger} from '../utils/log.js';
 import type {Logger} from '../utils/log.js';
 import {stripAfter} from '../utils/string.js';
 import {omitUndefined} from '../utils/object.js';
@@ -58,7 +58,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 		port: DEFAULT_SERVER_PORT,
 		https: null,
 		...omitUndefined(opts),
-		log: opts.log || new SystemLogger([cyan('[server]')]),
+		log: opts.log || new SystemLogger([printLogLabel('server', cyan)]),
 	};
 };
 

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -1,7 +1,7 @@
-import {magenta, cyan, red, gray} from '../utils/terminal.js';
+import {cyan, red, gray} from '../utils/terminal.js';
 import {EventEmitter} from 'events';
 import type {Args} from './task.js';
-import {SystemLogger, Logger, configureLogLevel} from '../utils/log.js';
+import {SystemLogger, Logger, configureLogLevel, printLogLabel} from '../utils/log.js';
 import {runTask} from './runTask.js';
 import {createStopwatch, Timings} from '../utils/time.js';
 import {printMs, printPath, printPathOrGroPath, printTiming} from '../utils/print.js';
@@ -50,7 +50,7 @@ export const invokeTask = async (
 	events = new EventEmitter(),
 	dev?: boolean,
 ): Promise<void> => {
-	const log = new SystemLogger([`${gray('[')}${magenta(taskName || 'gro')}${gray(']')}`]);
+	const log = new SystemLogger([printLogLabel(taskName || 'gro')]);
 
 	// Check if the caller just wants to see the version.
 	if (!taskName && (args.version || args.v)) {

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -1,7 +1,7 @@
 import type {EventEmitter} from 'events';
 
 import {cyan, magenta, red, gray} from '../utils/terminal.js';
-import {SystemLogger} from '../utils/log.js';
+import {printLogLabel, SystemLogger} from '../utils/log.js';
 import type {TaskModuleMeta} from './taskModule.js';
 import type {Args} from './task.js';
 import {TaskError} from './task.js';
@@ -39,7 +39,7 @@ export const runTask = async (
 			dev,
 			args,
 			events,
-			log: new SystemLogger([`${gray('[')}${magenta(task.name)}${gray(':log')}${gray(']')}`]),
+			log: new SystemLogger([`${printLogLabel(task.name)}${gray('[log]')}`]),
 			invokeTask: (invokedTaskName, invokedArgs = args, invokedEvents = events, invokedDev = dev) =>
 				invokeTask(invokedTaskName, invokedArgs, invokedEvents, invokedDev),
 		});

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -1,6 +1,6 @@
 import type {EventEmitter} from 'events';
 
-import {cyan, magenta, red, gray} from '../utils/terminal.js';
+import {cyan, red, gray} from '../utils/terminal.js';
 import {printLogLabel, SystemLogger} from '../utils/log.js';
 import type {TaskModuleMeta} from './taskModule.js';
 import type {Args} from './task.js';

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,4 +1,4 @@
-import {red, yellow, gray, black, bgYellow, bgRed} from '../utils/terminal.js';
+import {red, yellow, gray, black, magenta, bgYellow, bgRed} from '../utils/terminal.js';
 import {EMPTY_ARRAY} from './array.js';
 
 // TODO could use some refactoring
@@ -178,3 +178,6 @@ export const configureLogLevel = (
 		SystemLogger.level = level;
 	}
 };
+
+export const printLogLabel = (label: string, color = magenta): string =>
+	`${gray('[')}${color(label)}${gray(']')}`;

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,14 +1,14 @@
 import {spawn as spawnChildProcess} from 'child_process';
 import type {SpawnOptions, ChildProcess} from 'child_process';
 
-import {gray, green, magenta, red} from '../utils/terminal.js';
+import {gray, green, red} from '../utils/terminal.js';
 import {TaskError} from '../task/task.js';
-import {SystemLogger} from './log.js';
+import {printLogLabel, SystemLogger} from './log.js';
 import {printError, printKeyValue} from './print.js';
 import {wait} from './async.js';
 import type {Result} from './types.js';
 
-const log = new SystemLogger([`${gray('[')}${magenta('process')}${gray(']')}`]);
+const log = new SystemLogger([printLogLabel('process')]);
 
 export interface SpawnedProcess {
 	child: ChildProcess;
@@ -61,7 +61,7 @@ export const attachProcessErrorHandlers = () => {
 };
 
 const handleFatalError = async (err: Error, label = 'handleFatalError'): Promise<void> => {
-	new SystemLogger([red(`[${label}]`)]).error(printError(err));
+	new SystemLogger([printLogLabel(label, red)]).error(printError(err));
 	await Promise.all(Array.from(globalSpawn).map((child) => despawn(child)));
 	process.exit(1);
 };


### PR DESCRIPTION
This improves the readability of the logging colors and gives us a standard helper for creating log labels, the prefixes before log statements. It's a small but nice improvement.