### PR TITLE
update dev and build tasks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.18.0
 
-- change the interface of `gro dev`
+- **break**: change the interface of `gro dev` and `gro build` to support the API server
   ([#168](https://github.com/feltcoop/gro/pull/168))
 
 ## 0.17.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.18.0
+
+- change the interface of `gro dev`
+  ([#168](https://github.com/feltcoop/gro/pull/168))
+
 ## 0.17.1
 
 - fix `gro format` to whitelist files off root when formatting `src/`

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -6,6 +6,7 @@ import {
 	DIST_DIR,
 	isThisProjectGro,
 	sourceIdToBasePath,
+	SVELTE_KIT_APP_DIRNAME,
 	SVELTE_KIT_BUILD_DIRNAME,
 	toBuildExtension,
 } from './paths.js';
@@ -96,10 +97,10 @@ export const task: Task<TaskArgs, TaskEvents> = {
 			// TODO remove this when SvelteKit has its duplicate build dir bug fixed
 			// TODO take a look at its issues/codebase for fix
 			if (
-				(await pathExists(`${SVELTE_KIT_BUILD_DIRNAME}/_app`)) &&
-				(await pathExists(`${SVELTE_KIT_BUILD_DIRNAME}/app`))
+				(await pathExists(`${SVELTE_KIT_BUILD_DIRNAME}/_${SVELTE_KIT_APP_DIRNAME}`)) &&
+				(await pathExists(`${SVELTE_KIT_BUILD_DIRNAME}/${SVELTE_KIT_APP_DIRNAME}`))
 			) {
-				await remove(`${SVELTE_KIT_BUILD_DIRNAME}/_app`);
+				await remove(`${SVELTE_KIT_BUILD_DIRNAME}/_${SVELTE_KIT_APP_DIRNAME}`);
 			}
 			// TODO remove this when we implement something like `adapter-felt`
 			// We implement the adapting Svelte server ourselves in production,

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -30,6 +30,8 @@ export interface MapDependencyToSourceId {
 
 // TODO this could be `MapBuildIdToSourceId` and infer externals from the `basePath`
 export const mapDependencyToSourceId: MapDependencyToSourceId = (dependency, buildDir) => {
+	// TODO this is failing with build ids like `terser` - should that be the build id? yes?
+	// dependency.external
 	const basePath = toBuildBasePath(dependency.buildId, buildDir);
 	if (dependency.external) {
 		return EXTERNALS_SOURCE_ID;

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -10,7 +10,8 @@ import type {GroConfig} from './config/config.js';
 import {loadGroConfig} from './config/config.js';
 import type {ServedDirPartial} from './build/ServedDir.js';
 import {loadHttpsCredentials} from './server/https.js';
-import {createRestartableProcess, spawn, SpawnedProcess} from './utils/process.js';
+import {createRestartableProcess, spawn} from './utils/process.js';
+import type {SpawnedProcess} from './utils/process.js';
 import {
 	hasApiServerConfig,
 	API_SERVER_BUILD_BASE_PATH,

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -51,6 +51,7 @@ export const README_FILENAME = 'README.md';
 export const SVELTE_KIT_CONFIG_FILENAME = 'svelte.config.cjs';
 export const SVELTE_KIT_DEV_DIRNAME = '.svelte';
 export const SVELTE_KIT_BUILD_DIRNAME = 'build';
+export const SVELTE_KIT_APP_DIRNAME = 'app'; // same as /svelte.config.cjs `kit.appDir`
 export const NODE_MODULES_DIRNAME = 'node_modules';
 export const GITHUB_DIRNAME = '.github';
 export const GIT_DIRNAME = '.git';

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -51,7 +51,6 @@ export const README_FILENAME = 'README.md';
 export const SVELTE_KIT_CONFIG_FILENAME = 'svelte.config.cjs';
 export const SVELTE_KIT_DEV_DIRNAME = '.svelte';
 export const SVELTE_KIT_BUILD_DIRNAME = 'build';
-export const SVELTE_KIT_DIST_DIRNAME = 'sveltekit'; // dist/sveltekit/<your_svelte_build>
 export const NODE_MODULES_DIRNAME = 'node_modules';
 export const GITHUB_DIRNAME = '.github';
 export const GIT_DIRNAME = '.git';

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -125,7 +125,10 @@ export const toBuildBasePath = (buildId: string, buildDir = paths.build): string
 			return rootPath.substring(i + 1);
 		}
 	}
-	throw Error(`Invalid build id, cannot convert to build base path: ${buildId}`);
+	// TODO ? errors on inputs like `terser` - should that be allowed to be a `buildId`??
+	// can reproduce by removing a dependency (when turned off I think?)
+	// throw Error(`Invalid build id, cannot convert to build base path: ${buildId}`);
+	return buildId;
 };
 
 // TODO probably change this to use a regexp (benchmark?)

--- a/src/project/build.ts
+++ b/src/project/build.ts
@@ -19,7 +19,7 @@ import {plainCssPlugin} from './rollup-plugin-plain-css.js';
 import {outputCssPlugin} from './rollup-plugin-output-css.js';
 import {createCssCache, CssCache} from './cssCache.js';
 import {groJsonPlugin} from './rollup-plugin-gro-json.js';
-import {groTerserPlugin} from './rollup-plugin-gro-terser.js';
+// import {groTerserPlugin} from './rollup-plugin-gro-terser.js';
 import {groEsbuildPlugin} from './rollup-plugin-gro-esbuild.js';
 import {groSveltePlugin} from './rollup-plugin-gro-svelte.js';
 import type {GroCssBuild} from './types.js';
@@ -136,7 +136,8 @@ const createInputOptions = (inputFile: string, options: Options, _log: Logger): 
 			}),
 			resolvePlugin({preferBuiltins: true}),
 			commonjsPlugin(),
-			...(dev ? [] : [groTerserPlugin({minifyOptions: {sourceMap: sourcemap}})]),
+			// TODO re-enable terser, but add a config option (probably `terser` object)
+			// ...(dev ? [] : [groTerserPlugin({minifyOptions: {sourceMap: sourcemap}})]),
 		],
 
 		// >> advanced input options


### PR DESCRIPTION
This changes `gro dev` and `gro build` with breaking interface changes. The goal is to unify as much of the API as possible with the `DevTaskContext` (better name?).