### PR TITLE
fix formatting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.17.1
+
+- fix `gro format` to whitelist files off root when formatting `src/`
+  ([#166](https://github.com/feltcoop/gro/pull/166))
+
 ## 0.17.0
 
 - **break**: rename `src/utils/equal.ts` module from `deepEqual.ts`

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -27,7 +27,7 @@ import {inferEncoding} from '../fs/encoding.js';
 import type {Encoding} from '../fs/encoding.js';
 import {printBuildConfigLabel} from '../config/buildConfig.js';
 import type {BuildConfig} from '../config/buildConfig.js';
-import {DEFAULT_ECMA_SCRIPT_TARGET} from './tsBuildHelpers.js';
+import {DEFAULT_ECMA_SCRIPT_TARGET} from '../config/defaultBuildConfig.js';
 import type {EcmaScriptTarget} from './tsBuildHelpers.js';
 import {stripBase, toServedDirs} from './ServedDir.js';
 import type {ServedDir, ServedDirPartial} from './ServedDir.js';

--- a/src/build/esbuildBuildHelpers.ts
+++ b/src/build/esbuildBuildHelpers.ts
@@ -1,7 +1,7 @@
 import type esbuild from 'esbuild';
 import type * as sveltePreprocessEsbuild from 'svelte-preprocess-esbuild';
 
-import {DEFAULT_ECMA_SCRIPT_TARGET} from './tsBuildHelpers.js';
+import {DEFAULT_ECMA_SCRIPT_TARGET} from '../config/defaultBuildConfig.js';
 import type {EcmaScriptTarget} from './tsBuildHelpers.js';
 
 export interface EsbuildTransformOptions extends esbuild.TransformOptions {

--- a/src/build/formatDirectory.ts
+++ b/src/build/formatDirectory.ts
@@ -1,10 +1,21 @@
 import {spawnProcess} from '../utils/process.js';
 import type {SpawnResult} from '../utils/process.js';
-import {paths} from '../paths.js';
+import {
+	GITHUB_DIRNAME,
+	paths,
+	README_FILENAME,
+	SVELTE_KIT_CONFIG_FILENAME,
+	TSCONFIG_FILENAME,
+} from '../paths.js';
 
 // TODO ?
 const FORMATTED_EXTENSIONS = 'ts,js,json,svelte,html,css,md,yml';
-const FORMATTED_ROOT_PATHS = 'README.md,svelte.config.cjs,tsconfig.json,.gitignore,.github/**/*';
+const FORMATTED_ROOT_PATHS = `${[
+	README_FILENAME,
+	SVELTE_KIT_CONFIG_FILENAME,
+	TSCONFIG_FILENAME,
+	GITHUB_DIRNAME,
+].join(',')}/**/*`;
 
 // This formats a directory on the filesystem.
 // If the source directory is given, it also formats all of the root directory files.

--- a/src/build/formatDirectory.ts
+++ b/src/build/formatDirectory.ts
@@ -4,6 +4,7 @@ import {paths} from '../paths.js';
 
 // TODO ?
 const FORMATTED_EXTENSIONS = 'ts,js,json,svelte,html,css,md,yml';
+const FORMATTED_ROOT_PATHS = 'README.md,svelte.config.cjs,tsconfig.json,.gitignore,.github/**/*';
 
 // This formats a directory on the filesystem.
 // If the source directory is given, it also formats all of the root directory files.
@@ -13,7 +14,7 @@ export const formatDirectory = (directory: string, check = false): Promise<Spawn
 	const prettierArgs = ['prettier', check ? '--check' : '--write'];
 	prettierArgs.push(`${directory}**/*.{${FORMATTED_EXTENSIONS}}`);
 	if (directory === paths.source) {
-		prettierArgs.push(`${paths.root}*.{${FORMATTED_EXTENSIONS}}`);
+		prettierArgs.push(`${paths.root}{${FORMATTED_ROOT_PATHS}}`);
 	}
 	return spawnProcess('npx', prettierArgs);
 };

--- a/src/build/tsBuildHelpers.ts
+++ b/src/build/tsBuildHelpers.ts
@@ -3,6 +3,7 @@ import {join, dirname, resolve} from 'path';
 
 import {black, bgRed} from '../utils/terminal.js';
 import type {Logger} from '../utils/log.js';
+import {TSCONFIG_FILENAME} from '../paths.js';
 
 export type EcmaScriptTarget =
 	| 'es3'
@@ -14,8 +15,6 @@ export type EcmaScriptTarget =
 	| 'es2019'
 	| 'es2020'
 	| 'esnext';
-
-export const DEFAULT_ECMA_SCRIPT_TARGET: EcmaScriptTarget = 'es2020';
 
 // TODO remove eventually. might want to default the Gro config target to the
 // export const toEcmaScriptTarget = (target: ts.ScriptTarget | undefined): EcmaScriptTarget => {
@@ -73,7 +72,7 @@ export const loadTsconfig = (
 	forceReload = false,
 ): TsConfig => {
 	// create a canonical cache key that can accept multiple variations
-	const cacheKey = join(resolve(basePath), tsconfigPath || 'tsconfig.json');
+	const cacheKey = join(resolve(basePath), tsconfigPath || TSCONFIG_FILENAME);
 	if (!forceReload) {
 		const cachedTsconfig = tsconfigCache.get(cacheKey);
 		if (cachedTsconfig) return cachedTsconfig;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -12,7 +12,7 @@ import type {Logger} from '../utils/log.js';
 import {importTs} from '../fs/importTs.js';
 import {pathExists} from '../fs/node.js';
 import {PRIMARY_NODE_BUILD_CONFIG} from './defaultBuildConfig.js';
-import {DEFAULT_ECMA_SCRIPT_TARGET} from '../build/tsBuildHelpers.js';
+import {DEFAULT_ECMA_SCRIPT_TARGET} from './defaultBuildConfig.js';
 import type {EcmaScriptTarget} from '../build/tsBuildHelpers.js';
 import {omitUndefined} from '../utils/object.js';
 import type {ServedDirPartial} from '../build/ServedDir.js';

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -10,6 +10,9 @@ import {
 } from '../paths.js';
 import {pathExists} from '../fs/node.js';
 import {getExtensions} from '../fs/mime.js';
+import type {EcmaScriptTarget} from '../build/tsBuildHelpers.js';
+
+export const DEFAULT_ECMA_SCRIPT_TARGET: EcmaScriptTarget = 'es2020';
 
 export const GIT_DEPLOY_BRANCH = 'main'; // deploy and publish from this branch
 

--- a/src/fs/importTs.ts
+++ b/src/fs/importTs.ts
@@ -5,7 +5,7 @@ import {randomInt} from '../utils/random.js';
 import {createEsbuildBuilder} from '../build/esbuildBuilder.js';
 import type {BuildConfig} from '../config/buildConfig.js';
 import type {BuildContext, TextBuildSource} from '../build/builder.js';
-import {DEFAULT_ECMA_SCRIPT_TARGET} from '../build/tsBuildHelpers.js';
+import {DEFAULT_ECMA_SCRIPT_TARGET} from '../config/defaultBuildConfig.js';
 import {outputFile, readFile, remove} from './node.js';
 import {basename, dirname, join} from 'path';
 import {stripStart} from '../utils/string.js';

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -28,13 +28,6 @@ export const SOURCE_DIR = `${SOURCE_DIRNAME}/`;
 export const BUILD_DIR = `${BUILD_DIRNAME}/`;
 export const DIST_DIR = `${DIST_DIRNAME}/`;
 
-export const NODE_MODULES_DIRNAME = 'node_modules';
-export const SVELTE_KIT_DEV_DIRNAME = '.svelte';
-export const SVELTE_KIT_BUILD_DIRNAME = 'build';
-export const SVELTE_KIT_DIST_DIRNAME = 'sveltekit'; // dist/sveltekit/<your_svelte_build>
-export const GIT_DIRNAME = '.git';
-export const GITIGNORE_FILENAME = '.gitignore';
-
 export const CONFIG_SOURCE_PATH = 'gro.config.ts';
 export const CONFIG_BUILD_PATH = 'gro.config.js';
 
@@ -53,6 +46,17 @@ export const SOURCEMAP_EXTENSION = '.map';
 export const JS_SOURCEMAP_EXTENSION = '.js.map';
 export const SVELTE_JS_SOURCEMAP_EXTENSION = '.svelte.js.map';
 export const SVELTE_CSS_SOURCEMAP_EXTENSION = '.svelte.css.map';
+
+export const README_FILENAME = 'README.md';
+export const SVELTE_KIT_CONFIG_FILENAME = 'svelte.config.cjs';
+export const SVELTE_KIT_DEV_DIRNAME = '.svelte';
+export const SVELTE_KIT_BUILD_DIRNAME = 'build';
+export const SVELTE_KIT_DIST_DIRNAME = 'sveltekit'; // dist/sveltekit/<your_svelte_build>
+export const NODE_MODULES_DIRNAME = 'node_modules';
+export const GITHUB_DIRNAME = '.github';
+export const GIT_DIRNAME = '.git';
+export const GITIGNORE_FILENAME = '.gitignore';
+export const TSCONFIG_FILENAME = 'tsconfig.json';
 
 export interface Paths {
 	root: string;


### PR DESCRIPTION
This fixes `gro format` behavior when formatting `src/`. Previously, it detected that special condition and tried to format everything else in your project, which was the useful thing for our workflows. This switches that logic to use a whitelist, which allows us to opt into exactly the files we want to format outside of `src/`.