### PR TITLE
fix tests when none are present

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 - fix `gro format` to whitelist files off root when formatting `src/`
   ([#166](https://github.com/feltcoop/gro/pull/166))
+- fix `gro test` to gracefully handle projects with no Gro build outputs
+  ([#167](https://github.com/feltcoop/gro/pull/167))
+- run `gro check` before building in `gro version`
+  ([#167](https://github.com/feltcoop/gro/pull/167))
 
 ## 0.17.0
 

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -5,6 +5,9 @@ import {Timings} from './utils/time.js';
 import {spawnProcess} from './utils/process.js';
 import {toBuildOutPath, toRootPath} from './paths.js';
 import {PRIMARY_NODE_BUILD_CONFIG_NAME} from './config/defaultBuildConfig.js';
+import {pathExists} from './fs/node.js';
+import {loadGroConfig} from './config/config.js';
+import {buildSourceDirectory} from './build/buildSourceDirectory.js';
 
 // Runs the project's tests: `gro test [...args]`
 // Args are passed through directly to `uvu`'s CLI:
@@ -17,12 +20,31 @@ export const task: Task = {
 	run: async ({dev, log, args}): Promise<void> => {
 		const timings = new Timings();
 
-		const dir = toRootPath(toBuildOutPath(dev, PRIMARY_NODE_BUILD_CONFIG_NAME));
+		const testsBuildDir = toBuildOutPath(dev, PRIMARY_NODE_BUILD_CONFIG_NAME);
+
+		// TODO cleaner way to detect & rebuild?
+		if (!(await pathExists(testsBuildDir))) {
+			const timingToLoadConfig = timings.start('load config');
+			const config = await loadGroConfig(dev);
+			timingToLoadConfig();
+
+			const timingToPrebuild = timings.start('prebuild');
+			await buildSourceDirectory(config, dev, log);
+			timingToPrebuild();
+
+			// Projects may not define any artifacts for the Node build,
+			// and we don't force anything out in that case,
+			// so just exit early if that happens.
+			if (!(await pathExists(testsBuildDir))) {
+				log.info('no tests found');
+				return;
+			}
+		}
 
 		const timeToRunUvu = timings.start('run test with uvu');
 		const testRunResult = await spawnProcess('npx', [
 			'uvu',
-			dir,
+			toRootPath(testsBuildDir),
 			...(args._.length ? args._ : DEFAULT_TEST_FILE_PATTERNS),
 			...process.argv.slice(3),
 		]);

--- a/src/version.task.ts
+++ b/src/version.task.ts
@@ -58,6 +58,7 @@ export const task: Task<TaskArgs> = {
 		// think of a better way - maybe config+defaults?
 		// I don't want to touch Gro's prod build pipeline right now using package.json `"preversion"`
 		if (!isThisProjectGro) {
+			await invokeTask('check');
 			await invokeTask('build');
 		}
 		await spawnProcess('npm', ['version', ...process.argv.slice(3)]);


### PR DESCRIPTION
Currently, projects with no tests fail `gro check`. That can't be right. Also `gro version` should run `gro check` before running `gro build`.