### PR TITLE
fix start task

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.18.1
+
+- fix `gro start` task to work with SvelteKit and the API server if detected
+  ([#169](https://github.com/feltcoop/gro/pull/169))
+
 ## 0.18.0
 
 - **break**: change the interface of `gro dev` and `gro build` to support the API server

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -46,6 +46,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 			args.serve = [
 				{path: DIST_DIRNAME, base: dev ? '' : toSvelteKitBasePath(await loadPackageJson(), dev)},
 			];
+			// TODO set port to 3000 or whatever it should be
 			await invokeTask('serve');
 		} else {
 			const inputs: {

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -10,7 +10,7 @@ import {green} from './utils/terminal.js';
 import type {BuildConfig} from './config/buildConfig.js';
 import {printTiming} from './utils/print.js';
 import {resolveInputFiles} from './build/utils.js';
-import {hasSvelteKitFrontend} from './config/defaultBuildConfig.js';
+import {hasApiServer, hasSvelteKitFrontend} from './config/defaultBuildConfig.js';
 import type {TaskArgs as ServeTaskArgs} from './serve.task.js';
 import {toSvelteKitBasePath} from './build/sveltekit.js';
 import {loadPackageJson} from './project/packageJson.js';
@@ -40,7 +40,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		timingToLoadConfig();
 
 		// detect if we're in a SvelteKit project, and prefer that to Gro's system for now
-		if (await hasSvelteKitFrontend()) {
+		if ((await hasSvelteKitFrontend()) && !(await hasApiServer())) {
 			// `svelte-kit start` is not respecting the `svelte.config.cjs` property `paths.base`,
 			// so we serve up the dist ourselves. we were going to anyway, if we're being honest
 			args.serve = [


### PR DESCRIPTION
This fixes the `gro start` task to work with SvelteKit and the API server if detected.

- [x] basic behavior
- [ ] ~~port for static deployments (see the TODO added in the code)~~