### PR TITLE
rename env helpers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## 0.14.0
 
+- **break**: rename `toEnvString` and `toEnvNumber` from `stringFromEnv` and `numberFromEnv`
+  ([#154](https://github.com/feltcoop/gro/pull/154))
+
+## 0.14.0
+
 - **break**: rename `src/fs/node.ts` from `src/fs/nodeFs.ts`
   ([#154](https://github.com/feltcoop/gro/pull/154))
 - **break**: rename `src/fs/clean.ts` from `src/project/clean.ts`

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Gro changelog
 
-## 0.14.0
+## 0.15.0
 
 - **break**: rename `toEnvString` and `toEnvNumber` from `stringFromEnv` and `numberFromEnv`
   ([#154](https://github.com/feltcoop/gro/pull/154))

--- a/src/build/externalsBuilder.ts
+++ b/src/build/externalsBuilder.ts
@@ -26,7 +26,7 @@ import {
 } from './externalsBuildHelpers.js';
 import type {ExternalsBuildState} from './externalsBuildHelpers.js';
 import {EMPTY_ARRAY} from '../utils/array.js';
-import {numberFromEnv} from '../utils/env.js';
+import {toEnvNumber} from '../utils/env.js';
 
 /*
 
@@ -167,7 +167,7 @@ export const createExternalsBuilder = (opts: InitialOptions = {}): ExternalsBuil
 // but it causes unnecessary delays building externals
 const IDLE_CHECK_INTERVAL = 200; // needs to be smaller than `IDLE_CHECK_DELAY`
 const IDLE_CHECK_DELAY = 700; // needs to be larger than `IDLE_CHECK_INTERVAL`
-const IDLE_TIME_LIMIT = numberFromEnv('GRO_IDLE_TIME_LIMIT', 20_000); // TODO hacky failsafe, it'll time out after this long, which may be totally busted in some cases..
+const IDLE_TIME_LIMIT = toEnvNumber('GRO_IDLE_TIME_LIMIT', 20_000); // TODO hacky failsafe, it'll time out after this long, which may be totally busted in some cases..
 // TODO wait what's the relationship between those two? check for errors?
 
 // TODO this hackily guesses if the filer is idle enough to start installing externals

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -3,7 +3,7 @@ import {createGroServer} from './server/server.js';
 import {Filer} from './build/Filer.js';
 import {printPath} from './utils/print.js';
 import {loadHttpsCredentials} from './server/https.js';
-import {numberFromEnv, stringFromEnv} from './utils/env.js';
+import {toEnvNumber, toEnvString} from './utils/env.js';
 
 export interface TaskArgs {
 	_: string[];
@@ -17,8 +17,8 @@ export interface TaskArgs {
 export const task: Task<TaskArgs> = {
 	description: 'start static file server',
 	run: async ({log, args}): Promise<void> => {
-		const host = args.host || stringFromEnv('HOST');
-		const port = Number(args.port) || numberFromEnv('PORT');
+		const host = args.host || toEnvString('HOST');
+		const port = Number(args.port) || toEnvNumber('PORT');
 		const servedDirs = args._.length ? args._ : ['.'];
 
 		// TODO this is inefficient for just serving files in a directory

--- a/src/server/https.ts
+++ b/src/server/https.ts
@@ -1,6 +1,6 @@
 import {join} from 'path';
 
-import {stringFromEnv} from '../utils/env.js';
+import {toEnvString} from '../utils/env.js';
 import {pathExists, readFile} from '../fs/node.js';
 import type {Logger} from '../utils/log.js';
 
@@ -9,10 +9,10 @@ export interface HttpsCredentials {
 	key: string;
 }
 
-const DEFAULT_CERT_FILE: string = stringFromEnv('GRO_CERT_FILE', () =>
+const DEFAULT_CERT_FILE: string = toEnvString('GRO_CERT_FILE', () =>
 	join(process.cwd(), 'localhost-cert.pem'),
 );
-const DEFAULT_CERTKEY_FILE: string = stringFromEnv('GRO_CERTKEY_FILE', () =>
+const DEFAULT_CERTKEY_FILE: string = toEnvString('GRO_CERTKEY_FILE', () =>
 	join(process.cwd(), 'localhost-privkey.pem'),
 );
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -26,7 +26,7 @@ import {paths} from '../paths.js';
 import {loadPackageJson} from '../project/packageJson.js';
 import type {ProjectState} from './projectState.js';
 import type {Assignable, PartialExcept} from '../index.js';
-import {numberFromEnv, stringFromEnv} from '../utils/env.js';
+import {toEnvNumber, toEnvString} from '../utils/env.js';
 
 type Http2StreamHandler = (
 	stream: ServerHttp2Stream,
@@ -41,8 +41,8 @@ export interface GroServer {
 	readonly port: number;
 }
 
-export const DEFAULT_SERVER_HOST: string = stringFromEnv('HOST', 'localhost');
-export const DEFAULT_SERVER_PORT: number = numberFromEnv('PORT', 8999);
+export const DEFAULT_SERVER_HOST: string = toEnvString('HOST', 'localhost');
+export const DEFAULT_SERVER_PORT: number = toEnvNumber('PORT', 8999);
 
 export interface Options {
 	filer: Filer;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -3,18 +3,18 @@ import {lazy} from './function.js';
 
 // TODO validation?
 
-interface StringFromEnv {
+interface ToEnvString {
 	(key: string): string | undefined;
 	(key: string, fallback: string | Lazy<string>): string;
 }
 
-export const stringFromEnv: StringFromEnv = (key: string, fallback?: string | Lazy<string>) =>
+export const toEnvString: ToEnvString = (key: string, fallback?: string | Lazy<string>) =>
 	(key in process.env && process.env[key]) || ((fallback && lazy(fallback)) as string); // TODO fix type casting
 
-interface NumberFromEnv {
+interface ToEnvNumber {
 	(key: string): number | undefined;
 	(key: string, fallback: number | Lazy<number>): number;
 }
 
-export const numberFromEnv: NumberFromEnv = (key: string, fallback?: number | Lazy<number>) =>
+export const toEnvNumber: ToEnvNumber = (key: string, fallback?: number | Lazy<number>) =>
 	(key in process.env && Number(process.env[key])) || (fallback && (lazy(fallback) as any)); // TODO fix type casting


### PR DESCRIPTION
This renames the `process.env` helpers `stringFromEnv` and `numberFromEnv` to `toEnvString` and `toEnvNumber`.

Breaking because we expose our guts.