### PR TITLE
fix dist build

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
   ([#117](https://github.com/feltcoop/gro/pull/117))
 - upgrade to `svelte@3.37.0`
   ([#102](https://github.com/feltcoop/gro/pull/102))
+- fix `dist/` build
+  ([#156](https://github.com/feltcoop/gro/pull/156))
 - export many more things from root: `import {/* !!! */} from '@feltcoop/gro';`
   ([#117](https://github.com/feltcoop/gro/pull/117))
 

--- a/src/project/build.task.ts
+++ b/src/project/build.task.ts
@@ -5,6 +5,7 @@ import {Timings} from '../utils/time.js';
 import {buildSourceDirectory} from '../build/buildSourceDirectory.js';
 import {loadGroConfig} from '../config/config.js';
 import {configureLogLevel} from '../utils/log.js';
+import {clean} from '../fs/clean.js';
 
 export const task: Task = {
 	description: 'build, create, and link the distribution',
@@ -21,6 +22,8 @@ export const task: Task = {
 		const timingToBuildWithFiler = timings.start('build with filer');
 		await buildSourceDirectory(config, dev, log);
 		timingToBuildWithFiler();
+
+		await clean({dist: true}, log);
 
 		// compile again with `tsc` to create all of the TypeScript type defs, sourcemaps, and typemaps
 		const timingToCompileWithTsc = timings.start('compile with tsc');

--- a/src/project/dist.task.ts
+++ b/src/project/dist.task.ts
@@ -3,7 +3,6 @@ import {copy} from '../fs/node.js';
 import {paths, toBuildOutPath} from '../paths.js';
 import {isTestBuildFile, isTestBuildArtifact} from '../fs/testModule.js';
 import {printPath} from '../utils/print.js';
-import {clean} from '../fs/clean.js';
 import {loadGroConfig} from '../config/config.js';
 import {configureLogLevel} from '../utils/log.js';
 import {printBuildConfig} from '../config/buildConfig.js';
@@ -12,8 +11,6 @@ export const task: Task = {
 	description: 'create and link the distribution',
 	dev: false,
 	run: async ({invokeTask, dev, log}) => {
-		await clean({dist: true}, log);
-
 		// This reads the `dist` flag on the build configs to help construct the final dist directory.
 		// See the docs at `./docs/config.md`.
 		const config = await loadGroConfig(dev);
@@ -27,7 +24,10 @@ export const task: Task = {
 						? paths.dist
 						: `${paths.dist}${printBuildConfig(buildConfig)}`;
 				log.info(`copying ${printPath(buildOutDir)} to ${printPath(distOutDir)}`);
-				return copy(buildOutDir, distOutDir, {filter: (id) => isDistFile(id)});
+				return copy(buildOutDir, distOutDir, {
+					overwrite: false, // let the TypeScript output take priority, but allow other files like Svelte
+					filter: (id) => isDistFile(id),
+				});
 			}),
 		);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     // "allowJs": false, // Allow javascript files to be compiled.
     // "checkJs": false, // Report errors in .js files.
     // "outFile": "./", // Concatenate and emit output to single file.
-    "outDir": ".gro/prod/node", // Redirect output structure to the directory.
+    "outDir": "dist", // Redirect output structure to the directory.
     "rootDir": "src", // Specify the root directory of input files. Use to control the output directory structure with `--outDir`.
     // "project": "", // Compile a project given a valid configuration file.
 


### PR DESCRIPTION
We have broken metadata in our build since we switched over to `esbuild`, since we were using its output artifacts in `dist/` instead of `tsc`. This should fix sourcemaps and typemaps, hopefully, by correctly prioritizing the TypeScript compiler's outputs over any . It's also cleaner and more correct - `tsconfig.json` points directly to `dist/` and knows nothing about Gro's internal build system - that was bad behavior, broken design.