### PR TITLE
patch bug in SvelteKit with duplicate build dirs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.15.1
+
+- patch SvelteKit bug with duplicate build directories
+  [#160](https://github.com/feltcoop/gro/pull/160)
+
 ## 0.15.0
 
 - **break**: make `src/build.task.ts`, `src/deploy.task.ts`,

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -21,7 +21,7 @@ import {printTiming} from './utils/print.js';
 import {resolveInputFiles} from './build/utils.js';
 import {toCommonBaseDir} from './utils/path.js';
 import {clean} from './fs/clean.js';
-import {move} from './fs/node.js';
+import {move, pathExists, remove} from './fs/node.js';
 import {printBuildConfigLabel} from './config/buildConfig.js';
 
 // outputs build artifacts to dist/ using SvelteKit or Gro config
@@ -74,6 +74,14 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		if ((await hasSvelteKitFrontend()) && !isThisProjectGro) {
 			const timingToBuildSvelteKit = timings.start('SvelteKit build');
 			await spawnProcess('npx', ['svelte-kit', 'build']);
+			// TODO remove this when SvelteKit has its duplicate build dir bug fixed
+			// TODO take a look at its issues/codebase for fix
+			if (
+				(await pathExists(`${SVELTE_KIT_BUILD_PATH}/_app`)) &&
+				(await pathExists(`${SVELTE_KIT_BUILD_PATH}/app`))
+			) {
+				await remove(`${SVELTE_KIT_BUILD_PATH}/_app`);
+			}
 			await move(SVELTE_KIT_BUILD_PATH, DIST_DIR);
 			timingToBuildSvelteKit();
 		}


### PR DESCRIPTION
This is a quick fix for a little bug in the SvelteKit build. There's more that I may need to fix, but I may go to the source instead of patching. This was easy enough to do right now.