### PR TITLE
update build and deploy tasks to work with SvelteKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,13 @@ npm run bootstrap # build and link `gro` - needed only once
 gro test # make sure everything looks good - same as `npm test`
 
 # development
-gro dev # start dev server in watch mode
-gro project/dist # update the `gro` CLI
+gro dev # start dev server in watch mode; it's designed as a long-running process
+gro build # update the `gro` CLI locally (see comment directly below: slow because bug)
+# gro project/dist # TODO this should be the command but it's currently bugged
+
+# use your development version of `gro` locally in another project
+cd ../otherproject
+npm link ../gro
 
 # release
 gro build # build for release and update the `gro` CLI

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ It includes:
 ## docs
 
 - [unbundled development](/src/docs/unbundled.md) for web frontends, servers, and libraries
+- [deploy](/src/docs/deploy.md) to GitHub pages
 - [`task`](/src/task) runner
 - [dev server](/src/server)
 - [`gen`](/src/gen) code generation

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ## 0.15.0
 
-- **break**: update `src/build.task.ts` and `src/deploy.task.ts` to work with SvelteKit
+- **break**: make `src/build.task.ts`, `src/deploy.task.ts`,
+  and `src/start.task.ts` work with SvelteKit
   ([#157](https://github.com/feltcoop/gro/pull/157))
   - add flag `gro deploy --clean` to reset deployment state
   - add flag `--branch` to both tasks, default to `main`

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 - **break**: update `src/deploy.task.ts` to work with SvelteKit
   ([#157](https://github.com/feltcoop/gro/pull/157))
+  - add flag `gro deploy --clean` to reset deployment state
   - it now uses the `deploy` branch instead of `gh-pages`
 - **break**: rename `toEnvString` and `toEnvNumber` from `stringFromEnv` and `numberFromEnv`
   ([#154](https://github.com/feltcoop/gro/pull/154))

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 - **break**: update `src/build.task.ts` and `src/deploy.task.ts` to work with SvelteKit
   ([#157](https://github.com/feltcoop/gro/pull/157))
   - add flag `gro deploy --clean` to reset deployment state
-  - it now uses the `deploy` branch instead of `gh-pages`
+  - default to the `deploy` branch instead of `gh-pages`
 - **break**: rename `toEnvString` and `toEnvNumber` from `stringFromEnv` and `numberFromEnv`
   ([#154](https://github.com/feltcoop/gro/pull/154))
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - **break**: update `src/build.task.ts` and `src/deploy.task.ts` to work with SvelteKit
   ([#157](https://github.com/feltcoop/gro/pull/157))
   - add flag `gro deploy --clean` to reset deployment state
+  - add flag `--branch` to both tasks, default to `main`
   - default to the `deploy` branch instead of `gh-pages`
 - **break**: rename `toEnvString` and `toEnvNumber` from `stringFromEnv` and `numberFromEnv`
   ([#154](https://github.com/feltcoop/gro/pull/154))

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.15.0
 
 - **break**: update `src/deploy.task.ts` to work with SvelteKit
-  ([#154](https://github.com/feltcoop/gro/pull/154))
+  ([#157](https://github.com/feltcoop/gro/pull/157))
   - it now uses the `deploy` branch instead of `gh-pages`
 - **break**: rename `toEnvString` and `toEnvNumber` from `stringFromEnv` and `numberFromEnv`
   ([#154](https://github.com/feltcoop/gro/pull/154))

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@
   - add flag `--branch` to both tasks, default to `main`
   - default to the `deploy` branch instead of `gh-pages`
 - **break**: rename `toEnvString` and `toEnvNumber` from `stringFromEnv` and `numberFromEnv`
-  ([#154](https://github.com/feltcoop/gro/pull/154))
+  ([#158](https://github.com/feltcoop/gro/pull/158))
 
 ## 0.14.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.15.0
 
-- **break**: update `src/deploy.task.ts` to work with SvelteKit
+- **break**: update `src/build.task.ts` and `src/deploy.task.ts` to work with SvelteKit
   ([#157](https://github.com/feltcoop/gro/pull/157))
   - add flag `gro deploy --clean` to reset deployment state
   - it now uses the `deploy` branch instead of `gh-pages`

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## 0.15.0
 
+- **break**: update `src/deploy.task.ts` to work with SvelteKit
+  ([#154](https://github.com/feltcoop/gro/pull/154))
+  - it now uses the `deploy` branch instead of `gh-pages`
 - **break**: rename `toEnvString` and `toEnvNumber` from `stringFromEnv` and `numberFromEnv`
   ([#154](https://github.com/feltcoop/gro/pull/154))
 

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -19,10 +19,10 @@ import type {TaskEvents as ServerTaskEvents} from './server.task.js';
 import {hasApiServerConfig, hasSvelteKitFrontend} from './config/defaultBuildConfig.js';
 import {printTiming} from './utils/print.js';
 import {resolveInputFiles} from './build/utils.js';
-import {green} from './utils/terminal.js';
 import {toCommonBaseDir} from './utils/path.js';
 import {clean} from './fs/clean.js';
 import {move} from './fs/node.js';
+import {printBuildConfigLabel} from './config/buildConfig.js';
 
 export interface TaskArgs {
 	mapInputOptions?: MapInputOptions;
@@ -48,15 +48,6 @@ export const task: Task<TaskArgs, TaskEvents> = {
 			return invokeTask('project/build');
 		}
 
-		// If this is a SvelteKit frontend, for now, just build it and exit immediately.
-		// TODO support merging SvelteKit and Gro builds (and then delete `felt-server`'s build task)
-		if ((await hasSvelteKitFrontend()) && !isThisProjectGro) {
-			await spawnProcess('npx', ['svelte-kit', 'build']);
-			await clean({dist: true}, log);
-			await move(SVELTE_KIT_BUILD_PATH, DIST_DIR);
-			return;
-		}
-
 		const timings = new Timings();
 
 		if (dev) {
@@ -72,6 +63,19 @@ export const task: Task<TaskArgs, TaskEvents> = {
 
 		const esbuildOptions = getDefaultEsbuildOptions(config.target, config.sourcemap, dev);
 
+		const timingToClean = timings.start('clean');
+		await clean({dist: true}, log);
+		timingToClean();
+
+		// If this is a SvelteKit frontend, for now, just build it and exit immediately.
+		// TODO support merging SvelteKit and Gro builds (and then delete `felt-server`'s build task)
+		if ((await hasSvelteKitFrontend()) && !isThisProjectGro) {
+			const timingToBuildSvelteKit = timings.start('SvelteKit build');
+			await spawnProcess('npx', ['svelte-kit', 'build']);
+			await move(SVELTE_KIT_BUILD_PATH, DIST_DIR);
+			timingToBuildSvelteKit();
+		}
+
 		// TODO think this through
 		// This is like a "prebuild" phase.
 		// Build everything with esbuild and Gro's `Filer` first,
@@ -79,7 +83,9 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		// See the other reference to `isThisProjectGro` for comments about its weirdness.
 		let spawnedApiServer: SpawnedProcess | null = null;
 		if (!isThisProjectGro) {
+			const timingToPrebuild = timings.start('prebuild');
 			await buildSourceDirectory(config, dev, log);
+			timingToPrebuild();
 			events.emit('build.prebuild');
 
 			// now that the prebuild is ready, we can start the API server, if it exists
@@ -102,32 +108,34 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		// and therefore belong in the default Rollup build.
 		// If more customization is needed, users should implement their own `src/build.task.ts`,
 		// which can be bootstrapped by copy/pasting this one. (and updating the imports)
+		const timingToBuild = timings.start('build');
 		await Promise.all(
 			buildConfigsToBuild.map(async (buildConfig) => {
 				const inputFiles = await resolveInputFiles(buildConfig);
+				if (!inputFiles.length) {
+					log.trace('no input files in', printBuildConfigLabel(buildConfig));
+					return;
+				}
 				// TODO ok wait, does `outputDir` need to be at the output dir path?
 				const outputDir = `${DIST_DIR}${toBuildExtension(
 					sourceIdToBasePath(toCommonBaseDir(inputFiles)),
 				)}`;
 				// const outputDir = paths.dist;
-				log.info(`building ${green(buildConfig.name)}`, outputDir, inputFiles);
-				if (inputFiles.length) {
-					const build = createBuild({
-						dev,
-						sourcemap: config.sourcemap,
-						inputFiles,
-						outputDir,
-						mapInputOptions,
-						mapOutputOptions,
-						mapWatchOptions,
-						esbuildOptions,
-					});
-					await build.promise;
-				} else {
-					log.warn(`no input files in build "${buildConfig.name}"`);
-				}
+				log.info('building', printBuildConfigLabel(buildConfig), outputDir, inputFiles);
+				const build = createBuild({
+					dev,
+					sourcemap: config.sourcemap,
+					inputFiles,
+					outputDir,
+					mapInputOptions,
+					mapOutputOptions,
+					mapWatchOptions,
+					esbuildOptions,
+				});
+				await build.promise;
 			}),
 		);
+		timingToBuild();
 
 		// done! clean up the API server
 		if (spawnedApiServer) {
@@ -136,7 +144,9 @@ export const task: Task<TaskArgs, TaskEvents> = {
 				args.closeApiServer(spawnedApiServer);
 			} else {
 				spawnedApiServer!.child.kill();
+				const timingToCloseServer = timings.start('close server');
 				await spawnedApiServer!.closed;
+				timingToCloseServer();
 			}
 		}
 

--- a/src/cert.task.ts
+++ b/src/cert.task.ts
@@ -12,8 +12,8 @@ export const task: Task<TaskArgs> = {
 		const host = args.host || 'localhost';
 		const certFile = `${host}-cert.pem`;
 		const keyFile = `${host}-privkey.pem`;
-		if (await pathExists(certFile)) throw Error(`File ${certFile} already exists. Aborting.`);
-		if (await pathExists(keyFile)) throw Error(`File ${keyFile} already exists. Aborting.`);
+		if (await pathExists(certFile)) throw Error(`File ${certFile} already exists. Canceling.`);
+		if (await pathExists(keyFile)) throw Error(`File ${keyFile} already exists. Canceling.`);
 		await spawnProcess(
 			'openssl',
 			`req -x509 -newkey rsa:2048 -nodes -sha256 -subj /CN=${host} -keyout ${keyFile} -out ${certFile}`.split(

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -43,13 +43,14 @@ export const API_SERVER_DEFAULT_PORT_DEV = 3001;
 export const toApiServerBuildPath = (dev: boolean, buildDir = paths.build): string =>
 	toBuildOutPath(dev, API_SERVER_BUILD_CONFIG_NAME, API_SERVER_BUILD_BASE_PATH, buildDir);
 
-export const hasDeprecatedGroFrontend = async (): Promise<boolean> => {
-	const [hasIndexHtml, hasIndexTs] = await Promise.all([
-		pathExists('src/index.html'),
-		pathExists('src/index.ts'),
-	]);
-	return hasIndexHtml && hasIndexTs;
-};
+const SVELTE_KIT_FRONTEND_PATHS = ['src/app.html', 'src/routes'];
+export const hasSvelteKitFrontend = async (): Promise<boolean> =>
+	everyPathExists(SVELTE_KIT_FRONTEND_PATHS);
+
+const DEPRECATED_GRO_FRONTEND_PATHS = ['src/index.html', 'src/index.ts'];
+export const hasDeprecatedGroFrontend = async (): Promise<boolean> =>
+	everyPathExists(DEPRECATED_GRO_FRONTEND_PATHS);
+
 export const toDefaultBrowserBuild = (assetPaths = toDefaultAssetPaths()): PartialBuildConfig => ({
 	name: 'browser',
 	platform: 'browser',
@@ -57,3 +58,6 @@ export const toDefaultBrowserBuild = (assetPaths = toDefaultAssetPaths()): Parti
 	dist: true,
 });
 const toDefaultAssetPaths = (): string[] => Array.from(getExtensions());
+
+const everyPathExists = async (paths: string[]): Promise<boolean> =>
+	(await Promise.all(paths.map((path) => pathExists(path)))).every((v) => !!v);

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -5,6 +5,8 @@ import {toBuildExtension, basePathToSourceId, toBuildOutPath, paths} from '../pa
 import {pathExists} from '../fs/node.js';
 import {getExtensions} from '../fs/mime.js';
 
+export const GIT_DEPLOY_BRANCH = 'main';
+
 // Gro currently enforces that the primary build config
 // for the Node platform has this value as its name.
 // This convention speeds up running tasks by standardizing where Gro can look for built files.

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -5,7 +5,7 @@ import {toBuildExtension, basePathToSourceId, toBuildOutPath, paths} from '../pa
 import {pathExists} from '../fs/node.js';
 import {getExtensions} from '../fs/mime.js';
 
-export const GIT_DEPLOY_BRANCH = 'main';
+export const GIT_DEPLOY_BRANCH = 'main'; // deploy and publish from this branch
 
 // Gro currently enforces that the primary build config
 // for the Node platform has this value as its name.

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -5,6 +5,7 @@ import {spawnProcess} from './utils/process.js';
 import {copy, pathExists} from './fs/node.js';
 import {paths} from './paths.js';
 import {printError, printPath} from './utils/print.js';
+import {green, red} from './utils/terminal.js';
 
 export interface TaskArgs {
 	dry?: boolean;
@@ -60,9 +61,9 @@ export const task: Task<TaskArgs> = {
 			}
 			await copy(initialFile, join(distDir, initialFile));
 		} catch (err) {
-			log.error('Build failed:', printError(err));
+			log.error(red('Build failed:'), printError(err));
 			if (dry) {
-				log.info('Dry deploy failed! Files are available in', printPath(distDirName));
+				log.info(red('Dry deploy failed!'), 'Files are available in', printPath(distDirName));
 			} else {
 				await cleanGitWorktree(true);
 			}
@@ -71,7 +72,7 @@ export const task: Task<TaskArgs> = {
 
 		// At this point, `dist/` is ready to be committed and deployed!
 		if (dry) {
-			log.info('Dry deploy complete! Files are available in', printPath(distDirName));
+			log.info(green('Dry deploy complete!'), 'Files are available in', printPath(distDirName));
 		} else {
 			await spawnProcess('git', ['add', '.'], {cwd: distDir});
 			await spawnProcess('git', ['commit', '-m', 'deployment'], {

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -28,6 +28,20 @@ export const task: Task<TaskArgs> = {
 	run: async ({invokeTask, args, log}): Promise<void> => {
 		const {dry, clean} = args;
 
+		// TODO checkout main
+		// TODO confirm with dialog some of the things (extract a Gro helper?)
+
+		console.log('spawnProcess git status');
+		// Exit early if the git working directory has any unstaged or staged changes.
+		const result = await spawnProcess('git', ['diff-index', '--quiet', 'HEAD']);
+		console.log('result;', result);
+		if (!result.ok) {
+		}
+		if (!dry) {
+			return;
+		}
+
+		// TODO filter stdout? `--quiet` didn't work
 		// Set up the deployment branch if necessary.
 		// If the `deploymentBranch` already exists, this is a no-op.
 		log.info(magenta('↓↓↓↓↓↓↓'), green('ignore any errors in here'), magenta('↓↓↓↓↓↓↓'));

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -36,13 +36,10 @@ export const task: Task<TaskArgs> = {
 
 		// TODO confirm with dialog some of the things (extract a Gro helper?)
 
-		console.log('spawnProcess git status');
 		// Exit early if the git working directory has any unstaged or staged changes.
 		const result = await spawnProcess('git', ['diff-index', '--quiet', 'HEAD']);
-		console.log('result;', result);
 		if (!result.ok) {
-		}
-		if (!dry) {
+			log.error(red('git working directory is unclean~ please commit or stash to proceed'));
 			return;
 		}
 
@@ -89,9 +86,9 @@ export const task: Task<TaskArgs> = {
 				await copy(SVELTE_KIT_BUILD_PATH, distDir);
 			}
 		} catch (err) {
-			log.error(red('Build failed'), 'but', green('no changes were made to git.'), printError(err));
+			log.error(red('build failed'), 'but', green('no changes were made to git'), printError(err));
 			if (dry) {
-				log.info(red('Dry deploy failed!'), 'Files are available in', printPath(distDirName));
+				log.info(red('dry deploy failed:'), 'files are available in', printPath(distDirName));
 			} else {
 				await cleanGitWorktree(true);
 			}
@@ -100,7 +97,7 @@ export const task: Task<TaskArgs> = {
 
 		// At this point, `dist/` is ready to be committed and deployed!
 		if (dry) {
-			log.info(green('Dry deploy complete!'), 'Files are available in', printPath(distDirName));
+			log.info(green('dry deploy complete:'), 'files are available in', printPath(distDirName));
 			return;
 		}
 
@@ -111,7 +108,7 @@ export const task: Task<TaskArgs> = {
 			await spawnProcess('git', ['commit', '-m', 'deployment'], gitArgs);
 			await spawnProcess('git', ['push', 'origin', deploymentBranch], gitArgs);
 		} catch (err) {
-			log.error(red('Updating git failed:'), printError(err));
+			log.error(red('updating git failed:'), printError(err));
 			throw Error(`Deploy failed in a bad state: built but not pushed. See the error above.`);
 		}
 

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -3,10 +3,10 @@ import {join, basename} from 'path';
 import type {Task} from './task/task.js';
 import {spawnProcess} from './utils/process.js';
 import {copy} from './fs/node.js';
-import {paths, SVELTE_KIT_BUILD_PATH} from './paths.js';
+import {paths} from './paths.js';
 import {printError, printPath} from './utils/print.js';
 import {magenta, green, rainbow, red} from './utils/terminal.js';
-import {GIT_DEPLOY_BRANCH, hasSvelteKitFrontend} from './config/defaultBuildConfig.js';
+import {GIT_DEPLOY_BRANCH} from './config/defaultBuildConfig.js';
 
 // TODO support other kinds of deployments
 // TODO add a flag to delete the existing deployment branch to avoid bloat (and maybe run `git gc --auto`)
@@ -83,11 +83,6 @@ export const task: Task<TaskArgs> = {
 
 			// Update the initial file.
 			await copy(initialFile, join(distDir, initialFile));
-
-			// Handle builds outside of Gro, like SvelteKit, without any configuration.
-			if (await hasSvelteKitFrontend()) {
-				await copy(SVELTE_KIT_BUILD_PATH, distDir);
-			}
 		} catch (err) {
 			log.error(red('build failed'), 'but', green('no changes were made to git'), printError(err));
 			if (dry) {

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -3,6 +3,7 @@
 > <sub>[gro](/../..) / docs / README.md</sub>
 
 - [config](config.md)
+- [deploy](deploy.md)
 - [options](options.md)
 - [publish](publish.md)
 - [tasks](tasks.md)

--- a/src/docs/deploy.md
+++ b/src/docs/deploy.md
@@ -1,10 +1,10 @@
 # gro/deploy
 
-For now, Gro's `gro deploy` task only supports static deployments to
+For now, Gro's `gro deploy` task supports only static deployments to
 [GitHub pages](https://pages.github.com/).
 Eventually we want to expand builtin support,
 including servers and other static clouds,
-but for now you may need to implement `src/deploy.task.ts` yourself.
+but for now you need to implement `src/deploy.task.ts` yourself outside of GitHub pages.
 
 ```bash
 gro deploy # prepares dist/

--- a/src/docs/deploy.md
+++ b/src/docs/deploy.md
@@ -1,0 +1,16 @@
+# gro/deploy
+
+For now, Gro's `gro deploy` task only supports static deployments to
+[GitHub pages](https://pages.github.com/).
+Eventually we want to expand builtin support,
+including servers and other static clouds,
+but for now you may need to implement `src/deploy.task.ts` yourself.
+
+```bash
+gro deploy # prepares dist/
+gro deploy --branch my-branch # deploy from a branch other than 'main'
+gro deploy --dry # prepare dist/ but don't commit or push
+gro deploy --clean # if something goes wrong, this resets git and gro state
+```
+
+See [`src/deploy.task.ts`](/src/deploy.task.ts) for more.

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -10,7 +10,7 @@ What is a `Task`? See [`src/tasks/README.md`](../task).
 - [cert](../cert.task.ts) - creates a self-signed cert for https with openssl
 - [check](../check.task.ts) - check that everything is ready to commit
 - [clean](../clean.task.ts) - remove temporary dev and build files
-- [deploy](../deploy.task.ts) - deploy to gh-pages
+- [deploy](../deploy.task.ts) - deploy to static hosting
 - [dev](../dev.task.ts) - start dev server
 - [format](../format.task.ts) - format source files
 - [gen](../gen.task.ts) - run code generation scripts

--- a/src/fs/watchNodeFs.ts
+++ b/src/fs/watchNodeFs.ts
@@ -30,6 +30,7 @@ export const DEBOUNCE_DEFAULT = 10;
 
 // ignore some things in a typical Gro project
 // note this set is exported & mutable 🤭
+// TODO use gitignore? expose gitignore interface to gro users?
 export const ignoredPaths = new Set(['.git', '.svelte', 'node_modules', '.DS_Store']);
 const defaultFilter: PathFilter = (file) => !ignoredPaths.has(file.path);
 

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -1,6 +1,6 @@
 import type {EventEmitter} from 'events';
 
-import {cyan, red, gray} from '../utils/terminal.js';
+import {cyan, red} from '../utils/terminal.js';
 import {printLogLabel, SystemLogger} from '../utils/log.js';
 import type {TaskModuleMeta} from './taskModule.js';
 import type {Args} from './task.js';

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -39,7 +39,7 @@ export const runTask = async (
 			dev,
 			args,
 			events,
-			log: new SystemLogger([`${printLogLabel(task.name)}${gray('[log]')}`]),
+			log: new SystemLogger([`${printLogLabel(task.name)}`]),
 			invokeTask: (invokedTaskName, invokedArgs = args, invokedEvents = events, invokedDev = dev) =>
 				invokeTask(invokedTaskName, invokedArgs, invokedEvents, invokedDev),
 		});

--- a/src/task/runTask.ts
+++ b/src/task/runTask.ts
@@ -51,7 +51,7 @@ export const runTask = async (
 					? err.message
 					: `Unexpected error running task ${cyan(
 							task.name,
-					  )}. Aborting. If this is unexpected try running \`gro clean\`.`,
+					  )}. Canceling. If this is unexpected try running \`gro clean\`.`,
 			),
 			error: err,
 		};


### PR DESCRIPTION
SvelteKit fits nicely with the deployment process we've been doing. Gro was building production artifacts to `dist/`, SvelteKit outputs to `build/`.

The trick now is to do the best integration with what `src/deploy.task.ts` was doing for our static deployments to GitHub Pages.

- [x] basic behavior

So far this PR:

- makes the build and deploy tasks work for SvelteKit projects
- adds custom `branch` CLI arg to both tasks
- adds the `clean` CLI arg to exit directly after cleaning up the git and Gro state
- adds the helper `hasSvelteKitFrontend` and uses it to try to do the right thing
- changes the deployment branch from `gh-pages` to `deploy` - we don't want to tie ourselves to GitHub, and now GitHub supports customizing the deployed branch name
- uses SvelteKit's `static/` to replace similar functionality we had for things like the `CNAME` file
