### PR TITLE
integrate gitignore with serve task

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@
   ([#164](https://github.com/feltcoop/gro/pull/164))
 - make serve task work for production SvelteKit builds
   ([#163](https://github.com/feltcoop/gro/pull/163))
+- add `src/project/gitignore.ts` with `isGitignored` and `loadGitignoreFilter`
+  ([#165](https://github.com/feltcoop/gro/pull/165))
 - add helper `toSvelteKitBasePath` to `src/build/sveltekit.ts`
   ([#163](https://github.com/feltcoop/gro/pull/163))
 - default to some environment variables

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -441,7 +441,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 	private onDirChange: FilerDirChangeCallback = async (change, filerDir) => {
 		const id =
 			change.path === EXTERNALS_SOURCE_ID ? EXTERNALS_SOURCE_ID : join(filerDir.dir, change.path);
-		console.log(red(change.type), id);
+		// console.log(red(change.type), id);
 		switch (change.type) {
 			case 'init':
 			case 'create':

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -441,7 +441,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 	private onDirChange: FilerDirChangeCallback = async (change, filerDir) => {
 		const id =
 			change.path === EXTERNALS_SOURCE_ID ? EXTERNALS_SOURCE_ID : join(filerDir.dir, change.path);
-		// console.log(red(change.type), id);
+		// console.log(red(change.type), id); // TODO maybe make an even more verbose log level for this?
 		switch (change.type) {
 			case 'init':
 			case 'create':

--- a/src/fs/watchNodeFs.ts
+++ b/src/fs/watchNodeFs.ts
@@ -3,6 +3,7 @@ import CheapWatch from 'cheap-watch';
 import type {PathStats, PathFilter} from './pathData.js';
 import {omitUndefined} from '../utils/object.js';
 import type {PartialExcept} from '../index.js';
+import {isIgnored} from '../project/gitignore.js';
 
 /*
 
@@ -28,11 +29,7 @@ export interface WatcherChangeCallback {
 
 export const DEBOUNCE_DEFAULT = 10;
 
-// ignore some things in a typical Gro project
-// note this set is exported & mutable 🤭
-// TODO use gitignore? expose gitignore interface to gro users?
-export const ignoredPaths = new Set(['.git', '.svelte', 'node_modules', '.DS_Store']);
-const defaultFilter: PathFilter = (file) => !ignoredPaths.has(file.path);
+const defaultFilter: PathFilter = (file) => !isIgnored(file.path);
 
 export interface Options {
 	dir: string;

--- a/src/fs/watchNodeFs.ts
+++ b/src/fs/watchNodeFs.ts
@@ -3,7 +3,7 @@ import CheapWatch from 'cheap-watch';
 import type {PathStats, PathFilter} from './pathData.js';
 import {omitUndefined} from '../utils/object.js';
 import type {PartialExcept} from '../index.js';
-import {isIgnored} from '../project/gitignore.js';
+import {isGitignored} from '../project/gitignore.js';
 
 /*
 
@@ -29,7 +29,7 @@ export interface WatcherChangeCallback {
 
 export const DEBOUNCE_DEFAULT = 10;
 
-const defaultFilter: PathFilter = (file) => !isIgnored(file.path);
+const defaultFilter: PathFilter = (file) => !isGitignored(file.path);
 
 export interface Options {
 	dir: string;

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -33,6 +33,7 @@ export const SVELTE_KIT_DEV_DIRNAME = '.svelte';
 export const SVELTE_KIT_BUILD_DIRNAME = 'build';
 export const SVELTE_KIT_DIST_DIRNAME = 'sveltekit'; // dist/sveltekit/<your_svelte_build>
 export const GIT_DIRNAME = '.git';
+export const GITIGNORE_FILENAME = '.gitignore';
 
 export const CONFIG_SOURCE_PATH = 'gro.config.ts';
 export const CONFIG_BUILD_PATH = 'gro.config.js';

--- a/src/project/gitignore.test.ts
+++ b/src/project/gitignore.test.ts
@@ -1,19 +1,37 @@
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
 
-import {isIgnored} from './gitignore.js';
+import {isGitignored, loadGitignoreFilter} from './gitignore.js';
 
-/* test_isIgnored */
-const test_isIgnored = suite('isIgnored');
+/* test_isGitignored */
+const test_isGitignored = suite('isGitignored');
 
-test_isIgnored('basic behavior', () => {
-	t.ok(isIgnored('node_modules'));
-	t.ok(!isIgnored('node_module'));
+test_isGitignored('basic behavior', () => {
+	t.ok(isGitignored('node_modules'));
+	t.ok(!isGitignored('node_module'));
 	// TODO ignore other patterns too, but this is sufficient for now
-	// t.ok(isIgnored('node_modules/a/b'));
-	// t.ok(isIgnored('a/b/node_modules/c/d'));
-	// t.ok(isIgnored('/a/b/node_modules/c/d'));
+	// t.ok(isGitignored('node_modules/a/b'));
+	// t.ok(isGitignored('a/b/node_modules/c/d'));
+	// t.ok(isGitignored('/a/b/node_modules/c/d'));
 });
 
-test_isIgnored.run();
-/* /test_isIgnored */
+test_isGitignored.run();
+/* /test_isGitignored */
+
+/* test_loadGitignoreFilter */
+const test_loadGitignoreFilter = suite('loadGitignoreFilter');
+
+test_loadGitignoreFilter('basic behavior', () => {
+	const filter1 = loadGitignoreFilter();
+	const filter2 = loadGitignoreFilter();
+	t.is(filter1, filter2);
+	const filter3 = loadGitignoreFilter(true);
+	t.is.not(filter1, filter3);
+	const filter4 = loadGitignoreFilter(false);
+	t.is(filter3, filter4);
+	const filter5 = loadGitignoreFilter(true);
+	t.is.not(filter4, filter5);
+});
+
+test_loadGitignoreFilter.run();
+/* /test_loadGitignoreFilter */

--- a/src/project/gitignore.test.ts
+++ b/src/project/gitignore.test.ts
@@ -1,0 +1,19 @@
+import {suite} from 'uvu';
+import * as t from 'uvu/assert';
+
+import {isIgnored} from './gitignore.js';
+
+/* test_isIgnored */
+const test_isIgnored = suite('isIgnored');
+
+test_isIgnored('basic behavior', () => {
+	t.ok(isIgnored('node_modules'));
+	t.ok(!isIgnored('node_module'));
+	// TODO ignore other patterns too, but this is sufficient for now
+	// t.ok(isIgnored('node_modules/a/b'));
+	// t.ok(isIgnored('a/b/node_modules/c/d'));
+	// t.ok(isIgnored('/a/b/node_modules/c/d'));
+});
+
+test_isIgnored.run();
+/* /test_isIgnored */

--- a/src/project/gitignore.ts
+++ b/src/project/gitignore.ts
@@ -53,6 +53,6 @@ export const loadGitignoreFilter = (forceRefresh = false): Filter => {
 export const isGitignored = (path: string, root = process.cwd()) =>
 	loadGitignoreFilter()(join(root, path));
 
-// TODO what's the better way to do this? mapping between
+// TODO what's the better way to do this? quick hacky mapping for one use case between
 // [picomatch](https://github.com/micromatch/picomatch) and `.gitignore`
 const toPattern = (line: string): string => stripStart(line, '/');

--- a/src/project/gitignore.ts
+++ b/src/project/gitignore.ts
@@ -54,6 +54,4 @@ export const isIgnored = (path: string, root = process.cwd()) => loadFilter()(jo
 
 // TODO what's the better way to do this? mapping between
 // [picomatch](https://github.com/micromatch/picomatch) and `.gitignore`
-const toPattern = (line: string): string => {
-	return stripStart(line, '/');
-};
+const toPattern = (line: string): string => stripStart(line, '/');

--- a/src/project/gitignore.ts
+++ b/src/project/gitignore.ts
@@ -50,8 +50,8 @@ export const loadGitignoreFilter = (forceRefresh = false): Filter => {
 	return filter;
 };
 
-export const isGitignored = (path: string, root = process.cwd()) =>
-	loadGitignoreFilter()(join(root, path));
+export const isGitignored = (path: string, root = process.cwd(), forceRefresh?: boolean) =>
+	loadGitignoreFilter(forceRefresh)(join(root, path));
 
 // TODO what's the better way to do this? quick hacky mapping for one use case between
 // [picomatch](https://github.com/micromatch/picomatch) and `.gitignore`

--- a/src/project/gitignore.ts
+++ b/src/project/gitignore.ts
@@ -1,0 +1,58 @@
+import {readFileSync} from 'fs';
+import {join} from 'path';
+import {createFilter} from '@rollup/pluginutils';
+
+import {
+	GITIGNORE_FILENAME,
+	GIT_DIRNAME,
+	NODE_MODULES_DIRNAME,
+	SVELTE_KIT_DEV_DIRNAME,
+} from '../paths.js';
+import {stripStart} from '../utils/string.js';
+
+/*
+
+This only handles the `gitignore` for the current working directory.
+
+If we need support for Gro simultaneously, see ./packageJson.ts as an example.
+
+*/
+
+interface Filter {
+	(id: string | unknown): boolean;
+}
+
+export let filter: Filter | null = null;
+
+export const DEFAULT_IGNORED_PATHS = [
+	GIT_DIRNAME,
+	SVELTE_KIT_DEV_DIRNAME,
+	NODE_MODULES_DIRNAME,
+	'.DS_Store',
+];
+
+// TODO need some mapping to match gitignore behavior correctly with nested directories
+export const loadFilter = (): Filter => {
+	if (filter) return filter;
+	let lines: string[];
+	try {
+		const gitignore = readFileSync(GITIGNORE_FILENAME, 'utf8');
+		lines = gitignore
+			.split('\n')
+			.map((line) => line.trim())
+			.filter(Boolean);
+		lines.push(GIT_DIRNAME); // special lil case
+	} catch (err) {
+		lines = DEFAULT_IGNORED_PATHS;
+	}
+	filter = createFilter(lines.map((line) => toPattern(line)));
+	return filter;
+};
+
+export const isIgnored = (path: string, root = process.cwd()) => loadFilter()(join(root, path));
+
+// TODO what's the better way to do this? mapping between
+// [picomatch](https://github.com/micromatch/picomatch) and `.gitignore`
+const toPattern = (line: string): string => {
+	return stripStart(line, '/');
+};

--- a/src/project/gitignore.ts
+++ b/src/project/gitignore.ts
@@ -22,9 +22,9 @@ interface Filter {
 	(id: string | unknown): boolean;
 }
 
-export let filter: Filter | null = null;
+let filter: Filter | null = null;
 
-export const DEFAULT_IGNORED_PATHS = [
+const DEFAULT_IGNORED_PATHS = [
 	GIT_DIRNAME,
 	SVELTE_KIT_DEV_DIRNAME,
 	NODE_MODULES_DIRNAME,
@@ -32,7 +32,8 @@ export const DEFAULT_IGNORED_PATHS = [
 ];
 
 // TODO need some mapping to match gitignore behavior correctly with nested directories
-export const loadFilter = (): Filter => {
+export const loadFilter = (forceRefresh = false): Filter => {
+	if (forceRefresh) filter = null;
 	if (filter) return filter;
 	let lines: string[];
 	try {

--- a/src/project/gitignore.ts
+++ b/src/project/gitignore.ts
@@ -32,7 +32,7 @@ const DEFAULT_IGNORED_PATHS = [
 ];
 
 // TODO need some mapping to match gitignore behavior correctly with nested directories
-export const loadFilter = (forceRefresh = false): Filter => {
+export const loadGitignoreFilter = (forceRefresh = false): Filter => {
 	if (forceRefresh) filter = null;
 	if (filter) return filter;
 	let lines: string[];
@@ -50,7 +50,8 @@ export const loadFilter = (forceRefresh = false): Filter => {
 	return filter;
 };
 
-export const isIgnored = (path: string, root = process.cwd()) => loadFilter()(join(root, path));
+export const isGitignored = (path: string, root = process.cwd()) =>
+	loadGitignoreFilter()(join(root, path));
 
 // TODO what's the better way to do this? mapping between
 // [picomatch](https://github.com/micromatch/picomatch) and `.gitignore`


### PR DESCRIPTION
This makes `gro serve` use `.gitignore`, if it's available. It adds two helpers around `.gitignore`, `isGitignored` and `loadGitignoreFilter`. It loads once and caches, and is synchronous for convenience. (normally filesystem interactions would be async, but this is a special case for more general use cases in tools we don't control)