### PR TITLE
fix port for gro start on static builds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.18.2
+
+- fix `gro start` task to serve static builds to port 3000 like the others
+  ([#170](https://github.com/feltcoop/gro/pull/170))
+
 ## 0.18.1
 
 - fix `gro start` task to work with SvelteKit and the API server if detected

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -51,7 +51,7 @@ export const API_SERVER_BUILD_CONFIG: BuildConfig = {
 // TODO change to remove the second, search upwards for an open port
 export const API_SERVER_DEFAULT_PORT_PROD = 3000;
 export const API_SERVER_DEFAULT_PORT_DEV = 3001;
-export const toApiServePort = (dev: boolean): number =>
+export const toApiServerPort = (dev: boolean): number =>
 	dev ? API_SERVER_DEFAULT_PORT_DEV : API_SERVER_DEFAULT_PORT_PROD;
 export const toApiServerBuildPath = (dev: boolean, buildDir = paths.build): string =>
 	toBuildOutPath(dev, API_SERVER_BUILD_CONFIG_NAME, API_SERVER_BUILD_BASE_PATH, buildDir);

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -51,6 +51,8 @@ export const API_SERVER_BUILD_CONFIG: BuildConfig = {
 // TODO change to remove the second, search upwards for an open port
 export const API_SERVER_DEFAULT_PORT_PROD = 3000;
 export const API_SERVER_DEFAULT_PORT_DEV = 3001;
+export const toApiServePort = (dev: boolean): number =>
+	dev ? API_SERVER_DEFAULT_PORT_DEV : API_SERVER_DEFAULT_PORT_PROD;
 export const toApiServerBuildPath = (dev: boolean, buildDir = paths.build): string =>
 	toBuildOutPath(dev, API_SERVER_BUILD_CONFIG_NAME, API_SERVER_BUILD_BASE_PATH, buildDir);
 

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -10,7 +10,7 @@ import {green} from './utils/terminal.js';
 import type {BuildConfig} from './config/buildConfig.js';
 import {printTiming} from './utils/print.js';
 import {resolveInputFiles} from './build/utils.js';
-import {hasApiServer, hasSvelteKitFrontend} from './config/defaultBuildConfig.js';
+import {hasApiServer, hasSvelteKitFrontend, toApiServePort} from './config/defaultBuildConfig.js';
 import type {TaskArgs as ServeTaskArgs} from './serve.task.js';
 import {toSvelteKitBasePath} from './build/sveltekit.js';
 import {loadPackageJson} from './project/packageJson.js';
@@ -46,8 +46,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 			args.serve = [
 				{path: DIST_DIRNAME, base: dev ? '' : toSvelteKitBasePath(await loadPackageJson(), dev)},
 			];
-			// TODO set port to 3000 or whatever it should be
-			await invokeTask('serve');
+			await invokeTask('serve', {...args, port: args.port || toApiServePort(dev)});
 		} else {
 			const inputs: {
 				buildConfig: BuildConfig;

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -10,7 +10,7 @@ import {green} from './utils/terminal.js';
 import type {BuildConfig} from './config/buildConfig.js';
 import {printTiming} from './utils/print.js';
 import {resolveInputFiles} from './build/utils.js';
-import {hasApiServer, hasSvelteKitFrontend, toApiServePort} from './config/defaultBuildConfig.js';
+import {hasApiServer, hasSvelteKitFrontend, toApiServerPort} from './config/defaultBuildConfig.js';
 import type {TaskArgs as ServeTaskArgs} from './serve.task.js';
 import {toSvelteKitBasePath} from './build/sveltekit.js';
 import {loadPackageJson} from './project/packageJson.js';
@@ -46,7 +46,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 			args.serve = [
 				{path: DIST_DIRNAME, base: dev ? '' : toSvelteKitBasePath(await loadPackageJson(), dev)},
 			];
-			await invokeTask('serve', {...args, port: args.port || toApiServePort(dev)});
+			await invokeTask('serve', {...args, port: args.port || toApiServerPort(dev)});
 		} else {
 			const inputs: {
 				buildConfig: BuildConfig;


### PR DESCRIPTION
For static builds, `gro start` was serving on Gro's development ports; this aligns them with the other production builds on port 3000.