### PR TITLE
make serve task work for production SvelteKit builds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 - **break**: rename `src/utils/equal.ts` module from `deepEqual.ts`
   ([#162](https://github.com/feltcoop/gro/pull/162))
+- make serve task work for production SvelteKit builds
+  ([#163](https://github.com/feltcoop/gro/pull/163))
+- add helper `toSvelteKitBasePath` to `src/build/sveltekit.ts`
+  ([#163](https://github.com/feltcoop/gro/pull/163))
 - default to some environment variables
   for undefined Gro config properties:
   `GRO_HOST`, `GRO_PORT`, `GRO_LOG_LEVEL`

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -365,7 +365,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 		isInput: boolean,
 	): Promise<void> {
 		// this.log.trace(
-		// 	`adding source file to build ${printBuildConfig(buildConfig)} ${gray(sourceFile.id)}`,
+		// 	`adding source file to build ${printBuildConfigLabel(buildConfig)} ${gray(sourceFile.id)}`,
 		// );
 		if (sourceFile.buildConfigs.has(buildConfig)) {
 			throw Error(`Already has buildConfig ${buildConfig.name}: ${gray(sourceFile.id)}`);
@@ -441,6 +441,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 	private onDirChange: FilerDirChangeCallback = async (change, filerDir) => {
 		const id =
 			change.path === EXTERNALS_SOURCE_ID ? EXTERNALS_SOURCE_ID : join(filerDir.dir, change.path);
+		console.log(red(change.type), id);
 		switch (change.type) {
 			case 'init':
 			case 'create':

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -29,7 +29,7 @@ import {printBuildConfigLabel} from '../config/buildConfig.js';
 import type {BuildConfig} from '../config/buildConfig.js';
 import {DEFAULT_ECMA_SCRIPT_TARGET} from './tsBuildHelpers.js';
 import type {EcmaScriptTarget} from './tsBuildHelpers.js';
-import {toServedDirs} from './ServedDir.js';
+import {stripBase, toServedDirs} from './ServedDir.js';
 import type {ServedDir, ServedDirPartial} from './ServedDir.js';
 import {assertBuildableSourceFile, assertSourceFile, createSourceFile} from './sourceFile.js';
 import type {BuildableSourceFile, SourceFile} from './sourceFile.js';
@@ -233,7 +233,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 	async findByPath(path: string): Promise<BaseFilerFile | null> {
 		const {files} = this;
 		for (const servedDir of this.servedDirs) {
-			const id = `${servedDir.servedAt}/${path}`;
+			const id = `${servedDir.servedAt}/${stripBase(path, servedDir.base)}`;
 			const file = files.get(id);
 			if (file === undefined) {
 				this.log.trace(`findByPath: miss: ${id}`);

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -233,7 +233,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 	async findByPath(path: string): Promise<BaseFilerFile | null> {
 		const {files} = this;
 		for (const servedDir of this.servedDirs) {
-			const id = `${servedDir.servedAt}/${stripBase(path, servedDir.base)}`;
+			const id = `${servedDir.root}/${stripBase(path, servedDir.base)}`;
 			const file = files.get(id);
 			if (file === undefined) {
 				this.log.trace(`findByPath: miss: ${id}`);
@@ -1127,11 +1127,11 @@ const createFilerDirs = (
 			// TODO I think these are bugged with trailing slashes -
 			// note the `servedDir.dir` of `servedDir.dir.startsWith` could also not have a trailing slash!
 			// so I think you add `{dir} + '/'` to both?
-			!sourceDirs.find((d) => servedDir.dir.startsWith(d)) &&
-			!servedDirs.find((d) => d !== servedDir && servedDir.dir.startsWith(d.dir)) &&
-			!servedDir.dir.startsWith(buildDir)
+			!sourceDirs.find((d) => servedDir.path.startsWith(d)) &&
+			!servedDirs.find((d) => d !== servedDir && servedDir.path.startsWith(d.path)) &&
+			!servedDir.path.startsWith(buildDir)
 		) {
-			dirs.push(createFilerDir(servedDir.dir, false, onChange, filter, watch, watcherDebounce));
+			dirs.push(createFilerDir(servedDir.path, false, onChange, filter, watch, watcherDebounce));
 		}
 	}
 	return dirs;

--- a/src/build/ServedDir.ts
+++ b/src/build/ServedDir.ts
@@ -4,20 +4,20 @@ import type {PartialExcept} from '../index.js';
 import {stripStart} from '../utils/string.js';
 
 export interface ServedDir {
-	dir: string; // TODO rename? `source`, `sourceDir`, `path`
-	servedAt: string; // TODO rename? `root`
-	base: string; // relative path stripped from requests to support e.g. for GitHub pages this is the repo name
+	path: string;
+	root: string;
+	base: string; // relative path stripped from requests; for GitHub pages, this is the repo name
 }
 
-export type ServedDirPartial = string | PartialExcept<ServedDir, 'dir'>;
+export type ServedDirPartial = string | PartialExcept<ServedDir, 'path'>;
 
 export const toServedDir = (dir: ServedDirPartial): ServedDir => {
-	if (typeof dir === 'string') dir = {dir};
-	const resolvedDir = resolve(dir.dir);
+	if (typeof dir === 'string') dir = {path: dir};
+	const resolvedDir = resolve(dir.path);
 	return {
-		dir: resolvedDir,
+		path: resolvedDir,
 		base: dir.base ? baseToRelativePath(dir.base) : '', // see `baseToRelativePath` for more
-		servedAt: dir.servedAt ? resolve(dir.servedAt) : resolvedDir,
+		root: dir.root ? resolve(dir.root) : resolvedDir,
 	};
 };
 
@@ -27,10 +27,10 @@ export const toServedDirs = (partials: ServedDirPartial[]): ServedDir[] => {
 	for (const dir of dirs) {
 		// TODO instead of the error, should we allow multiple served paths for each input dir?
 		// This is mainly done to prevent duplicate work in watching the source directories.
-		if (uniqueDirs.has(dir.dir)) {
-			throw Error(`Duplicate servedDirs are not allowed: ${dir.dir}`);
+		if (uniqueDirs.has(dir.path)) {
+			throw Error(`Duplicate servedDirs are not allowed: ${dir.path}`);
 		}
-		uniqueDirs.add(dir.dir);
+		uniqueDirs.add(dir.path);
 	}
 	return dirs;
 };

--- a/src/build/ServedDir.ts
+++ b/src/build/ServedDir.ts
@@ -1,13 +1,25 @@
 import {resolve} from 'path';
 
 import type {PartialExcept} from '../index.js';
+import {stripStart} from '../utils/string.js';
 
 export interface ServedDir {
 	dir: string; // TODO rename? `source`, `sourceDir`, `path`
-	servedAt: string; // TODO rename?
+	servedAt: string; // TODO rename? `root`
+	base: string; // relative path stripped from requests to support e.g. for GitHub pages this is the repo name
 }
 
 export type ServedDirPartial = string | PartialExcept<ServedDir, 'dir'>;
+
+export const toServedDir = (dir: ServedDirPartial): ServedDir => {
+	if (typeof dir === 'string') dir = {dir};
+	const resolvedDir = resolve(dir.dir);
+	return {
+		dir: resolvedDir,
+		base: dir.base ? baseToRelativePath(dir.base) : '', // see `baseToRelativePath` for more
+		servedAt: dir.servedAt ? resolve(dir.servedAt) : resolvedDir,
+	};
+};
 
 export const toServedDirs = (partials: ServedDirPartial[]): ServedDir[] => {
 	const dirs = partials.map((d) => toServedDir(d));
@@ -23,11 +35,8 @@ export const toServedDirs = (partials: ServedDirPartial[]): ServedDir[] => {
 	return dirs;
 };
 
-export const toServedDir = (dir: ServedDirPartial): ServedDir => {
-	if (typeof dir === 'string') dir = {dir};
-	const resolvedDir = resolve(dir.dir);
-	return {
-		dir: resolvedDir,
-		servedAt: dir.servedAt ? resolve(dir.servedAt) : resolvedDir,
-	};
-};
+// `base` is the same as in `ServedDir` above
+export const stripBase = (path: string, base: string) => stripStart(stripStart(path, base), '/');
+
+// for compatibility with SvelteKit, the incoming `base` value may have a leading / or ./ or be a .
+const baseToRelativePath = (base: string): string => stripStart(stripStart(base, '.'), '/');

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -110,8 +110,8 @@ export const postprocess = (
 			if (cssCompilation !== undefined) {
 				let importPath: string | undefined;
 				for (const servedDir of ctx.servedDirs) {
-					if (cssCompilation.id.startsWith(servedDir.dir)) {
-						importPath = stripStart(cssCompilation.id, servedDir.servedAt);
+					if (cssCompilation.id.startsWith(servedDir.path)) {
+						importPath = stripStart(cssCompilation.id, servedDir.root);
 						break;
 					}
 				}

--- a/src/build/sveltekit.ts
+++ b/src/build/sveltekit.ts
@@ -1,0 +1,5 @@
+import {toPackageRepoName} from '../project/packageJson.js';
+import type {PackageJson} from '../project/packageJson.js';
+
+export const toSvelteKitBasePath = (pkg: PackageJson, dev: boolean): string =>
+	dev ? '' : `/${toPackageRepoName(pkg)}`;

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -77,14 +77,48 @@ to serve the contents of both `src/` and `src/client/` off of the root directory
 serve: [toBuildOutPath(true, 'browser', 'client'), toBuildOutPath(true, 'browser', '')],
 ```
 
-An optional `servedAt` property can be paired with the directories passed to `serve`:
+```ts
+type ServedDirPartial =
+	| string
+	| {
+			path: string;
+			root?: string;
+			base?: string;
+	  };
+```
+
+The optional `root` property can be paired with the directories passed to `serve`:
 
 ```ts
 config = {
 	serve: [
-		{dir: '/some/path', servedAt: '/some'},
-		'/a', // is the same as:
-		{dir: '/a'},
+		{path: '/some/path', root: '/some'},
+
+		// no root by default; these are all equivalent:
+		'/a',
+		{path: '/a'},
+		{path: '/a', root: ''},
+		{path: '/a', root: '.'},
+		{path: '/a', root: './'},
+	],
+};
+```
+
+The optional `base` property is used by `serve` to mimic the production behavior
+of static deployments like GitHub pages:
+
+```ts
+config = {
+	serve: [
+		{path: '/', base: 'my-package-name'}, // served at e.g. `myname.github.io/my-package-name`
+
+		// no base by default; these are all equivalent:
+		'/a',
+		{path: '/a'},
+		{path: '/a', base: ''},
+		{path: '/a', base: '/'},
+		{path: '/a', base: '.'},
+		{path: '/a', base: './'},
 	],
 };
 ```

--- a/src/fs/node.ts
+++ b/src/fs/node.ts
@@ -38,6 +38,13 @@ to the Node platform when the cost and friction are low.
 Eventually we'll want our code to run on other platforms, like Deno,
 and this practice will make future interop or migration more feasible.
 
+All of these functions return promises.
+This is important because they will conform to a future filesystem host interface,
+and because we need to support contexts like the browser and who knows what remote servers,
+an async-only filesystem interface is the way to go.
+
+TODO implement and use the Filesystem interface
+
 */
 export const pathExists = fsExtra.pathExists;
 export const stat = fsExtra.stat;

--- a/src/project/packageJson.ts
+++ b/src/project/packageJson.ts
@@ -3,7 +3,6 @@ import {join} from 'path';
 import {readJson} from '../fs/node.js';
 import {paths, groPaths, isThisProjectGro} from '../paths.js';
 import type {Json} from '../utils/json.js';
-import type {Obj} from '../index.js';
 
 /*
 
@@ -13,8 +12,11 @@ and in the future we should be able to easily auto-generate types for them.
 
 */
 
-export type PackageJson = Obj<Json>; // TODO generate one day
-export type GroPackageJson = Obj<Json>; // TODO generate one day
+export interface PackageJson {
+	[key: string]: Json;
+	name: string;
+}
+export interface GroPackageJson extends PackageJson {}
 
 let packageJson: PackageJson | undefined;
 let groPackageJson: GroPackageJson | undefined;
@@ -32,3 +34,7 @@ export const loadGroPackageJson = async (forceRefresh = false): Promise<GroPacka
 	}
 	return groPackageJson!;
 };
+
+// gets the "b" of "@a/b" for namespaced packages
+export const toPackageRepoName = (pkg: PackageJson): string =>
+	pkg.name.includes('/') ? pkg.name.split('/').slice(1).join('/') : pkg.name;

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -1,11 +1,12 @@
 import type {Task} from './task/task.js';
 import {createGroServer, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT} from './server/server.js';
 import {Filer} from './build/Filer.js';
-import {printPath} from './utils/print.js';
 import {loadHttpsCredentials} from './server/https.js';
+import type {ServedDirPartial} from './build/ServedDir.js';
 
 export interface TaskArgs {
 	_: string[];
+	serve?: ServedDirPartial[]; // takes priority over the CLI arg "_" above
 	host?: string;
 	port?: string | number;
 	nocert?: boolean;
@@ -15,14 +16,15 @@ export interface TaskArgs {
 
 export const task: Task<TaskArgs> = {
 	description: 'start static file server',
-	run: async ({log, args}): Promise<void> => {
+	run: async ({log, args, dev}): Promise<void> => {
 		const host = args.host || DEFAULT_SERVER_HOST;
 		const port = Number(args.port) || DEFAULT_SERVER_PORT;
-		const servedDirs = args._.length ? args._ : ['.'];
+		const servedDirs: ServedDirPartial[] = args.serve || (args._.length ? args._ : ['.']);
+		console.log('servedDirs', servedDirs);
 
 		// TODO this is inefficient for just serving files in a directory
 		// maybe we want a `lazy` flag?
-		const filer = new Filer({servedDirs});
+		const filer = new Filer({servedDirs, dev});
 		await filer.init();
 
 		// TODO write docs and validate args, maybe refactor, see also `dev.task.ts`
@@ -31,7 +33,7 @@ export const task: Task<TaskArgs> = {
 			: await loadHttpsCredentials(log, args.certfile, args.certkeyfile);
 
 		const server = createGroServer({filer, host, port, https});
-		log.info(`serving on ${server.host}:${server.port}`, ...servedDirs.map((d) => printPath(d)));
+		log.info(`serving on ${server.host}:${server.port}`, ...servedDirs);
 		await server.start();
 	},
 };

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -64,11 +64,6 @@ export const initOptions = (opts: InitialOptions): Options => {
 };
 
 export const createGroServer = (opts: InitialOptions): GroServer => {
-	// We don't want to have to worry about the security of the dev server.
-	if (process.env.NODE_ENV === 'production') {
-		throw Error('The dev server may only be run in development for security reasons.');
-	}
-
 	const options = initOptions(opts);
 	const {filer, host, port, https, log} = options;
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -69,10 +69,10 @@ export const createGroServer = (opts: InitialOptions): GroServer => {
 
 	let finalPort = port;
 	const nextPort = () => {
-		// hacky but w/e - these values are not final until `devServer.start` resolves
+		// hacky but w/e - these values are not final until `groServer.start` resolves
 		finalPort--;
 		listenOptions.port = finalPort;
-		(devServer as Assignable<GroServer>).port = finalPort;
+		(groServer as Assignable<GroServer>).port = finalPort;
 	};
 
 	const listenOptions: ListenOptions = {
@@ -109,7 +109,7 @@ export const createGroServer = (opts: InitialOptions): GroServer => {
 
 	let started = false;
 
-	const devServer: GroServer = {
+	const groServer: GroServer = {
 		server,
 		host,
 		port, // this value is not valid until `start` is complete
@@ -132,7 +132,7 @@ export const createGroServer = (opts: InitialOptions): GroServer => {
 			});
 		},
 	};
-	return devServer;
+	return groServer;
 };
 
 const createHttp2StreamListener = (filer: Filer, log: Logger): Http2StreamHandler => {

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -44,7 +44,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 			// `svelte-kit start` is not respecting the `svelte.config.cjs` property `paths.base`,
 			// so we serve up the dist ourselves. we were going to anyway, if we're being honest
 			args.serve = [
-				{dir: DIST_DIRNAME, base: dev ? '' : toSvelteKitBasePath(await loadPackageJson(), dev)},
+				{path: DIST_DIRNAME, base: dev ? '' : toSvelteKitBasePath(await loadPackageJson(), dev)},
 			];
 			await invokeTask('serve');
 		} else {


### PR DESCRIPTION
This makes `gro start` work with production SvelteKit builds. Currently, `svelte-kit start` fails if projects define a `kit.paths.base` other than `'.'`  in their `svelte.config.cjs`, so we can't just defer to `svelte-kit` like with build and dev. We should be able to improve the API of `gro start` a bit to make this work.