### PR TITLE
fix gitignore and refactor filters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,12 @@
 
 ## 0.19.0
 
-- extract the `Filesystem` interface and thread it everywhere from `src/cli/invoke.ts` and tests
+- **break**: extract the `Filesystem` interface and
+  thread it everywhere from `src/cli/invoke.ts` and tests
   ([#171](https://github.com/feltcoop/gro/pull/171))
+- **break**: replace `src/project/gitignore.ts` helper `isGitignored`
+  with `src/fs/pathFilter.ts` helper `toPathFilter`
+  ([#172](https://github.com/feltcoop/gro/pull/172))
 
 ## 0.18.2
 
@@ -38,7 +42,7 @@
   ([#164](https://github.com/feltcoop/gro/pull/164))
 - make serve task work for production SvelteKit builds
   ([#163](https://github.com/feltcoop/gro/pull/163))
-- add `src/project/gitignore.ts` with `loadGitignoreFilter`
+- add `src/project/gitignore.ts` with `isGitignored` and `loadGitignoreFilter`
   ([#165](https://github.com/feltcoop/gro/pull/165))
 - add helper `toSvelteKitBasePath` to `src/build/sveltekit.ts`
   ([#163](https://github.com/feltcoop/gro/pull/163))

--- a/changelog.md
+++ b/changelog.md
@@ -38,7 +38,7 @@
   ([#164](https://github.com/feltcoop/gro/pull/164))
 - make serve task work for production SvelteKit builds
   ([#163](https://github.com/feltcoop/gro/pull/163))
-- add `src/project/gitignore.ts` with `isGitignored` and `loadGitignoreFilter`
+- add `src/project/gitignore.ts` with `loadGitignoreFilter`
   ([#165](https://github.com/feltcoop/gro/pull/165))
 - add helper `toSvelteKitBasePath` to `src/build/sveltekit.ts`
   ([#163](https://github.com/feltcoop/gro/pull/163))

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -90,7 +90,7 @@ export interface Options {
 	target: EcmaScriptTarget;
 	watch: boolean;
 	watcherDebounce: number | undefined;
-	filter: PathFilter | null;
+	filter: PathFilter | null | undefined;
 	cleanOutputDirs: boolean;
 	log: Logger;
 }
@@ -155,7 +155,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 		target: DEFAULT_ECMA_SCRIPT_TARGET,
 		watch: true,
 		watcherDebounce: undefined,
-		filter: null,
+		filter: undefined,
 		cleanOutputDirs: true,
 		...omitUndefined(opts),
 		log: opts.log || new SystemLogger(printLogLabel('filer')),

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -50,7 +50,7 @@ import {queueExternalsBuild} from './externalsBuilder.js';
 import type {SourceMeta} from './sourceMeta.js';
 import {deleteSourceMeta, updateSourceMeta, cleanSourceMeta, initSourceMeta} from './sourceMeta.js';
 import type {OmitStrict, Assignable, PartialExcept} from '../index.js';
-import type {PathFilter} from '../fs/pathData.js';
+import type {PathFilter} from '../fs/pathFilter.js';
 
 /*
 

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -90,7 +90,7 @@ export interface Options {
 	target: EcmaScriptTarget;
 	watch: boolean;
 	watcherDebounce: number | undefined;
-	filter: PathFilter | undefined;
+	filter: PathFilter | null;
 	cleanOutputDirs: boolean;
 	log: Logger;
 }
@@ -155,7 +155,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 		target: DEFAULT_ECMA_SCRIPT_TARGET,
 		watch: true,
 		watcherDebounce: undefined,
-		filter: undefined,
+		filter: null,
 		cleanOutputDirs: true,
 		...omitUndefined(opts),
 		log: opts.log || new SystemLogger(printLogLabel('filer')),
@@ -221,7 +221,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 		this.target = target;
 		this.log = log;
 		this.dirs = createFilerDirs(
-			this.fs,
+			fs,
 			sourceDirs,
 			servedDirs,
 			buildDir,
@@ -1126,7 +1126,7 @@ const createFilerDirs = (
 	onChange: FilerDirChangeCallback,
 	watch: boolean,
 	watcherDebounce: number | undefined,
-	filter: PathFilter | undefined,
+	filter: PathFilter | null,
 ): FilerDir[] => {
 	const dirs: FilerDir[] = [];
 	for (const sourceDir of sourceDirs) {

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -1126,11 +1126,11 @@ const createFilerDirs = (
 	onChange: FilerDirChangeCallback,
 	watch: boolean,
 	watcherDebounce: number | undefined,
-	filter: PathFilter | null,
+	filter: PathFilter | null | undefined,
 ): FilerDir[] => {
 	const dirs: FilerDir[] = [];
 	for (const sourceDir of sourceDirs) {
-		dirs.push(createFilerDir(fs, sourceDir, true, onChange, filter, watch, watcherDebounce));
+		dirs.push(createFilerDir(fs, sourceDir, true, onChange, watch, watcherDebounce, filter));
 	}
 	for (const servedDir of servedDirs) {
 		// If a `servedDir` is inside a source or externals directory,
@@ -1145,7 +1145,7 @@ const createFilerDirs = (
 			!servedDir.path.startsWith(buildDir)
 		) {
 			dirs.push(
-				createFilerDir(fs, servedDir.path, false, onChange, filter, watch, watcherDebounce),
+				createFilerDir(fs, servedDir.path, false, onChange, watch, watcherDebounce, filter),
 			);
 		}
 	}

--- a/src/build/FilerDir.ts
+++ b/src/build/FilerDir.ts
@@ -34,10 +34,11 @@ export const createFilerDir = (
 	dir: string,
 	buildable: boolean,
 	onChange: FilerDirChangeCallback,
-	filter: PathFilter | undefined,
+	filter: PathFilter | null,
 	watch: boolean,
 	watcherDebounce: number = DEBOUNCE_DEFAULT,
 ): FilerDir => {
+	// TODO abstract this from the Node filesystem
 	const watcher = watchNodeFs({
 		dir,
 		onChange: (change) => onChange(change, filerDir),

--- a/src/build/FilerDir.ts
+++ b/src/build/FilerDir.ts
@@ -1,4 +1,4 @@
-import {DEBOUNCE_DEFAULT, watchNodeFs} from '../fs/watchNodeFs.js';
+import {watchNodeFs} from '../fs/watchNodeFs.js';
 import type {WatchNodeFs} from '../fs/watchNodeFs.js';
 import type {PathFilter, PathStats} from '../fs/pathData.js';
 import type {Filesystem} from '../fs/filesystem.js';
@@ -34,17 +34,17 @@ export const createFilerDir = (
 	dir: string,
 	buildable: boolean,
 	onChange: FilerDirChangeCallback,
-	filter: PathFilter | null,
 	watch: boolean,
-	watcherDebounce: number = DEBOUNCE_DEFAULT,
+	watcherDebounce: number | undefined,
+	filter: PathFilter | null | undefined,
 ): FilerDir => {
 	// TODO abstract this from the Node filesystem
 	const watcher = watchNodeFs({
 		dir,
 		onChange: (change) => onChange(change, filerDir),
-		filter,
 		watch,
 		debounce: watcherDebounce,
+		filter,
 	});
 	const close = () => {
 		watcher.close();

--- a/src/build/FilerDir.ts
+++ b/src/build/FilerDir.ts
@@ -1,6 +1,7 @@
 import {watchNodeFs} from '../fs/watchNodeFs.js';
 import type {WatchNodeFs} from '../fs/watchNodeFs.js';
-import type {PathFilter, PathStats} from '../fs/pathData.js';
+import type {PathStats} from '../fs/pathData.js';
+import type {PathFilter} from '../fs/pathFilter.js';
 import type {Filesystem} from '../fs/filesystem.js';
 
 // Buildable filer dirs are watched, built, and written to disk.

--- a/src/build/buildSourceDirectory.ts
+++ b/src/build/buildSourceDirectory.ts
@@ -27,13 +27,13 @@ export const buildSourceDirectory = async (
 	const timingToCreateFiler = timings.start('create filer');
 	const filer = new Filer({
 		fs,
+		dev,
 		builder: createDefaultBuilder(),
 		sourceDirs: [paths.source],
 		buildConfigs: config.builds,
 		watch: false,
 		target: config.target,
 		sourcemap: config.sourcemap,
-		dev,
 	});
 	timingToCreateFiler();
 

--- a/src/client/SourceId.svelte
+++ b/src/client/SourceId.svelte
@@ -5,7 +5,7 @@
 
 	export let id: string;
 
-	$: displayed = id.startsWith($ps.sourceDir) ? id.slice($ps.sourceDir.length - 1) : id;
+	$: displayed = id.startsWith($ps.sourceDir) ? id.substring($ps.sourceDir.length - 1) : id;
 </script>
 
 <span class="source-id">{displayed}</span>

--- a/src/client/pathHelpers.ts
+++ b/src/client/pathHelpers.ts
@@ -14,7 +14,7 @@ export const toBasePath = (id: string, buildDir: string): string => {
 		if (id[i] === '/') {
 			slashCount++;
 			if (slashCount === 2) {
-				return (toBasePathCache[cacheKey] = id.slice(i));
+				return (toBasePathCache[cacheKey] = id.substring(i));
 			}
 		}
 	}
@@ -33,5 +33,5 @@ export const toRootPath = (id: string, buildDir: string): string => {
 		if (char === '/') break;
 		start--;
 	}
-	return (toRootPathCache[cacheKey] = id.slice(start - 1));
+	return (toRootPathCache[cacheKey] = id.substring(start - 1));
 };

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -60,6 +60,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		const timingToCreateFiler = timings.start('create filer');
 		const filer = new Filer({
 			fs,
+			dev,
 			builder: createDefaultBuilder(),
 			sourceDirs: [paths.source],
 			servedDirs: config.serve || getDefaultServedDirs(config),

--- a/src/fs/file.ts
+++ b/src/fs/file.ts
@@ -1,0 +1,5 @@
+// TODO more
+
+export interface FileFilter {
+	(id: string): boolean;
+}

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -1,6 +1,7 @@
 import type {PathLike, Stats, CopyOptions, MoveOptions} from 'fs-extra';
 
-import type {PathFilter, PathStats} from './pathData.js';
+import type {PathStats} from './pathData.js';
+import type {PathFilter} from './pathFilter.js';
 
 export type {Stats} from 'fs-extra';
 

--- a/src/fs/node.ts
+++ b/src/fs/node.ts
@@ -2,8 +2,9 @@ import CheapWatch from 'cheap-watch';
 import fsExtra from 'fs-extra';
 
 import type {Filesystem} from './filesystem.js';
-import type {PathStats, PathFilter} from './pathData.js';
+import type {PathStats} from './pathData.js';
 import {sortMap, compareSimpleMapEntries} from '../utils/map.js';
+import type {PathFilter} from './pathData.js';
 
 // This uses `CheapWatch` which probably isn't the fastest, but it works fine for now.
 // TODO should this API be changed to only include files and not directories?

--- a/src/fs/node.ts
+++ b/src/fs/node.ts
@@ -4,7 +4,7 @@ import fsExtra from 'fs-extra';
 import type {Filesystem} from './filesystem.js';
 import type {PathStats} from './pathData.js';
 import {sortMap, compareSimpleMapEntries} from '../utils/map.js';
-import type {PathFilter} from './pathData.js';
+import type {PathFilter} from './pathFilter.js';
 
 // This uses `CheapWatch` which probably isn't the fastest, but it works fine for now.
 // TODO should this API be changed to only include files and not directories?

--- a/src/fs/pathData.ts
+++ b/src/fs/pathData.ts
@@ -8,13 +8,14 @@ export interface PathStats {
 	isDirectory(): boolean;
 }
 
-export interface PathFilter {
-	(file: {path: string; stats: PathStats}): boolean;
-}
-
 export const toPathData = (id: string, stats: PathStats): PathData => {
 	return {
 		id,
 		isDirectory: stats.isDirectory(),
 	};
 };
+
+// This is a subset of the `cheap-watch` types designed for browser compatibility.
+export interface PathFilter {
+	(file: {path: string; stats: PathStats}): boolean;
+}

--- a/src/fs/pathData.ts
+++ b/src/fs/pathData.ts
@@ -14,8 +14,3 @@ export const toPathData = (id: string, stats: PathStats): PathData => {
 		isDirectory: stats.isDirectory(),
 	};
 };
-
-// This is a subset of the `cheap-watch` types designed for browser compatibility.
-export interface PathFilter {
-	(file: {path: string; stats: PathStats}): boolean;
-}

--- a/src/fs/pathFilter.ts
+++ b/src/fs/pathFilter.ts
@@ -9,5 +9,5 @@ export interface PathFilter {
 	(file: {path: string; stats: PathStats}): boolean;
 }
 
-export const toPathFilter = (filter: FileFilter, root = paths.root): PathFilter => ({path}) =>
-	!filter(join(root, path));
+export const toPathFilter = (exclude: FileFilter, root = paths.root): PathFilter => ({path}) =>
+	!exclude(join(root, path));

--- a/src/fs/pathFilter.ts
+++ b/src/fs/pathFilter.ts
@@ -1,0 +1,13 @@
+import {join} from 'path';
+
+import {paths} from '../paths.js';
+import type {FileFilter} from './file.js';
+import type {PathStats} from './pathData.js';
+
+// This is a subset of the `cheap-watch` types designed for browser compatibility.
+export interface PathFilter {
+	(file: {path: string; stats: PathStats}): boolean;
+}
+
+export const toPathFilter = (filter: FileFilter, root = paths.root): PathFilter => ({path}) =>
+	!filter(join(root, path));

--- a/src/fs/watchNodeFs.ts
+++ b/src/fs/watchNodeFs.ts
@@ -1,11 +1,10 @@
-import {join} from 'path';
 import CheapWatch from 'cheap-watch';
 
-import type {PathFilter, PathStats} from './pathData.js';
-import {paths} from '../paths.js';
+import type {PathStats} from './pathData.js';
+import {toPathFilter} from './pathFilter.js';
+import type {PathFilter} from './pathFilter.js';
 import {omitUndefined} from '../utils/object.js';
 import type {PartialExcept} from '../index.js';
-import type {FileFilter} from './file.js';
 import {loadGitignoreFilter} from '../project/gitignore.js';
 
 /*
@@ -70,10 +69,5 @@ export const watchNodeFs = (opts: InitialOptions): WatchNodeFs => {
 		},
 	};
 };
-
-// TODO refactor these
-
-const toPathFilter = (filter: FileFilter, root = paths.root): PathFilter => ({path}) =>
-	!filter(join(root, path));
 
 const toDefaultFilter = (): PathFilter => toPathFilter(loadGitignoreFilter());

--- a/src/fs/watchNodeFs.ts
+++ b/src/fs/watchNodeFs.ts
@@ -77,7 +77,4 @@ export const watchNodeFs = (opts: InitialOptions): WatchNodeFs => {
 const toPathFilter = (filter: FileFilter, root = paths.root): PathFilter => ({path}) =>
 	!filter(join(root, path));
 
-const toDefaultFilter = (): PathFilter => {
-	const gitignoreFilter = loadGitignoreFilter();
-	return toPathFilter(gitignoreFilter);
-};
+const toDefaultFilter = (): PathFilter => toPathFilter(loadGitignoreFilter());

--- a/src/fs/watchNodeFs.ts
+++ b/src/fs/watchNodeFs.ts
@@ -7,7 +7,6 @@ import {omitUndefined} from '../utils/object.js';
 import type {PartialExcept} from '../index.js';
 import type {FileFilter} from './file.js';
 import {loadGitignoreFilter} from '../project/gitignore.js';
-import type {Filesystem} from './filesystem.js';
 
 /*
 
@@ -36,7 +35,7 @@ export const DEBOUNCE_DEFAULT = 10;
 export interface Options {
 	dir: string;
 	onChange: WatcherChangeCallback;
-	filter: PathFilter | null;
+	filter: PathFilter | null | undefined;
 	watch: boolean;
 	debounce: number;
 }

--- a/src/project/gitignore.test.ts
+++ b/src/project/gitignore.test.ts
@@ -1,27 +1,23 @@
+import {resolve} from 'path';
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
 
-import {isGitignored, loadGitignoreFilter} from './gitignore.js';
-
-/* test_isGitignored */
-const test_isGitignored = suite('isGitignored');
-
-test_isGitignored('basic behavior', () => {
-	t.ok(isGitignored('node_modules'));
-	t.ok(!isGitignored('node_module'));
-	// TODO ignore other patterns too, but this is sufficient for now
-	// t.ok(isGitignored('node_modules/a/b'));
-	// t.ok(isGitignored('a/b/node_modules/c/d'));
-	// t.ok(isGitignored('/a/b/node_modules/c/d'));
-});
-
-test_isGitignored.run();
-/* /test_isGitignored */
+import {loadGitignoreFilter} from './gitignore.js';
 
 /* test_loadGitignoreFilter */
 const test_loadGitignoreFilter = suite('loadGitignoreFilter');
 
 test_loadGitignoreFilter('basic behavior', () => {
+	const filter = loadGitignoreFilter();
+	t.ok(filter(resolve('node_modules')));
+	t.ok(!filter(resolve('node_module')));
+	// TODO ignore other patterns too, but this is sufficient for now
+	// t.ok(filter('node_modules/a/b'));
+	// t.ok(filter('a/b/node_modules/c/d'));
+	// t.ok(filter('/a/b/node_modules/c/d'));
+});
+
+test_loadGitignoreFilter('caching and forceRefresh', () => {
 	const filter1 = loadGitignoreFilter();
 	const filter2 = loadGitignoreFilter();
 	t.is(filter1, filter2);

--- a/src/project/gitignore.test.ts
+++ b/src/project/gitignore.test.ts
@@ -9,12 +9,16 @@ const test_loadGitignoreFilter = suite('loadGitignoreFilter');
 
 test_loadGitignoreFilter('basic behavior', () => {
 	const filter = loadGitignoreFilter();
+	t.ok(filter(resolve('dist')));
+	t.ok(!filter(resolve('a/dist')));
 	t.ok(filter(resolve('node_modules')));
+	t.ok(filter(resolve('a/node_modules')));
+	t.ok(filter(resolve('node_modules/a')));
+	t.ok(filter(resolve('a/node_modules/b')));
 	t.ok(!filter(resolve('node_module')));
-	// TODO ignore other patterns too, but this is sufficient for now
-	// t.ok(filter('node_modules/a/b'));
-	// t.ok(filter('a/b/node_modules/c/d'));
-	// t.ok(filter('/a/b/node_modules/c/d'));
+	t.ok(!filter(resolve('a/node_module')));
+	t.ok(!filter(resolve('node_module/a')));
+	t.ok(!filter(resolve('a/node_module/b')));
 });
 
 test_loadGitignoreFilter('caching and forceRefresh', () => {

--- a/src/project/gitignore.ts
+++ b/src/project/gitignore.ts
@@ -50,6 +50,22 @@ export const loadGitignoreFilter = (forceRefresh = false): FileFilter => {
 export const isGitignored = (path: string, root = process.cwd(), forceRefresh?: boolean) =>
 	loadGitignoreFilter(forceRefresh)(join(root, path));
 
-// TODO what's the better way to do this? quick hacky mapping for one use case between
-// [picomatch](https://github.com/micromatch/picomatch) and `.gitignore`
-const toPattern = (line: string): string => stripStart(line, '/');
+// TODO What's the better way to do this?
+// This is a quick hacky mapping for one use case between
+// `.gitignore` and picomatch: https://github.com/micromatch/picomatch
+// This code definitely fails for valid patterns!
+const toPattern = (line: string): string => {
+	const firstChar = line[0];
+	if (firstChar === '/') {
+		line = line.substring(1);
+	} else if (firstChar !== '*') {
+		line = `**/${line}`;
+	}
+	const lastChar = line[line.length - 1];
+	if (lastChar === '/') {
+		line = `${line}**`;
+	} else if (lastChar !== '*') {
+		line = `${line}/**`;
+	}
+	return line;
+};

--- a/src/project/gitignore.ts
+++ b/src/project/gitignore.ts
@@ -9,6 +9,7 @@ import {
 	SVELTE_KIT_DEV_DIRNAME,
 } from '../paths.js';
 import {stripStart} from '../utils/string.js';
+import type {FileFilter} from '../fs/file.js';
 
 /*
 
@@ -18,11 +19,7 @@ If we need support for Gro simultaneously, see ./packageJson.ts as an example.
 
 */
 
-interface Filter {
-	(id: string | unknown): boolean;
-}
-
-let filter: Filter | null = null;
+let filter: FileFilter | null = null;
 
 const DEFAULT_IGNORED_PATHS = [
 	GIT_DIRNAME,
@@ -32,7 +29,7 @@ const DEFAULT_IGNORED_PATHS = [
 ];
 
 // TODO need some mapping to match gitignore behavior correctly with nested directories
-export const loadGitignoreFilter = (forceRefresh = false): Filter => {
+export const loadGitignoreFilter = (forceRefresh = false): FileFilter => {
 	if (forceRefresh) filter = null;
 	if (filter) return filter;
 	let lines: string[];

--- a/src/project/gitignore.ts
+++ b/src/project/gitignore.ts
@@ -8,7 +8,6 @@ import {
 	NODE_MODULES_DIRNAME,
 	SVELTE_KIT_DEV_DIRNAME,
 } from '../paths.js';
-import {stripStart} from '../utils/string.js';
 import type {FileFilter} from '../fs/file.js';
 
 /*


### PR DESCRIPTION
This started out more ambitious but I ran into issues with gitignore. Eventually we'd like to abstract the filesystem from where the `Filer` uses `watchNodeFs` but until then we have this one corner of the app, gitignore, use the sync Node filesystem API.