### PR TITLE
add memory fs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,18 +1,3 @@
 {
-  "typescript.tsdk": "./node_modules/typescript/lib",
-  "files.exclude": {
-    "**/.git": true,
-    "**/.DS_Store": true
-  },
-  "files.watcherExclude": {
-    "**/.git": true,
-    "**/node_modules": true,
-    "**/dist": true,
-    "**/.gro": true
-  },
-  "search.exclude": {
-    "**/node_modules": true,
-    "**/dist": true,
-    "**/.gro": true
-  }
+  "editor.formatOnSave": true
 }

--- a/README.md
+++ b/README.md
@@ -132,17 +132,19 @@ gro serve some/dir and/another/dir # serve some directories
 ```
 
 ```bash
-gro version patch # bump version, publish to npm, and sync to GitHub
-gro version major --and args --are forwarded --to 'npm version'
-```
-
-```bash
 gro -v # aka `--version`: print the Gro version
 ```
 
 ```bash
 gro check # typecheck, run tests, and ensure generated files are current
 gro typecheck # just the typechecking
+```
+
+To publish: (also see [`src/docs/publish.md`](src/docs/publish.md))
+
+```bash
+gro version patch # bump version, publish to npm, and sync to GitHub
+gro version major --and args --are forwarded --to 'npm version'
 ```
 
 ## develop

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,10 @@
 
 ## 0.20.0
 
-- **break**: rework the `Fs` interface and implement `MemoryFs` for testing
+- **break**: rework the `Filesystem` interfaces
+  ([#173](https://github.com/feltcoop/gro/pull/173))
+- add abstract class `Fs` and implement `MemoryFs`
+  to complement the `fs-extra` implementation at `src/fs/node.ts`
   ([#173](https://github.com/feltcoop/gro/pull/173))
 
 ## 0.19.0

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 
 ## 0.19.0
 
-- **break**: extract the `Fs` interface and
+- **break**: extract the `Filesystem` interface and
   thread it everywhere from `src/cli/invoke.ts` and tests
   ([#171](https://github.com/feltcoop/gro/pull/171))
 - **break**: replace `src/project/gitignore.ts` helper `isGitignored`

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 - **break**: rework the `Filesystem` interfaces
   ([#173](https://github.com/feltcoop/gro/pull/173))
+  - export a `fs` instance from each `Filesystem` implementation
+    and do not export individual functions
+  - rename `pathExists` to `exists`
+  - remove `readJson`
 - add abstract class `Fs` and implement `MemoryFs`
   to complement the `fs-extra` implementation at `src/fs/node.ts`
   ([#173](https://github.com/feltcoop/gro/pull/173))

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,13 @@
 # Gro changelog
 
+## 0.20.0
+
+- **break**: rework the `Fs` interface and implement `MemoryFs` for testing
+  ([#173](https://github.com/feltcoop/gro/pull/173))
+
 ## 0.19.0
 
-- **break**: extract the `Filesystem` interface and
+- **break**: extract the `Fs` interface and
   thread it everywhere from `src/cli/invoke.ts` and tests
   ([#171](https://github.com/feltcoop/gro/pull/171))
 - **break**: replace `src/project/gitignore.ts` helper `isGitignored`

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -96,8 +96,8 @@ export const task: Task<TaskArgs, TaskEvents> = {
 			// TODO remove this when SvelteKit has its duplicate build dir bug fixed
 			// TODO take a look at its issues/codebase for fix
 			if (
-				(await fs.pathExists(`${SVELTE_KIT_BUILD_DIRNAME}/_${SVELTE_KIT_APP_DIRNAME}`)) &&
-				(await fs.pathExists(`${SVELTE_KIT_BUILD_DIRNAME}/${SVELTE_KIT_APP_DIRNAME}`))
+				(await fs.exists(`${SVELTE_KIT_BUILD_DIRNAME}/_${SVELTE_KIT_APP_DIRNAME}`)) &&
+				(await fs.exists(`${SVELTE_KIT_BUILD_DIRNAME}/${SVELTE_KIT_APP_DIRNAME}`))
 			) {
 				await fs.remove(`${SVELTE_KIT_BUILD_DIRNAME}/_${SVELTE_KIT_APP_DIRNAME}`);
 			}

--- a/src/build/Filer.test.ts
+++ b/src/build/Filer.test.ts
@@ -19,10 +19,13 @@ test_Filer('basic serve usage', async ({fs}) => {
 	const dev = true;
 	fs._reset();
 
-	fs.outputFile('/served/a.html', 'a', 'utf8');
-	fs.outputFile('/served/b.svelte', 'b', 'utf8');
-	fs.outputFile('/served/c.svelte.md', 'c', 'utf8');
-	console.log('fs._files', fs._files);
+	const aId = '/served/a.html';
+	const bId = '/served/b.svelte';
+	const cId = '/served/c/c.svelte.md';
+
+	fs.outputFile(aId, 'a', 'utf8');
+	fs.outputFile(bId, 'b', 'utf8');
+	fs.outputFile(cId, 'c', 'utf8');
 
 	const filer = new Filer({
 		fs,
@@ -32,12 +35,21 @@ test_Filer('basic serve usage', async ({fs}) => {
 	});
 	t.ok(filer);
 
-	// TODO make this work
-	// await filer.init();
-	// TODO make sure the fs contains and filer loaded what we'd expect from the config (query both exhaustively for internal state)
-	t.ok(fs._files.size);
+	await filer.init();
 
-	// filer.close();
+	const a = await filer.findByPath('a.html');
+	t.is(a?.id, aId);
+	const b = await filer.findByPath('b.svelte');
+	t.is(b?.id, bId);
+	const c = await filer.findByPath('c/c.svelte.md');
+	t.is(c?.id, cId);
+
+	t.is(fs._files.size, 6);
+	t.ok(fs._files.has(aId));
+	t.ok(fs._files.has(bId));
+	t.ok(fs._files.has(cId));
+
+	filer.close();
 });
 
 // TODO this is broken

--- a/src/build/Filer.test.ts
+++ b/src/build/Filer.test.ts
@@ -1,0 +1,71 @@
+import {suite} from 'uvu';
+import * as t from 'uvu/assert';
+
+import {Filer} from './Filer.js';
+import {fs as memoryFs} from '../fs/memory.js';
+import type {MemoryFs} from '../fs/memory.js';
+
+interface SuiteContext {
+	fs: MemoryFs;
+}
+const suiteContext: SuiteContext = {fs: memoryFs};
+const resetMemoryFs = ({fs}: SuiteContext) => fs._reset();
+
+/* test_Filer */
+const test_Filer = suite('Filer', suiteContext);
+test_Filer.before.each(resetMemoryFs);
+
+test_Filer('basic serve usage', async ({fs}) => {
+	const dev = true;
+	fs._reset();
+
+	fs.outputFile('/served/a.html', 'a', 'utf8');
+	fs.outputFile('/served/b.svelte', 'b', 'utf8');
+	fs.outputFile('/served/c.svelte.md', 'c', 'utf8');
+	console.log('fs._files', fs._files);
+
+	const filer = new Filer({
+		fs,
+		dev,
+		servedDirs: ['/served'],
+		watch: false,
+	});
+	t.ok(filer);
+
+	// TODO make this work
+	// await filer.init();
+	// TODO make sure the fs contains and filer loaded what we'd expect from the config (query both exhaustively for internal state)
+	t.ok(fs._files.size);
+
+	// filer.close();
+});
+
+// TODO this is broken
+// test_Filer('basic build usage', async ({fs}) => {
+// 	const dev = true;
+// 	fs._reset();
+// const buildConfig: BuildConfig = {
+//   name: 'test_build_config',
+//   platform: 'node',
+//   primary: true,
+//   dist: false,
+//   input: ['entrypoint.ts'],
+// };
+// 	const filer = new Filer({
+// 		fs,
+// 		dev,
+// 		builder: createDefaultBuilder(),
+// 		sourceDirs: [paths.source],
+// 		buildConfigs: [buildConfig],
+// 		watch: false,
+// 	});
+// 	t.ok(filer);
+// 	await filer.init();
+// 	t.ok(fs._files.size);
+// 	filer.close();
+// });
+
+// TODO more tests
+
+test_Filer.run();
+/* /test_Filer */

--- a/src/build/Filer.test.ts
+++ b/src/build/Filer.test.ts
@@ -87,6 +87,7 @@ test_Filer('basic build usage with no watch', async ({fs}) => {
 	const entryFile = await filer.findByPath(entrypointFilename);
 	t.is(entryFile?.id, entryId);
 
+	console.log('fs._files.keys()', fs._files.keys());
 	t.is(fs._files.size, 12);
 	t.ok(fs._files.has(entryId));
 

--- a/src/build/Filer.test.ts
+++ b/src/build/Filer.test.ts
@@ -75,6 +75,7 @@ test_Filer('basic build usage with no watch', async ({fs}) => {
 	const filer = new Filer({
 		fs,
 		dev,
+		buildDir: '/c/',
 		builder,
 		buildConfigs: [buildConfig],
 		sourceDirs: [rootId],
@@ -87,8 +88,16 @@ test_Filer('basic build usage with no watch', async ({fs}) => {
 	const entryFile = await filer.findByPath(entrypointFilename);
 	t.is(entryFile?.id, entryId);
 
-	console.log('fs._files.keys()', fs._files.keys());
-	t.is(fs._files.size, 12);
+	t.equal(Array.from(fs._files.keys()), [
+		'/',
+		'/a',
+		'/a/b',
+		'/a/b/src',
+		'/a/b/src/entrypoint.ts',
+		'/c',
+		'/c/src',
+		'/c/src/entrypoint.ts.json',
+	]);
 	t.ok(fs._files.has(entryId));
 
 	filer.close();

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -996,7 +996,7 @@ const syncBuildFilesToDisk = async (
 			const {file} = change;
 			let shouldOutputNewFile = false;
 			if (change.type === 'added') {
-				if (!(await fs.pathExists(file.id))) {
+				if (!(await fs.exists(file.id))) {
 					// log.trace(label, 'creating build file on disk', gray(file.id));
 					shouldOutputNewFile = true;
 				} else {

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -989,7 +989,7 @@ const syncBuildFilesToDisk = async (
 	changes: BuildFileChange[],
 	log: Logger,
 ): Promise<void> => {
-	const {buildConfig} = changes[0]?.file;
+	const buildConfig = changes[0]?.file?.buildConfig;
 	const label = buildConfig ? printBuildConfigLabel(buildConfig) : '';
 	await Promise.all(
 		changes.map(async (change) => {

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -90,7 +90,7 @@ export interface Options {
 	target: EcmaScriptTarget;
 	watch: boolean;
 	watcherDebounce: number | undefined;
-	filter: PathFilter | null | undefined;
+	filter: PathFilter | undefined;
 	cleanOutputDirs: boolean;
 	log: Logger;
 }
@@ -1126,7 +1126,7 @@ const createFilerDirs = (
 	onChange: FilerDirChangeCallback,
 	watch: boolean,
 	watcherDebounce: number | undefined,
-	filter: PathFilter | null | undefined,
+	filter: PathFilter | undefined,
 ): FilerDir[] => {
 	const dirs: FilerDir[] = [];
 	for (const sourceDir of sourceDirs) {

--- a/src/build/baseFilerFile.ts
+++ b/src/build/baseFilerFile.ts
@@ -1,4 +1,5 @@
-import type {Filesystem, Stats} from '../fs/filesystem.js';
+import type {Filesystem} from '../fs/filesystem.js';
+import type {PathStats} from '../fs/pathData.js';
 import type {Encoding} from '../fs/encoding.js';
 import {getMimeTypeByExtension} from '../fs/mime.js';
 import {toHash} from './utils.js';
@@ -14,7 +15,7 @@ export interface BaseFilerFile {
 	readonly contents: string | Buffer;
 	contentsBuffer: Buffer | undefined; // `undefined` and mutable for lazy loading
 	contentsHash: string | undefined; // `undefined` and mutable for lazy loading
-	stats: Stats | undefined; // `undefined` and mutable for lazy loading
+	stats: PathStats | undefined; // `undefined` and mutable for lazy loading
 	mimeType: string | null | undefined; // `null` means unknown, `undefined` and mutable for lazy loading
 }
 
@@ -28,8 +29,8 @@ export const getFileContentsBuffer = (file: BaseFilerFile): Buffer =>
 		? file.contentsBuffer
 		: (file.contentsBuffer = Buffer.from(file.contents));
 
-// Stats are currently lazily loaded. Should they be?
-export const getFileStats = (fs: Filesystem, file: BaseFilerFile): Stats | Promise<Stats> =>
+// PathStats are currently lazily loaded. Should they be?
+export const getFileStats = (fs: Filesystem, file: BaseFilerFile): PathStats | Promise<PathStats> =>
 	file.stats !== undefined
 		? file.stats
 		: fs.stat(file.id).then((stats) => {

--- a/src/build/externalsBuildHelpers.ts
+++ b/src/build/externalsBuildHelpers.ts
@@ -84,7 +84,7 @@ export const loadImportMapFromDisk = async (
 ): Promise<ImportMap | undefined> => {
 	const importMapPath = toImportMapPath(dest);
 	if (!(await fs.exists(importMapPath))) return undefined;
-	const importMap: ImportMap = await fs.readJson(importMapPath);
+	const importMap: ImportMap = JSON.parse(await fs.readFile(importMapPath, 'utf8'));
 	return importMap;
 };
 

--- a/src/build/externalsBuildHelpers.ts
+++ b/src/build/externalsBuildHelpers.ts
@@ -83,7 +83,7 @@ export const loadImportMapFromDisk = async (
 	dest: string,
 ): Promise<ImportMap | undefined> => {
 	const importMapPath = toImportMapPath(dest);
-	if (!(await fs.pathExists(importMapPath))) return undefined;
+	if (!(await fs.exists(importMapPath))) return undefined;
 	const importMap: ImportMap = await fs.readJson(importMapPath);
 	return importMap;
 };

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -72,7 +72,7 @@ export const updateSourceMeta = async (
 	// This is useful for debugging, but has false positives
 	// when source changes but output doesn't, like if comments get elided.
 	// if (
-	// 	(await pathExists(cacheId)) &&
+	// 	(await fs.exists(cacheId)) &&
 	// 	deepEqual(await readJson(cacheId), sourceMeta)
 	// ) {
 	// 	console.log(
@@ -109,7 +109,7 @@ export const initSourceMeta = async ({
 	buildDir,
 }: BuildContext): Promise<void> => {
 	const sourceMetaDir = toSourceMetaDir(buildDir);
-	if (!(await fs.pathExists(sourceMetaDir))) return;
+	if (!(await fs.exists(sourceMetaDir))) return;
 	const files = await fs.findFiles(sourceMetaDir, undefined, null);
 	await Promise.all(
 		Array.from(files.entries()).map(async ([path, stats]) => {

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -73,7 +73,7 @@ export const updateSourceMeta = async (
 	// when source changes but output doesn't, like if comments get elided.
 	// if (
 	// 	(await fs.exists(cacheId)) &&
-	// 	deepEqual(await readJson(cacheId), sourceMeta)
+	// 	deepEqual(JSON.parse(await readFile(cacheId, 'utf8')), sourceMeta)
 	// ) {
 	// 	console.log(
 	// 		'wasted build detected! unchanged file was built and identical source meta written to disk: ' +
@@ -115,7 +115,7 @@ export const initSourceMeta = async ({
 		Array.from(files.entries()).map(async ([path, stats]) => {
 			if (stats.isDirectory()) return;
 			const cacheId = `${sourceMetaDir}/${path}`;
-			const data: SourceMetaData = await fs.readJson(cacheId);
+			const data: SourceMetaData = JSON.parse(await fs.readFile(cacheId, 'utf8'));
 			sourceMetaById.set(data.sourceId, {cacheId, data});
 		}),
 	);

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -54,7 +54,7 @@ export const resolveInputFiles = async (
 	(
 		await Promise.all(
 			buildConfig.input.map(async (input) =>
-				typeof input === 'string' && (await fs.pathExists(input)) ? input : null!,
+				typeof input === 'string' && (await fs.exists(input)) ? input : null!,
 			),
 		)
 	).filter(Boolean);

--- a/src/cert.task.ts
+++ b/src/cert.task.ts
@@ -11,8 +11,8 @@ export const task: Task<TaskArgs> = {
 		const host = args.host || 'localhost';
 		const certFile = `${host}-cert.pem`;
 		const keyFile = `${host}-privkey.pem`;
-		if (await fs.pathExists(certFile)) throw Error(`File ${certFile} already exists. Canceling.`);
-		if (await fs.pathExists(keyFile)) throw Error(`File ${keyFile} already exists. Canceling.`);
+		if (await fs.exists(certFile)) throw Error(`File ${certFile} already exists. Canceling.`);
+		if (await fs.exists(keyFile)) throw Error(`File ${keyFile} already exists. Canceling.`);
 		await spawnProcess(
 			'openssl',
 			`req -x509 -newkey rsa:2048 -nodes -sha256 -subj /CN=${host} -keyout ${keyFile} -out ${certFile}`.split(

--- a/src/cli/invoke.ts
+++ b/src/cli/invoke.ts
@@ -12,7 +12,7 @@ import mri from 'mri';
 
 import type {Args} from '../task/task.js';
 import {invokeTask} from '../task/invokeTask.js';
-import {nodeFilesystem} from '../fs/node.js';
+import {fs as nodeFs} from '../fs/node.js';
 
 /*
 
@@ -32,7 +32,7 @@ const main = async () => {
 	} = argv;
 	const args = {_, ...namedArgs};
 
-	await invokeTask(nodeFilesystem, taskName, args);
+	await invokeTask(nodeFs, taskName, args);
 };
 
 main(); // see `attachProcessErrorHandlers` above for why we don't catch here

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -2,10 +2,10 @@ import {test} from 'uvu';
 import * as t from 'uvu/assert';
 
 import {loadGroConfig} from './config.js';
-import {nodeFilesystem} from '../fs/node.js';
+import {fs} from '../fs/node.js';
 
 test('loadGroConfig', async () => {
-	const config = await loadGroConfig(nodeFilesystem, true);
+	const config = await loadGroConfig(fs, true);
 	t.ok(config);
 });
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -137,12 +137,12 @@ export const loadGroConfig = async (
 	// TODO maybe refactor this to use `../fs/modules#loadModule`, duplicates some stuff
 	let configModule: GroConfigModule;
 	let modulePath: string;
-	if (await fs.pathExists(configSourceId)) {
+	if (await fs.exists(configSourceId)) {
 		// The project has a `gro.config.ts`, so import it.
 		// If it's not already built, we need to bootstrap the config and use it to compile everything.
 		modulePath = configSourceId;
 		const configBuildId = toBuildOutPath(dev, PRIMARY_NODE_BUILD_CONFIG.name, CONFIG_BUILD_PATH);
-		if (await fs.pathExists(configBuildId)) {
+		if (await fs.exists(configBuildId)) {
 			configModule = await import(configBuildId);
 		} else {
 			// We need to bootstrap the config because it's not yet built.

--- a/src/config/defaultBuildConfig.ts
+++ b/src/config/defaultBuildConfig.ts
@@ -32,8 +32,7 @@ export const PRIMARY_NODE_BUILD_CONFIG: BuildConfig = {
 export const API_SERVER_SOURCE_BASE_PATH = 'server/server.ts';
 export const API_SERVER_BUILD_BASE_PATH = toBuildExtension(API_SERVER_SOURCE_BASE_PATH); // 'server/server.js'
 export const API_SERVER_SOURCE_ID = basePathToSourceId(API_SERVER_SOURCE_BASE_PATH); // '/home/to/your/src/server/server.ts'
-export const hasApiServer = (fs: Filesystem): Promise<boolean> =>
-	fs.pathExists(API_SERVER_SOURCE_ID);
+export const hasApiServer = (fs: Filesystem): Promise<boolean> => fs.exists(API_SERVER_SOURCE_ID);
 export const hasApiServerConfig = (buildConfigs: BuildConfig[]): boolean =>
 	buildConfigs.some(
 		(b) =>
@@ -74,4 +73,4 @@ export const toDefaultBrowserBuild = (assetPaths = toDefaultAssetPaths()): Build
 const toDefaultAssetPaths = (): string[] => Array.from(getExtensions());
 
 const everyPathExists = async (fs: Filesystem, paths: string[]): Promise<boolean> =>
-	(await Promise.all(paths.map((path) => fs.pathExists(path)))).every((v) => !!v);
+	(await Promise.all(paths.map((path) => fs.exists(path)))).every((v) => !!v);

--- a/src/fs/clean.ts
+++ b/src/fs/clean.ts
@@ -29,7 +29,7 @@ export const clean = async (
 	]);
 
 export const cleanDir = async (fs: Filesystem, path: string, log: SystemLogger): Promise<void> => {
-	if (await fs.pathExists(path)) {
+	if (await fs.exists(path)) {
 		log.info('removing', printPath(path));
 		await fs.remove(path);
 	}

--- a/src/fs/filesystem.test.ts
+++ b/src/fs/filesystem.test.ts
@@ -1,0 +1,17 @@
+import {suite} from 'uvu';
+import * as t from 'uvu/assert';
+
+import {FsStats} from './filesystem.js';
+
+/* test_FsStats */
+const test_FsStats = suite('FsStats');
+
+test_FsStats('basic behavior', async () => {
+	const dirStats = new FsStats(true);
+	t.ok(dirStats.isDirectory());
+	const fileStats = new FsStats(false);
+	t.ok(!fileStats.isDirectory());
+});
+
+test_FsStats.run();
+/* /test_FsStats */

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -109,7 +109,7 @@ export type FsId = Flavored<string, 'FsId'>;
 // The `resolve` looks magic and hardcoded - it's matching how `fs` and `fs-extra` resolve paths.
 export const toFsId = (path: string): FsId => resolve(path);
 
-// TODO extract - how do they intersect with Filer types? and smaller interfaces like `PathData`?
+// TODO extract these? - how do they intersect with Filer types? and smaller interfaces like `PathData`?
 export type FsNode = TextFileNode | BinaryFileNode | DirectoryNode;
 
 // TODO should we use `BaseFilerFile` here?

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -66,7 +66,6 @@ export interface FsFindFiles {
 	): Promise<Map<string, PathStats>>;
 }
 
-// TODO maybe swap these two names?
 export abstract class Fs implements Filesystem {
 	abstract stat: FsStat;
 	abstract exists: FsExists;
@@ -82,14 +81,14 @@ export abstract class Fs implements Filesystem {
 	abstract findFiles: FsFindFiles;
 }
 
-// TODO remove some of these, but which?
+// TODO try to implement some of these
 export interface FsCopyOptions {
-	dereference?: boolean;
+	// dereference?: boolean;
 	overwrite?: boolean;
-	preserveTimestamps?: boolean;
-	errorOnExist?: boolean;
-	filter?: FsCopyFilterSync | FsCopyFilterAsync;
-	recursive?: boolean;
+	// preserveTimestamps?: boolean;
+	// errorOnExist?: boolean;
+	// filter?: FsCopyFilterSync | FsCopyFilterAsync;
+	// recursive?: boolean;
 }
 export interface FsMoveOptions {
 	overwrite?: boolean;
@@ -107,7 +106,7 @@ export class FsStats implements PathStats {
 
 export type FsId = Flavored<string, 'FsId'>;
 
-// TODO probably needs to take a cwd param?
+// The `resolve` looks magic and hardcoded - it's matching how `fs` and `fs-extra` resolve paths.
 export const toFsId = (path: string): FsId => resolve(path);
 
 // TODO extract - how do they intersect with Filer types? and smaller interfaces like `PathData`?

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -107,8 +107,7 @@ export class FsStats implements PathStats {
 
 export type FsId = Flavored<string, 'FsId'>;
 
-// TODO improve and move
-// name? `toNormalPath`? `normalize`? `normalizePath`?
+// TODO probably needs to take a cwd param?
 export const toFsId = (path: string): FsId => stripEnd(path, '/');
 
 // TODO extract - how do they intersect with Filer types? and smaller interfaces like `PathData`?

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -7,7 +7,7 @@ import type {PathFilter} from './pathFilter.js';
 // API is modeled after `fs-extra`: https://github.com/jprichardson/node-fs-extra/
 export interface Filesystem {
 	stat: FsStat;
-	pathExists: stringExists;
+	pathExists: FsPathExists;
 	readFile: FsReadFile;
 	readJson: FsReadJson;
 	outputFile: FsOutputFile;
@@ -23,7 +23,7 @@ export interface Filesystem {
 export interface FsStat {
 	(path: string): Promise<PathStats>;
 }
-export interface stringExists {
+export interface FsPathExists {
 	(path: string): Promise<boolean>;
 }
 export interface FsReadFile {
@@ -69,7 +69,7 @@ export interface FsFindFiles {
 // TODO maybe swap these two names?
 export abstract class Fs implements Filesystem {
 	abstract stat: FsStat;
-	abstract pathExists: stringExists;
+	abstract pathExists: FsPathExists;
 	abstract readFile: FsReadFile;
 	abstract readJson: FsReadJson;
 	abstract outputFile: FsOutputFile;

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -1,4 +1,5 @@
-import {stripEnd} from '../utils/string.js';
+import {resolve} from 'path';
+
 import type {Flavored} from '../utils/types.js';
 import type {Encoding} from './encoding.js';
 import type {PathData, PathStats} from './pathData.js';
@@ -108,7 +109,7 @@ export class FsStats implements PathStats {
 export type FsId = Flavored<string, 'FsId'>;
 
 // TODO probably needs to take a cwd param?
-export const toFsId = (path: string): FsId => stripEnd(path, '/');
+export const toFsId = (path: string): FsId => resolve(path);
 
 // TODO extract - how do they intersect with Filer types? and smaller interfaces like `PathData`?
 export type FsNode = TextFileNode | BinaryFileNode | DirectoryNode;

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -28,7 +28,6 @@ export interface FsExists {
 	(path: string): Promise<boolean>;
 }
 export interface FsReadFile {
-	// TODO ran into problems using overrides, couldn't get subclass to typecheck:
 	(path: string): Promise<Buffer>;
 	(path: string, encoding: 'utf8'): Promise<string>;
 	(path: string, encoding: null): Promise<Buffer>;

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -87,7 +87,7 @@ export interface FsCopyOptions {
 	overwrite?: boolean;
 	// preserveTimestamps?: boolean;
 	// errorOnExist?: boolean;
-	// filter?: FsCopyFilterSync | FsCopyFilterAsync;
+	filter?: FsCopyFilterSync | FsCopyFilterAsync;
 	// recursive?: boolean;
 }
 export interface FsMoveOptions {

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -10,7 +10,6 @@ export interface Filesystem {
 	stat: FsStat;
 	exists: FsExists;
 	readFile: FsReadFile;
-	readJson: FsReadJson;
 	outputFile: FsOutputFile;
 	remove: FsRemove;
 	move: FsMove;
@@ -32,9 +31,6 @@ export interface FsReadFile {
 	(path: string, encoding: 'utf8'): Promise<string>;
 	(path: string, encoding: null): Promise<Buffer>;
 	(path: string, encoding?: Encoding): Promise<Buffer | string>;
-}
-export interface FsReadJson {
-	(path: string): Promise<any>;
 }
 export interface FsOutputFile {
 	(path: string, data: any, encoding?: Encoding): Promise<void>;
@@ -70,7 +66,6 @@ export abstract class Fs implements Filesystem {
 	abstract stat: FsStat;
 	abstract exists: FsExists;
 	abstract readFile: FsReadFile;
-	abstract readJson: FsReadJson;
 	abstract outputFile: FsOutputFile;
 	abstract remove: FsRemove;
 	abstract move: FsMove;

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -7,7 +7,7 @@ import type {PathFilter} from './pathFilter.js';
 // API is modeled after `fs-extra`: https://github.com/jprichardson/node-fs-extra/
 export interface Filesystem {
 	stat: FsStat;
-	pathExists: FsPathExists;
+	exists: FsExists;
 	readFile: FsReadFile;
 	readJson: FsReadJson;
 	outputFile: FsOutputFile;
@@ -23,7 +23,7 @@ export interface Filesystem {
 export interface FsStat {
 	(path: string): Promise<PathStats>;
 }
-export interface FsPathExists {
+export interface FsExists {
 	(path: string): Promise<boolean>;
 }
 export interface FsReadFile {
@@ -69,7 +69,7 @@ export interface FsFindFiles {
 // TODO maybe swap these two names?
 export abstract class Fs implements Filesystem {
 	abstract stat: FsStat;
-	abstract pathExists: FsPathExists;
+	abstract exists: FsExists;
 	abstract readFile: FsReadFile;
 	abstract readJson: FsReadJson;
 	abstract outputFile: FsOutputFile;

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -2,7 +2,7 @@ import {resolve} from 'path';
 
 import type {Flavored} from '../utils/types.js';
 import type {Encoding} from './encoding.js';
-import type {PathData, PathStats} from './pathData.js';
+import type {PathStats} from './pathData.js';
 import type {PathFilter} from './pathFilter.js';
 
 // API is modeled after `fs-extra`: https://github.com/jprichardson/node-fs-extra/
@@ -128,7 +128,7 @@ export interface BaseNode {
 	readonly contents: string | Buffer | null;
 	// readonly contentsBuffer: Buffer | null;
 	readonly stats: PathStats;
-	readonly path: PathData; // TODO name? `PathInfo`? `PathMeta`? `Path`?
+	// readonly pathData: PathData; // TODO currently isn't used - rename? `PathInfo`? `PathMeta`? `Path`?
 }
 export interface BaseFileNode extends BaseNode {
 	readonly isDirectory: false;

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -1,13 +1,13 @@
-import type {PathLike, Stats, CopyOptions, MoveOptions} from 'fs-extra';
-
-import type {PathStats} from './pathData.js';
+import {stripEnd} from '../utils/string.js';
+import type {Flavored} from '../utils/types.js';
+import type {Encoding} from './encoding.js';
+import type {PathData, PathStats} from './pathData.js';
 import type {PathFilter} from './pathFilter.js';
 
-export type {Stats} from 'fs-extra';
-
+// API is modeled after `fs-extra`: https://github.com/jprichardson/node-fs-extra/
 export interface Filesystem {
 	stat: FsStat;
-	pathExists: FsPathExists;
+	pathExists: stringExists;
 	readFile: FsReadFile;
 	readJson: FsReadJson;
 	outputFile: FsOutputFile;
@@ -21,29 +21,32 @@ export interface Filesystem {
 }
 
 export interface FsStat {
-	(path: PathLike): Promise<Stats>;
+	(path: string): Promise<PathStats>;
 }
-export interface FsPathExists {
+export interface stringExists {
 	(path: string): Promise<boolean>;
 }
 export interface FsReadFile {
-	(file: PathLike | number): Promise<Buffer>;
-	(file: PathLike | number, encoding: string): Promise<string>;
+	// TODO ran into problems using overrides, couldn't get subclass to typecheck:
+	(path: string): Promise<Buffer>;
+	(path: string, encoding: 'utf8'): Promise<string>;
+	(path: string, encoding: null): Promise<Buffer>;
+	(path: string, encoding?: Encoding): Promise<Buffer | string>;
 }
 export interface FsReadJson {
-	(file: string): Promise<any>;
+	(path: string): Promise<any>;
 }
 export interface FsOutputFile {
-	(file: string, data: any, encoding?: string): Promise<void>;
+	(path: string, data: any, encoding?: Encoding): Promise<void>;
 }
 export interface FsRemove {
 	(path: string): Promise<void>;
 }
 export interface FsMove {
-	(src: string, dest: string, options?: MoveOptions): Promise<void>; // TODO which options?
+	(src: string, dest: string, options?: FsMoveOptions): Promise<void>; // TODO which options?
 }
 export interface FsCopy {
-	(src: string, dest: string, options?: CopyOptions): Promise<void>; // TODO which options? all? breaks conventionn with above
+	(src: string, dest: string, options?: FsCopyOptions): Promise<void>; // TODO which options? all? breaks conventionn with above
 }
 export interface FsReadDir {
 	(path: string): Promise<string[]>;
@@ -61,4 +64,87 @@ export interface FsFindFiles {
 		// pass `null` to speed things up at the risk of infrequent misorderings (at least on Linux)
 		sort?: ((a: [any, any], b: [any, any]) => number) | null,
 	): Promise<Map<string, PathStats>>;
+}
+
+// TODO maybe swap these two names?
+export abstract class Fs implements Filesystem {
+	abstract stat: FsStat;
+	abstract pathExists: stringExists;
+	abstract readFile: FsReadFile;
+	abstract readJson: FsReadJson;
+	abstract outputFile: FsOutputFile;
+	abstract remove: FsRemove;
+	abstract move: FsMove;
+	abstract copy: FsCopy;
+	abstract readDir: FsReadDir;
+	abstract emptyDir: FsEmptyDir;
+	abstract ensureDir: FsEnsureDir;
+	abstract findFiles: FsFindFiles;
+}
+
+// TODO remove some of these, but which?
+export interface FsCopyOptions {
+	dereference?: boolean;
+	overwrite?: boolean;
+	preserveTimestamps?: boolean;
+	errorOnExist?: boolean;
+	filter?: FsCopyFilterSync | FsCopyFilterAsync;
+	recursive?: boolean;
+}
+export interface FsMoveOptions {
+	overwrite?: boolean;
+	limit?: number;
+}
+export type FsCopyFilterSync = (src: string, dest: string) => boolean;
+export type FsCopyFilterAsync = (src: string, dest: string) => Promise<boolean>;
+
+export class FsStats implements PathStats {
+	constructor(private readonly _isDirectory: boolean) {}
+	isDirectory() {
+		return this._isDirectory;
+	}
+}
+
+export type FsId = Flavored<string, 'FsId'>;
+
+// TODO improve and move
+// name? `toNormalPath`? `normalize`? `normalizePath`?
+export const toFsId = (path: string): FsId => stripEnd(path, '/');
+
+// TODO extract - how do they intersect with Filer types? and smaller interfaces like `PathData`?
+export type FsNode = TextFileNode | BinaryFileNode | DirectoryNode;
+
+// TODO should we use `BaseFilerFile` here?
+// this mirrors a lot of that, except this models directories as well,
+// which we wanted to upstream ..
+// so this is a good entrypoint for backporting dirs into the Filer
+
+// TODO names? should they have `Fs` prefix? extract?
+
+export interface BaseNode {
+	readonly id: FsId;
+	readonly isDirectory: boolean;
+	readonly encoding: Encoding;
+	readonly contents: string | Buffer | null;
+	// readonly contentsBuffer: Buffer | null;
+	readonly stats: PathStats;
+	readonly path: PathData; // TODO name? `PathInfo`? `PathMeta`? `Path`?
+}
+export interface BaseFileNode extends BaseNode {
+	readonly isDirectory: false;
+	readonly contents: string | Buffer;
+}
+export interface TextFileNode extends BaseFileNode {
+	readonly encoding: 'utf8';
+	readonly contents: string;
+}
+export interface BinaryFileNode extends BaseFileNode {
+	readonly encoding: null;
+	readonly contents: Buffer;
+	// readonly contentsBuffer: Buffer;
+}
+export interface DirectoryNode extends BaseNode {
+	readonly isDirectory: true;
+	readonly contents: null;
+	// readonly contentsBuffer: null;
 }

--- a/src/fs/inputPath.test.ts
+++ b/src/fs/inputPath.test.ts
@@ -12,7 +12,7 @@ import {
 import type {PathStats} from './pathData.js';
 import {groPaths, replaceRootDir, createPaths, paths} from '../paths.js';
 import type {Obj} from '../index.js';
-import {nodeFilesystem} from './node.js';
+import {fs} from './node.js';
 
 /* test_resolveRawInputPath */
 const test_resolveRawInputPath = suite('resolveRawInputPath');
@@ -126,7 +126,7 @@ const test_loadSourcePathDataByInputPath = suite('loadSourcePathDataByInputPath'
 test_loadSourcePathDataByInputPath('loads source path data and handles missing paths', async () => {
 	const result = await loadSourcePathDataByInputPath(
 		{
-			...nodeFilesystem,
+			...fs,
 			pathExists: async (path) => path !== 'fake/test3.bar.ts' && !path.startsWith('fake/missing'),
 			stat: async (path) =>
 				({

--- a/src/fs/inputPath.test.ts
+++ b/src/fs/inputPath.test.ts
@@ -127,7 +127,7 @@ test_loadSourcePathDataByInputPath('loads source path data and handles missing p
 	const result = await loadSourcePathDataByInputPath(
 		{
 			...fs,
-			pathExists: async (path) => path !== 'fake/test3.bar.ts' && !path.startsWith('fake/missing'),
+			exists: async (path) => path !== 'fake/test3.bar.ts' && !path.startsWith('fake/missing'),
 			stat: async (path) =>
 				({
 					isDirectory: () => path === 'fake/test2' || path === 'fake/test3',

--- a/src/fs/inputPath.ts
+++ b/src/fs/inputPath.ts
@@ -98,7 +98,7 @@ export const getPossibleSourceIds = (
 Gets the path data for each input path,
 searching for the possibilities based on `extensions`
 and stopping at the first match.
-Parameterized by `pathExists` and `stat` so it's fs-agnostic.
+Parameterized by `exists` and `stat` so it's fs-agnostic.
 
 */
 export const loadSourcePathDataByInputPath = async (
@@ -118,7 +118,7 @@ export const loadSourcePathDataByInputPath = async (
 			? getPossibleSourceIdsForInputPath(inputPath)
 			: [inputPath];
 		for (const possibleSourceId of possibleSourceIds) {
-			if (!(await fs.pathExists(possibleSourceId))) continue;
+			if (!(await fs.exists(possibleSourceId))) continue;
 			const stats = await fs.stat(possibleSourceId);
 			if (stats.isDirectory()) {
 				if (!dirPathData) {

--- a/src/fs/memory.test.ts
+++ b/src/fs/memory.test.ts
@@ -84,7 +84,7 @@ test_readFile('basic behavior', async ({fs}) => {
 });
 
 test_readFile('missing file throws', async ({fs}) => {
-	// TODO async `t.throws` ? hmm
+	// TODO async `t.throws` or `t.rejects` ?
 	try {
 		fs._reset();
 		await fs.readFile('/missing/file', 'utf8');
@@ -112,7 +112,7 @@ test_readJson('basic behavior', async ({fs}) => {
 });
 
 test_readJson('missing file throws', async ({fs}) => {
-	// TODO async `t.throws` ? hmm
+	// TODO async `t.throws` or `t.rejects` ?
 	try {
 		fs._reset();
 		await fs.readJson('/missing/file');
@@ -202,10 +202,10 @@ test_move('handles move conflict with overwrite false', async ({fs}) => {
 	await fs.outputFile(path1, fakeTsContents);
 	await fs.outputFile(path2, fakeTsContents);
 	t.is(fs._files.size, 5);
-	// async `t.throws`
+	// TODO async `t.throws` or `t.rejects` ?
 	let failed = true;
 	try {
-		await fs.move(path1, path2); // TODO does it throw?
+		await fs.move(path1, path2);
 	} catch (err) {
 		failed = false;
 	}
@@ -231,7 +231,7 @@ test_move('handles move conflict with overwrite true', async ({fs}) => {
 });
 
 test_move('missing source path throws', async ({fs}) => {
-	// TODO async `t.throws` ? hmm
+	// TODO async `t.throws` or `t.rejects` ?
 	try {
 		await fs.move('/missing/file', '/');
 	} catch (err) {
@@ -289,10 +289,10 @@ test_copy('handles copy conflict with overwrite false', async ({fs}) => {
 	await fs.outputFile(path1, fakeTsContents);
 	await fs.outputFile(path2, fakeTsContents);
 	t.is(fs._files.size, 5);
-	// async `t.throws`
+	// TODO async `t.throws`
 	let failed = true;
 	try {
-		await fs.copy(path1, path2); // TODO does it throw?
+		await fs.copy(path1, path2);
 	} catch (err) {
 		failed = false;
 	}
@@ -318,7 +318,7 @@ test_copy('handles copy conflict with overwrite true', async ({fs}) => {
 });
 
 test_copy('missing source path throws', async ({fs}) => {
-	// TODO async `t.throws` ? hmm
+	// TODO async `t.throws` or `t.rejects` ?
 	try {
 		await fs.copy('/missing/file', '/');
 	} catch (err) {
@@ -381,6 +381,41 @@ test_ensureDir('normalize paths', async ({fs}) => {
 
 test_ensureDir.run();
 /* /test_ensureDir */
+
+/* test_readDir */
+const test_readDir = suite('readDir', suiteContext);
+test_readDir.before.each(resetMemoryFs);
+
+test_readDir('basic behavior', async ({fs}) => {
+	for (const path of testPaths) {
+		fs._reset();
+		await fs.outputFile(path, 'contents', 'utf8');
+		t.ok(fs._exists(path));
+		const dir = dirname(path);
+		const paths = await fs.readDir(dir);
+		t.ok(paths.length);
+	}
+});
+
+test_readDir('readDirs contained files and dirs', async ({fs}) => {
+	const path = '/a/b/c';
+	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
+	await fs.outputFile(`${path}/dir1/b/c1.ts`, fakeTsContents);
+	await fs.outputFile(`${path}/dir1/b/c2.ts`, fakeTsContents);
+	await fs.outputFile(`${path}/dir1/b/c3.ts`, fakeTsContents);
+	await fs.outputFile(`${path}/dir1/d`, fakeTsContents);
+	const paths = await fs.readDir(`${path}/dir1`);
+	t.equal(paths, ['a.ts', 'b', 'b/c1.ts', 'b/c2.ts', 'b/c3.ts', 'd']);
+});
+
+test_readDir('missing file fails silently', async ({fs}) => {
+	const paths = await fs.readDir('/missing/file');
+	t.equal(paths, []);
+	t.is(fs._files.size, 0);
+});
+
+test_readDir.run();
+/* /test_readDir */
 
 /* test_emptyDir */
 const test_emptyDir = suite('emptyDir', suiteContext);

--- a/src/fs/memory.test.ts
+++ b/src/fs/memory.test.ts
@@ -97,34 +97,6 @@ test_readFile('missing file throws', async ({fs}) => {
 test_readFile.run();
 /* /test_readFile */
 
-/* test_readJson */
-const test_readJson = suite('readJson', suiteContext);
-test_readJson.before.each(resetMemoryFs);
-
-test_readJson('basic behavior', async ({fs}) => {
-	for (const path of testPaths) {
-		fs._reset();
-		const contents = {contents: {deep: {1: 1}}};
-		await fs.outputFile(path, JSON.stringify(contents), 'utf8');
-		const found = await fs.readJson(path);
-		t.equal(contents, found);
-	}
-});
-
-test_readJson('missing file throws', async ({fs}) => {
-	// TODO async `t.throws` or `t.rejects` ?
-	try {
-		fs._reset();
-		await fs.readJson('/missing/file');
-	} catch (err) {
-		return;
-	}
-	throw Error();
-});
-
-test_readJson.run();
-/* /test_readJson */
-
 /* test_remove */
 const test_remove = suite('remove', suiteContext);
 test_remove.before.each(resetMemoryFs);

--- a/src/fs/memory.test.ts
+++ b/src/fs/memory.test.ts
@@ -1,0 +1,172 @@
+import {suite} from 'uvu';
+import * as t from 'uvu/assert';
+
+import {fs as memoryFs, MemoryFs} from './memory.js';
+import {toFsId} from './filesystem.js';
+import {stripEnd} from '../utils/string.js';
+
+// TODO reset the fs between calls, or suites, or something
+// having a fresh one each time seems really useful to see the totality of what e.g. the Filer is doing
+
+// TODO organize these test suites better
+// TODO generic fs test suite
+
+// TODO mount at / and test that path `a` resolves to `/a` (not cwd!)
+// then mount at /a and test that path `b` resolves to `/a/b`
+
+// add leading and trailing slash variants
+const testPaths = ['a', 'a/b', 'a/b/c'].flatMap((p) => [p, `/${p}`]).flatMap((p) => [p, `${p}/`]);
+
+interface SuiteContext {
+	fs: MemoryFs;
+}
+const suiteContext: SuiteContext = {fs: memoryFs};
+
+const resetMemoryFs = ({fs}: SuiteContext) => {
+	fs._reset();
+};
+
+/* test_outputFile */
+const test_outputFile = suite('outputFile', suiteContext);
+test_outputFile.before.each(resetMemoryFs);
+
+for (const path of testPaths) {
+	test_outputFile('basic behavior', async ({fs}) => {
+		t.is(fs._files.size, 0);
+		const contents = 'hi';
+		await fs.outputFile(path, contents, 'utf8');
+		t.ok(fs._files.size);
+		t.is(fs._find(toFsId(path))!.contents, contents);
+		fs._reset();
+	});
+}
+
+for (const path of testPaths) {
+	test_outputFile(`updates an existing file: ${path}`, async ({fs}) => {
+		t.is(fs._files.size, 0);
+		const contents1 = 'contents1';
+		await fs.outputFile(path, contents1, 'utf8');
+		const {size} = fs._files;
+		t.ok(size);
+		t.is(fs._find(toFsId(path))!.contents, contents1);
+		const contents2 = 'contents2';
+		await fs.outputFile(path, contents2, 'utf8');
+		t.is(fs._files.size, size); // count has not changed
+		t.is(fs._find(toFsId(path))!.contents, contents2);
+		fs._reset();
+	});
+}
+
+// TODO test that it creates the in-between directories
+// this will break the `length` checks!! can use the new length checks to check segment creation
+
+test_outputFile.run();
+/* /test_outputFile */
+
+/* test_readFile */
+const test_readFile = suite('readFile', suiteContext);
+test_readFile.before.each(resetMemoryFs);
+
+for (const path of testPaths) {
+	test_readFile('basic behavior', async ({fs}) => {
+		const contents = 'contents';
+		await fs.outputFile(path, contents, 'utf8');
+		const found = await fs.readFile(path, 'utf8');
+		t.is(contents, found);
+		fs._reset();
+	});
+}
+
+test_readFile('missing file', async ({fs}) => {
+	// TODO async `t.throws` ? hmm
+	try {
+		fs._reset();
+		await fs.readFile('/missing/file', 'utf8');
+	} catch (err) {
+		return;
+	}
+	throw Error();
+});
+
+test_readFile.run();
+/* /test_readFile */
+
+/* test_readJson */
+const test_readJson = suite('readJson', suiteContext);
+test_readJson.before.each(resetMemoryFs);
+
+for (const path of testPaths) {
+	test_readJson('basic behavior', async ({fs}) => {
+		const contents = {contents: {deep: {1: 1}}};
+		await fs.outputFile(path, JSON.stringify(contents), 'utf8');
+		const found = await fs.readJson(path);
+		t.equal(contents, found);
+		fs._reset();
+	});
+}
+
+test_readJson('missing file', async ({fs}) => {
+	// TODO async `t.throws` ? hmm
+	try {
+		fs._reset();
+		await fs.readJson('/missing/file');
+	} catch (err) {
+		return;
+	}
+	throw Error();
+});
+
+test_readJson.run();
+/* /test_readJson */
+
+/* test_findFiles */
+const test_findFiles = suite('findFiles', suiteContext);
+test_findFiles.before.each(resetMemoryFs);
+
+for (const path of testPaths) {
+	test_findFiles('basic behavior', async ({fs}) => {
+		const contents = 'contents';
+		await fs.outputFile(path, contents, 'utf8');
+		const files = await fs.findFiles(path);
+		t.is(files.size, 1);
+		t.ok(files.has(toFsId(path)));
+		fs._reset();
+	});
+}
+
+test_findFiles.run();
+/* /test_findFiles */
+
+/* test_ensureDir */
+const test_ensureDir = suite('ensureDir', suiteContext);
+test_ensureDir.before.each(resetMemoryFs);
+
+for (const path of testPaths) {
+	test_ensureDir('basic behavior', async ({fs}) => {
+		t.ok(!(await fs.pathExists(path)));
+		await fs.ensureDir(path);
+		t.ok(await fs.pathExists(path));
+		fs._reset();
+	});
+}
+
+for (const path of testPaths) {
+	test_ensureDir('normalize paths', async ({fs}) => {
+		const testNormalizePaths = async (path1: string, path2: string) => {
+			t.ok(!(await fs.pathExists(path1)));
+			t.ok(!(await fs.pathExists(path2)));
+			await fs.ensureDir(path1);
+			t.ok(await fs.pathExists(path1));
+			t.ok(await fs.pathExists(path2));
+			fs._reset();
+		};
+
+		const endsWithSlash = path.endsWith('/');
+		// TODO maybe add a `stripLast` instead of this
+		const testPath2 = endsWithSlash ? stripEnd(path, '/') : `${path}/`;
+		await testNormalizePaths(endsWithSlash ? path : testPath2, endsWithSlash ? testPath2 : path);
+	});
+}
+
+test_ensureDir.run();
+/* /test_ensureDir */

--- a/src/fs/memory.test.ts
+++ b/src/fs/memory.test.ts
@@ -26,10 +26,7 @@ interface SuiteContext {
 	fs: MemoryFs;
 }
 const suiteContext: SuiteContext = {fs: memoryFs};
-
-const resetMemoryFs = ({fs}: SuiteContext) => {
-	fs._reset();
-};
+const resetMemoryFs = ({fs}: SuiteContext) => fs._reset();
 
 const fakeTsContents = 'export const a = 5;';
 

--- a/src/fs/memory.test.ts
+++ b/src/fs/memory.test.ts
@@ -268,7 +268,9 @@ test_copy('copies contained files and dirs', async ({fs}) => {
 	await fs.outputFile(`${path}/dir2/d.ts`, fakeTsContents);
 	t.is(fs._files.size, 11);
 	const newPath = '/a/e';
-	await fs.copy(`${path}/dir1`, `${newPath}/dir1`, {filter: (id) => !id.endsWith('/IGNORE.ts')});
+	await fs.copy(`${path}/dir1`, `${newPath}/dir1`, {
+		filter: (id) => Promise.resolve(!id.endsWith('/IGNORE.ts')),
+	});
 	t.ok(fs._exists(`${newPath}/dir1`));
 	t.ok(fs._exists(`${newPath}/dir1/a.ts`));
 	t.ok(fs._exists(`${newPath}/dir1/b`));

--- a/src/fs/memory.test.ts
+++ b/src/fs/memory.test.ts
@@ -59,7 +59,7 @@ test_outputFile('updates an existing file', async ({fs}) => {
 	}
 });
 
-// TODO test_pathExists
+// TODO test_exists
 
 // TODO test that it creates the in-between directories
 // this will break the `length` checks!! can use the new length checks to check segment creation

--- a/src/fs/memory.test.ts
+++ b/src/fs/memory.test.ts
@@ -1,9 +1,11 @@
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
+import {dirname} from 'path';
 
 import {fs as memoryFs, MemoryFs} from './memory.js';
 import {toFsId} from './filesystem.js';
 import {stripEnd} from '../utils/string.js';
+import {toPathParts} from '../utils/path.js';
 
 // TODO reset the fs between calls, or suites, or something
 // having a fresh one each time seems really useful to see the totality of what e.g. the Filer is doing
@@ -38,7 +40,7 @@ test_outputFile('basic behavior', async ({fs}) => {
 		t.is(fs._files.size, 0);
 		const contents = 'hi';
 		await fs.outputFile(path, contents, 'utf8');
-		t.ok(fs._files.size);
+		t.is(fs._files.size, toPathParts(toFsId(path)).length + 1);
 		t.is(fs._find(toFsId(path))!.contents, contents);
 	}
 });
@@ -50,7 +52,7 @@ test_outputFile('updates an existing file', async ({fs}) => {
 		const contents1 = 'contents1';
 		await fs.outputFile(path, contents1, 'utf8');
 		const {size} = fs._files;
-		t.ok(size);
+		t.is(size, toPathParts(toFsId(path)).length + 1);
 		t.is(fs._find(toFsId(path))!.contents, contents1);
 		const contents2 = 'contents2';
 		await fs.outputFile(path, contents2, 'utf8');
@@ -138,18 +140,16 @@ test_remove('basic behavior', async ({fs}) => {
 });
 
 test_remove('removes contained files and dirs', async ({fs}) => {
-	fs._reset();
 	const path = '/a/b/c';
 	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
 	await fs.outputFile(`${path}/dir1/b/c.ts`, fakeTsContents);
 	await fs.outputFile(`${path}/dir2/d.ts`, fakeTsContents);
-	t.is(fs._files.size, 9);
+	t.is(fs._files.size, 10);
 	await fs.remove(`${path}/dir1`);
-	t.is(fs._files.size, 5);
+	t.is(fs._files.size, 6);
 });
 
 test_remove('missing file fails silently', async ({fs}) => {
-	fs._reset();
 	await fs.remove('/missing/file');
 });
 
@@ -174,12 +174,11 @@ test_move('basic behavior', async ({fs}) => {
 });
 
 test_move('moves contained files and dirs', async ({fs}) => {
-	fs._reset();
 	const path = '/a/b/c';
 	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
 	await fs.outputFile(`${path}/dir1/b/c.ts`, fakeTsContents);
 	await fs.outputFile(`${path}/dir2/d.ts`, fakeTsContents);
-	t.is(fs._files.size, 9);
+	t.is(fs._files.size, 10);
 	const newPath = '/a/e';
 	await fs.move(`${path}/dir1`, `${newPath}/dir1`); // TODO any special merge behavior?
 	t.ok(fs._exists(`${newPath}/dir1`));
@@ -191,11 +190,10 @@ test_move('moves contained files and dirs', async ({fs}) => {
 	t.ok(!fs._exists(`${path}/dir1/a.ts`));
 	t.ok(!fs._exists(`${path}/dir1/b`));
 	t.ok(!fs._exists(`${path}/dir1/b/c.ts`));
-	t.is(fs._files.size, 10); // add the one new base dir
+	t.is(fs._files.size, 11); // add the one new base dir
 });
 
-test_move('move conflict with overwrite false', async ({fs}) => {
-	fs._reset();
+test_move('handles move conflict with overwrite false', async ({fs}) => {
 	const dir = '/a/b';
 	const filename1 = '1.ts';
 	const filename2 = '2.ts';
@@ -203,7 +201,7 @@ test_move('move conflict with overwrite false', async ({fs}) => {
 	const path2 = `${dir}/${filename2}`;
 	await fs.outputFile(path1, fakeTsContents);
 	await fs.outputFile(path2, fakeTsContents);
-	t.is(fs._files.size, 4);
+	t.is(fs._files.size, 5);
 	// async `t.throws`
 	let failed = true;
 	try {
@@ -214,11 +212,10 @@ test_move('move conflict with overwrite false', async ({fs}) => {
 	if (failed) throw Error();
 	t.ok(fs._exists(path1));
 	t.ok(fs._exists(path2));
-	t.is(fs._files.size, 4);
+	t.is(fs._files.size, 5);
 });
 
-test_move('move conflict with overwrite true', async ({fs}) => {
-	fs._reset();
+test_move('handles move conflict with overwrite true', async ({fs}) => {
 	const dir = '/a/b';
 	const filename1 = '1.ts';
 	const filename2 = '2.ts';
@@ -226,17 +223,16 @@ test_move('move conflict with overwrite true', async ({fs}) => {
 	const path2 = `${dir}/${filename2}`;
 	await fs.outputFile(path1, fakeTsContents);
 	await fs.outputFile(path2, fakeTsContents);
-	t.is(fs._files.size, 4);
+	t.is(fs._files.size, 5);
 	await fs.move(path1, path2, {overwrite: true});
 	t.ok(!fs._exists(path1));
 	t.ok(fs._exists(path2));
-	t.is(fs._files.size, 3);
+	t.is(fs._files.size, 4);
 });
 
 test_move('missing source path throws', async ({fs}) => {
 	// TODO async `t.throws` ? hmm
 	try {
-		fs._reset();
 		await fs.move('/missing/file', '/');
 	} catch (err) {
 		return;
@@ -246,6 +242,93 @@ test_move('missing source path throws', async ({fs}) => {
 
 test_move.run();
 /* /test_move */
+
+/* test_copy */
+const test_copy = suite('copy', suiteContext);
+test_copy.before.each(resetMemoryFs);
+
+test_copy('basic behavior', async ({fs}) => {
+	const dest = '/testdest';
+	for (const path of testPaths) {
+		fs._reset();
+		await fs.outputFile(path, 'contents', 'utf8');
+		t.ok(fs._exists(path));
+		t.ok(!fs._exists(dest));
+		await fs.copy(path, dest);
+		t.ok(fs._exists(path));
+		t.ok(fs._exists(dest));
+	}
+});
+
+test_copy('copies contained files and dirs', async ({fs}) => {
+	const path = '/a/b/c';
+	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
+	await fs.outputFile(`${path}/dir1/b/c.ts`, fakeTsContents);
+	await fs.outputFile(`${path}/dir2/d.ts`, fakeTsContents);
+	t.is(fs._files.size, 10);
+	const newPath = '/a/e';
+	await fs.copy(`${path}/dir1`, `${newPath}/dir1`); // TODO any special merge behavior?
+	t.ok(fs._exists(`${newPath}/dir1`));
+	t.ok(fs._exists(`${newPath}/dir1/a.ts`));
+	t.ok(fs._exists(`${newPath}/dir1/b`));
+	t.ok(fs._exists(`${newPath}/dir1/b/c.ts`));
+	t.ok(fs._exists(`${path}/dir2/d.ts`));
+	t.ok(fs._exists(`${path}/dir1`));
+	t.ok(fs._exists(`${path}/dir1/a.ts`));
+	t.ok(fs._exists(`${path}/dir1/b`));
+	t.ok(fs._exists(`${path}/dir1/b/c.ts`));
+	t.is(fs._files.size, 15); // add the one new base dir
+});
+
+test_copy('handles copy conflict with overwrite false', async ({fs}) => {
+	const dir = '/a/b';
+	const filename1 = '1.ts';
+	const filename2 = '2.ts';
+	const path1 = `${dir}/${filename1}`;
+	const path2 = `${dir}/${filename2}`;
+	await fs.outputFile(path1, fakeTsContents);
+	await fs.outputFile(path2, fakeTsContents);
+	t.is(fs._files.size, 5);
+	// async `t.throws`
+	let failed = true;
+	try {
+		await fs.copy(path1, path2); // TODO does it throw?
+	} catch (err) {
+		failed = false;
+	}
+	if (failed) throw Error();
+	t.ok(fs._exists(path1));
+	t.ok(fs._exists(path2));
+	t.is(fs._files.size, 5);
+});
+
+test_copy('handles copy conflict with overwrite true', async ({fs}) => {
+	const dir = '/a/b';
+	const filename1 = '1.ts';
+	const filename2 = '2.ts';
+	const path1 = `${dir}/${filename1}`;
+	const path2 = `${dir}/${filename2}`;
+	await fs.outputFile(path1, fakeTsContents);
+	await fs.outputFile(path2, fakeTsContents);
+	t.is(fs._files.size, 5);
+	await fs.copy(path1, path2, {overwrite: true});
+	t.ok(fs._exists(path1));
+	t.ok(fs._exists(path2));
+	t.is(fs._files.size, 5);
+});
+
+test_copy('missing source path throws', async ({fs}) => {
+	// TODO async `t.throws` ? hmm
+	try {
+		await fs.copy('/missing/file', '/');
+	} catch (err) {
+		return;
+	}
+	throw Error();
+});
+
+test_copy.run();
+/* /test_copy */
 
 /* test_findFiles */
 const test_findFiles = suite('findFiles', suiteContext);
@@ -298,3 +381,42 @@ test_ensureDir('normalize paths', async ({fs}) => {
 
 test_ensureDir.run();
 /* /test_ensureDir */
+
+/* test_emptyDir */
+const test_emptyDir = suite('emptyDir', suiteContext);
+test_emptyDir.before.each(resetMemoryFs);
+
+test_emptyDir('basic behavior', async ({fs}) => {
+	for (const path of testPaths) {
+		fs._reset();
+		await fs.outputFile(path, 'contents', 'utf8');
+		t.ok(fs._exists(path));
+		const {size} = fs._files;
+		const dir = dirname(path);
+		await fs.emptyDir(dir);
+		t.ok(fs._exists(dir));
+		t.ok(!fs._exists(path));
+		t.ok(size > fs._files.size);
+		t.ok(fs._files.size);
+	}
+});
+
+test_emptyDir('emptyDirs contained files and dirs', async ({fs}) => {
+	const path = '/a/b/c';
+	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
+	await fs.outputFile(`${path}/dir1/b/c1.ts`, fakeTsContents);
+	await fs.outputFile(`${path}/dir1/b/c2.ts`, fakeTsContents);
+	await fs.outputFile(`${path}/dir1/b/c3.ts`, fakeTsContents);
+	await fs.outputFile(`${path}/dir2/d.ts`, fakeTsContents);
+	t.is(fs._files.size, 12);
+	await fs.emptyDir(`${path}/dir1`);
+	t.is(fs._files.size, 7);
+	t.ok(fs._exists(`${path}/dir1`));
+});
+
+test_emptyDir('missing file fails silently', async ({fs}) => {
+	await fs.emptyDir('/missing/file');
+});
+
+test_emptyDir.run();
+/* /test_emptyDir */

--- a/src/fs/memory.test.ts
+++ b/src/fs/memory.test.ts
@@ -264,20 +264,24 @@ test_copy('copies contained files and dirs', async ({fs}) => {
 	const path = '/a/b/c';
 	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
 	await fs.outputFile(`${path}/dir1/b/c.ts`, fakeTsContents);
+	await fs.outputFile(`${path}/dir1/b/IGNORE.ts`, fakeTsContents);
 	await fs.outputFile(`${path}/dir2/d.ts`, fakeTsContents);
-	t.is(fs._files.size, 10);
+	t.is(fs._files.size, 11);
 	const newPath = '/a/e';
-	await fs.copy(`${path}/dir1`, `${newPath}/dir1`); // TODO any special merge behavior?
+	await fs.copy(`${path}/dir1`, `${newPath}/dir1`, {filter: (id) => !id.endsWith('/IGNORE.ts')});
 	t.ok(fs._exists(`${newPath}/dir1`));
 	t.ok(fs._exists(`${newPath}/dir1/a.ts`));
 	t.ok(fs._exists(`${newPath}/dir1/b`));
 	t.ok(fs._exists(`${newPath}/dir1/b/c.ts`));
+	t.ok(!fs._exists(`${newPath}/dir1/b/IGNORE.ts`));
+	t.ok(!fs._exists(`${newPath}/dir2/d.ts`));
 	t.ok(fs._exists(`${path}/dir2/d.ts`));
 	t.ok(fs._exists(`${path}/dir1`));
 	t.ok(fs._exists(`${path}/dir1/a.ts`));
 	t.ok(fs._exists(`${path}/dir1/b`));
 	t.ok(fs._exists(`${path}/dir1/b/c.ts`));
-	t.is(fs._files.size, 15); // add the one new base dir
+	t.ok(fs._exists(`${path}/dir1/b/IGNORE.ts`));
+	t.is(fs._files.size, 16); // add the one new base dir
 });
 
 test_copy('handles copy conflict with overwrite false', async ({fs}) => {

--- a/src/fs/memory.ts
+++ b/src/fs/memory.ts
@@ -156,7 +156,7 @@ export class MemoryFs extends Fs {
 		// create a new node at the new location
 		for (const srcNode of srcNodes) {
 			const nodeDestId = `${destId === ROOT ? '' : destId}${stripStart(srcNode.id, srcId)}`;
-			if (filter && !filter(srcNode.id, nodeDestId)) continue;
+			if (filter && !(await filter(srcNode.id, nodeDestId))) continue;
 			const exists = this._files.has(nodeDestId);
 			let output = false;
 			if (exists) {

--- a/src/fs/memory.ts
+++ b/src/fs/memory.ts
@@ -78,7 +78,7 @@ export class MemoryFs extends Fs {
 		}
 		return file.stats;
 	};
-	pathExists = async (path: string): Promise<boolean> => {
+	exists = async (path: string): Promise<boolean> => {
 		const id = toFsId(path);
 		return this._files.has(id);
 	};

--- a/src/fs/memory.ts
+++ b/src/fs/memory.ts
@@ -99,10 +99,6 @@ export class MemoryFs extends Fs {
 		}
 		return file.contents || '';
 	};
-	readJson = async (path: string): Promise<any> => {
-		const contents = await this.readFile(path, 'utf8');
-		return JSON.parse(contents);
-	};
 	outputFile = async (path: string, data: any, encoding: Encoding = 'utf8'): Promise<void> => {
 		const id = toFsId(path);
 

--- a/src/fs/memory.ts
+++ b/src/fs/memory.ts
@@ -145,6 +145,8 @@ export class MemoryFs extends Fs {
 		await this.remove(srcId);
 	};
 	copy = async (srcPath: string, destPath: string, options?: FsCopyOptions): Promise<void> => {
+		const overwrite = options?.overwrite;
+		const filter = options?.filter;
 		const srcId = toFsId(srcPath);
 		// first grab the nodes and delete the src
 		const srcNodes = this._filter(srcId);
@@ -154,10 +156,11 @@ export class MemoryFs extends Fs {
 		// create a new node at the new location
 		for (const srcNode of srcNodes) {
 			const nodeDestId = `${destId === ROOT ? '' : destId}${stripStart(srcNode.id, srcId)}`;
+			if (filter && !filter(srcNode.id, nodeDestId)) continue;
 			const exists = this._files.has(nodeDestId);
 			let output = false;
 			if (exists) {
-				if (options?.overwrite) {
+				if (overwrite) {
 					await this.remove(nodeDestId);
 					output = true;
 				} else {

--- a/src/fs/memory.ts
+++ b/src/fs/memory.ts
@@ -1,0 +1,158 @@
+import {Fs, toFsId, FsStats} from './filesystem.js';
+import type {FsCopyOptions, FsId, FsMoveOptions, FsNode} from './filesystem';
+import {toPathData} from './pathData.js';
+import type {PathStats} from './pathData.js';
+import {compareSimpleMapEntries} from '../utils/map.js';
+import type {PathFilter} from './pathFilter.js';
+import type {Encoding} from './encoding.js';
+import type {Assignable} from '../utils/types.js';
+import {toPathParts} from '../utils/path.js';
+
+// TODO extend EventEmitter and emit lots of events
+// TODO formalize module interface for all filesystem impls
+// TODO should this module have a more specific name? or a more specific directory, with all other implementations?
+
+// TODO can we have internal methods that don't normalize `toFsId`? or flags to avoid normalizing? (optional bool? could be a long-lived object)
+
+export class MemoryFs extends Fs {
+	// TODO for now we're prefixing all non-Fs API with an underscore for clarity, maybe compose better?
+	// TODO other data structures? what access patterns do we want to optimize for?
+	_files: Map<FsId, FsNode> = new Map();
+	_find(id: FsId): FsNode | undefined {
+		return this._files.get(id);
+	}
+	_update(id: FsId, node: FsNode): void {
+		// TODO should this merge? or always expect that upstream? or maybe `_merge`
+		this._files.set(id, node);
+	}
+	_add(node: FsNode): void {
+		this._update(node.id, node);
+		const pathParts = toPathParts(node.id);
+		// skip the last one, that's what's created above
+		for (let i = 0; i < pathParts.length - 1; i++) {
+			const pathPart = pathParts[i];
+			const isDirectory = true;
+			const stats = new FsStats(isDirectory);
+			this._update(pathPart, {
+				id: pathPart,
+				isDirectory,
+				encoding: null,
+				contents: null,
+				// contentsBuffer: null,
+				stats,
+				path: toPathData(pathPart, stats),
+			});
+		}
+	}
+	// delete everything, a very safe and cool `rm -rf /`
+	_reset() {
+		this._files.clear();
+	}
+
+	stat = async (path: string): Promise<PathStats> => {
+		const id = toFsId(path);
+		const file = this._find(id);
+		if (!file) {
+			throw Error(`ENOENT: no such file or directory, stat '${id}'`);
+		}
+		return file.stats;
+	};
+	pathExists = async (path: string): Promise<boolean> => {
+		const id = toFsId(path);
+		return this._files.has(id);
+	};
+	// TODO the `any` fixes a type error, not sure how to fix properly
+	readFile: Fs['readFile'] = async (path: string, encoding?: Encoding): Promise<any> => {
+		const id = toFsId(path);
+		const file = this._find(id);
+		if (!file) {
+			throw Error(`ENOENT: no such file or directory, open '${id}'`);
+		}
+		if (file.encoding !== encoding) {
+			console.error('unexpected encoding mismatch', encoding, file);
+		}
+		return file.contents || '';
+	};
+	readJson = async (path: string): Promise<any> => {
+		const contents = await this.readFile(path, 'utf8');
+		return JSON.parse(contents);
+	};
+	outputFile = async (path: string, data: any, encoding: Encoding = 'utf8'): Promise<void> => {
+		const id = toFsId(path);
+
+		// does the file already exist? update if so
+		const file = this._find(id);
+		if (file) {
+			(file as Assignable<FsNode, 'contents'>).contents = data;
+			return;
+		}
+
+		// doesn't exist, so create it
+		const stats = new FsStats(false);
+		this._add({
+			id,
+			isDirectory: false,
+			encoding,
+			contents: data,
+			// contentsBuffer: data, // TODO lazily load this?
+			stats,
+			path: toPathData(id, stats),
+		});
+	};
+	remove = async (path: string): Promise<void> => {
+		// TODO
+	};
+	move = async (src: string, dest: string, options?: FsMoveOptions): Promise<void> => {
+		// TODO
+	};
+	copy = async (src: string, dest: string, options?: FsCopyOptions): Promise<void> => {
+		// TODO
+	};
+	readDir = async (path: string): Promise<string[]> => {
+		// TODO
+		return [];
+	};
+	emptyDir = async (path: string): Promise<void> => {
+		// TODO
+	};
+	ensureDir = async (path: string): Promise<void> => {
+		if (await this.pathExists(path)) return;
+		// TODO normalize path
+		const id = toFsId(path);
+		const isDirectory = true;
+		const stats = new FsStats(isDirectory);
+		this._add({
+			id,
+			isDirectory,
+			encoding: null,
+			contents: null,
+			// contentsBuffer: null,
+			stats,
+			path: toPathData(id, stats),
+		});
+	};
+	findFiles = async (
+		dir: string,
+		filter?: PathFilter,
+		// pass `null` to speed things up at the risk of rare misorderings
+		sort: typeof compareSimpleMapEntries | null = compareSimpleMapEntries,
+	): Promise<Map<string, PathStats>> => {
+		// TODO wait so in the dir .. we can now find this dir and all of its subdirs
+		// cache the subdirs somehow (backlink to parent node? do we have stable references? we do ya?)
+
+		const found = new Map();
+		const baseDir = toFsId(dir); // TODO resolve relative to filesystem's base (mount at `/` in memory!)
+		for (const file of this._files.values()) {
+			if (file.id.startsWith(baseDir)) {
+				// TODO should each file have its `basePath`?
+				// const basePath = stripStart(file.id, baseDir);
+				// console.log('basePath', basePath);
+				found.set(file.id, file.stats);
+			}
+		}
+		// console.log('found', Array.from(found.entries()));
+		return found;
+	};
+}
+
+export const fs = new MemoryFs();

--- a/src/fs/modules.test.ts
+++ b/src/fs/modules.test.ts
@@ -6,7 +6,7 @@ import {findModules, loadModules, loadModule} from './modules.js';
 import * as modTest1 from './fixtures/test1.foo.js';
 import * as modTestBaz1 from './fixtures/baz1/test1.baz.js';
 import * as modTestBaz2 from './fixtures/baz2/test2.baz.js';
-import {findFiles, nodeFilesystem} from './node.js';
+import {findFiles, fs} from './node.js';
 import {getPossibleSourceIds} from './inputPath.js';
 import type {Obj} from '../index.js';
 
@@ -76,7 +76,7 @@ test_findModules('with and without extension', async () => {
 	const id1 = resolve('src/fs/fixtures/test1.foo.ts');
 	const id2 = resolve('src/fs/fixtures/test2.foo.ts');
 	const result = await findModules(
-		nodeFilesystem,
+		fs,
 		[path1, id2],
 		(id) => findFiles(id),
 		(inputPath) => getPossibleSourceIds(inputPath, ['.foo.ts']),
@@ -100,7 +100,7 @@ test_findModules('with and without extension', async () => {
 
 test_findModules('directory', async () => {
 	const id = resolve('src/fs/fixtures/');
-	const result = await findModules(nodeFilesystem, [id], (id) =>
+	const result = await findModules(fs, [id], (id) =>
 		findFiles(id, ({path}) => path.includes('.foo.')),
 	);
 	t.ok(result.ok);
@@ -113,7 +113,7 @@ test_findModules('directory', async () => {
 
 test_findModules('fail with unmappedInputPaths', async () => {
 	const result = await findModules(
-		nodeFilesystem,
+		fs,
 		[
 			resolve('src/fs/fixtures/bar1'),
 			resolve('src/fs/fixtures/failme1'),
@@ -137,7 +137,7 @@ test_findModules('fail with unmappedInputPaths', async () => {
 
 test_findModules('fail with inputDirectoriesWithNoFiles', async () => {
 	const result = await findModules(
-		nodeFilesystem,
+		fs,
 		[
 			resolve('src/fs/fixtures/baz1'),
 			resolve('src/fs/fixtures/bar1'),

--- a/src/fs/modules.test.ts
+++ b/src/fs/modules.test.ts
@@ -6,7 +6,7 @@ import {findModules, loadModules, loadModule} from './modules.js';
 import * as modTest1 from './fixtures/test1.foo.js';
 import * as modTestBaz1 from './fixtures/baz1/test1.baz.js';
 import * as modTestBaz2 from './fixtures/baz2/test2.baz.js';
-import {findFiles, fs} from './node.js';
+import {fs} from './node.js';
 import {getPossibleSourceIds} from './inputPath.js';
 import type {Obj} from '../index.js';
 
@@ -78,7 +78,7 @@ test_findModules('with and without extension', async () => {
 	const result = await findModules(
 		fs,
 		[path1, id2],
-		(id) => findFiles(id),
+		(id) => fs.findFiles(id),
 		(inputPath) => getPossibleSourceIds(inputPath, ['.foo.ts']),
 	);
 	t.ok(result.ok);
@@ -101,7 +101,7 @@ test_findModules('with and without extension', async () => {
 test_findModules('directory', async () => {
 	const id = resolve('src/fs/fixtures/');
 	const result = await findModules(fs, [id], (id) =>
-		findFiles(id, ({path}) => path.includes('.foo.')),
+		fs.findFiles(id, ({path}) => path.includes('.foo.')),
 	);
 	t.ok(result.ok);
 	t.equal(
@@ -120,7 +120,7 @@ test_findModules('fail with unmappedInputPaths', async () => {
 			resolve('src/fs/fixtures/bar2'),
 			resolve('src/fs/fixtures/failme2'),
 		],
-		(id) => findFiles(id),
+		(id) => fs.findFiles(id),
 		(inputPath) => getPossibleSourceIds(inputPath, ['.foo.ts']),
 	);
 	t.not.ok(result.ok);
@@ -144,7 +144,7 @@ test_findModules('fail with inputDirectoriesWithNoFiles', async () => {
 			resolve('src/fs/fixtures/bar2'),
 			resolve('src/fs/fixtures/baz2'),
 		],
-		(id) => findFiles(id, ({path}) => !path.includes('.bar.')),
+		(id) => fs.findFiles(id, ({path}) => !path.includes('.bar.')),
 	);
 	t.not.ok(result.ok);
 	t.ok(result.reasons.length);

--- a/src/fs/node.test.ts
+++ b/src/fs/node.test.ts
@@ -1,0 +1,38 @@
+import {suite} from 'uvu';
+import * as t from 'uvu/assert';
+
+import {fs as nodeFs} from './node.js';
+
+/* test_findFiles */
+const test_findFiles = suite('findFiles', {fs: nodeFs});
+
+test_findFiles('basic behavior', async ({fs}) => {
+	const ignoredPath = 'test1.foo.ts';
+	let hasIgnoredPath = false;
+	const result = await fs.findFiles(
+		'./src/fs/fixtures',
+		({path}) => {
+			if (!hasIgnoredPath) hasIgnoredPath = path === ignoredPath;
+			return path !== 'test1.foo.ts';
+		},
+		(a, b) => -a[0].localeCompare(b[0]),
+	);
+	t.ok(hasIgnoredPath); // makes sure the test isn't wrong
+	t.ok(result.size);
+	t.equal(Array.from(result.keys()), [
+		'test2.foo.ts',
+		'baz2/test2.baz.ts',
+		'baz2',
+		'baz1/test1.baz.ts',
+		'baz1',
+		'bar2/test2.bar.ts',
+		'bar2',
+		'bar1/test1.bar.ts',
+		'bar1',
+	]);
+});
+
+// TODO more tests
+
+test_findFiles.run();
+/* /test_findFiles */

--- a/src/fs/node.test.ts
+++ b/src/fs/node.test.ts
@@ -13,12 +13,11 @@ test_findFiles('basic behavior', async ({fs}) => {
 		'./src/fs/fixtures',
 		({path}) => {
 			if (!hasIgnoredPath) hasIgnoredPath = path === ignoredPath;
-			return path !== 'test1.foo.ts';
+			return path !== ignoredPath;
 		},
 		(a, b) => -a[0].localeCompare(b[0]),
 	);
 	t.ok(hasIgnoredPath); // makes sure the test isn't wrong
-	t.ok(result.size);
 	t.equal(Array.from(result.keys()), [
 		'test2.foo.ts',
 		'baz2/test2.baz.ts',

--- a/src/fs/node.ts
+++ b/src/fs/node.ts
@@ -9,7 +9,7 @@ import type {PathFilter} from './pathFilter.js';
 // This uses `CheapWatch` which probably isn't the fastest, but it works fine for now.
 // TODO should this API be changed to only include files and not directories?
 // or maybe change the name so it's not misleading?
-export const findFiles = async (
+const findFiles = async (
 	dir: string,
 	filter?: PathFilter,
 	// pass `null` to speed things up at the risk of rare misorderings

--- a/src/fs/node.ts
+++ b/src/fs/node.ts
@@ -31,7 +31,6 @@ export const fs: Filesystem = {
 	stat: fsExtra.stat,
 	exists: fsExtra.pathExists,
 	readFile: fsExtra.readFile,
-	readJson: fsExtra.readJson,
 	outputFile: fsExtra.outputFile as FsOutputFile, // TODO incompatible encodings: is this an actual problem? or is `fs-extra` mistyped? test with `null`
 	remove: fsExtra.remove,
 	move: fsExtra.move,

--- a/src/fs/node.ts
+++ b/src/fs/node.ts
@@ -29,7 +29,7 @@ export const findFiles = async (
 
 export const fs: Filesystem = {
 	stat: fsExtra.stat,
-	pathExists: fsExtra.pathExists,
+	exists: fsExtra.pathExists,
 	readFile: fsExtra.readFile,
 	readJson: fsExtra.readJson,
 	outputFile: fsExtra.outputFile as FsOutputFile, // TODO incompatible encodings: is this an actual problem? or is `fs-extra` mistyped? test with `null`

--- a/src/fs/node.ts
+++ b/src/fs/node.ts
@@ -1,7 +1,7 @@
 import CheapWatch from 'cheap-watch';
 import fsExtra from 'fs-extra';
 
-import type {Filesystem} from './filesystem.js';
+import type {Filesystem, FsOutputFile} from './filesystem.js';
 import type {PathStats} from './pathData.js';
 import {sortMap, compareSimpleMapEntries} from '../utils/map.js';
 import type {PathFilter} from './pathFilter.js';
@@ -27,48 +27,17 @@ export const findFiles = async (
 	return sort ? sortMap(watcher.paths, sort) : watcher.paths;
 };
 
-/*
-
-Re-export the functions we use from `fs-extra`.
-The reason is twofold.
-
-1. `fs-extra` doesn't support named imports yet.
-https://github.com/jprichardson/node-fs-extra/issues/746
-
-2. We want to minimize our code's reliance
-to the Node platform when the cost and friction are low.
-Eventually we'll want our code to run on other platforms, like Deno,
-and this practice will make future interop or migration more feasible.
-
-All of these functions return promises.
-This is important because they will conform to a future filesystem host interface,
-and because we need to support contexts like the browser and who knows what remote servers,
-an async-only filesystem interface is the way to go.
-
-*/
-export const stat = fsExtra.stat;
-export const pathExists = fsExtra.pathExists;
-export const readFile = fsExtra.readFile;
-export const readJson = fsExtra.readJson;
-export const outputFile = fsExtra.outputFile;
-export const remove = fsExtra.remove;
-export const move = fsExtra.move;
-export const copy = fsExtra.copy;
-export const readDir = fsExtra.readdir;
-export const emptyDir = fsExtra.emptyDir;
-export const ensureDir = fsExtra.ensureDir;
-
-export const nodeFilesystem: Filesystem = {
-	stat,
-	pathExists,
-	readFile,
-	readJson,
-	outputFile,
-	remove,
-	move,
-	copy,
-	readDir,
-	emptyDir,
-	ensureDir,
+export const fs: Filesystem = {
+	stat: fsExtra.stat,
+	pathExists: fsExtra.pathExists,
+	readFile: fsExtra.readFile,
+	readJson: fsExtra.readJson,
+	outputFile: fsExtra.outputFile as FsOutputFile, // TODO incompatible encodings: is this an actual problem? or is `fs-extra` mistyped? test with `null`
+	remove: fsExtra.remove,
+	move: fsExtra.move,
+	copy: fsExtra.copy,
+	readDir: fsExtra.readdir,
+	emptyDir: fsExtra.emptyDir,
+	ensureDir: fsExtra.ensureDir,
 	findFiles,
 };

--- a/src/fs/pathData.ts
+++ b/src/fs/pathData.ts
@@ -3,14 +3,16 @@ export interface PathData {
 	isDirectory: boolean;
 }
 
-// This is a browser-compatible subset of `fs.Stats`.
-export interface PathStats {
-	isDirectory(): boolean;
-}
-
 export const toPathData = (id: string, stats: PathStats): PathData => {
 	return {
 		id,
 		isDirectory: stats.isDirectory(),
 	};
 };
+
+// This is a browser-compatible subset of `fs.Stats`.
+// TODO the `size` ? should we always support it?
+export interface PathStats {
+	size?: number;
+	isDirectory(): boolean;
+}

--- a/src/gen/genModule.test.ts
+++ b/src/gen/genModule.test.ts
@@ -4,7 +4,7 @@ import {join} from 'path';
 
 import {validateGenModule, findGenModules} from './genModule.js';
 import {paths} from '../paths.js';
-import {nodeFilesystem} from '../fs/node.js';
+import {fs} from '../fs/node.js';
 
 /* test_validateGenModule */
 const test_validateGenModule = suite('validateGenModule');
@@ -25,7 +25,7 @@ test_validateGenModule.run();
 const test_findGenModules = suite('findGenModules');
 
 test_findGenModules('finds gen modules in a directory', async () => {
-	const findGenModulesResult = await findGenModules(nodeFilesystem, [join(paths.source, 'docs/')]);
+	const findGenModulesResult = await findGenModules(fs, [join(paths.source, 'docs/')]);
 	t.ok(findGenModulesResult.ok);
 	t.ok(findGenModulesResult.sourceIdPathDataByInputPath.size);
 });

--- a/src/gen/genModule.ts
+++ b/src/gen/genModule.ts
@@ -45,7 +45,7 @@ export const checkGenModule = async (
 	fs: Filesystem,
 	file: GenFile,
 ): Promise<CheckGenModuleResult> => {
-	if (!(await fs.pathExists(file.id))) {
+	if (!(await fs.exists(file.id))) {
 		return {
 			file,
 			existingContents: null,

--- a/src/gen/runGen.test.ts
+++ b/src/gen/runGen.test.ts
@@ -4,7 +4,7 @@ import {resolve, join} from 'path';
 
 import type {GenModuleMeta} from './genModule.js';
 import {runGen} from './runGen.js';
-import {nodeFilesystem} from '../fs/node.js';
+import {fs} from '../fs/node.js';
 
 /* test_gen */
 const test_gen = suite('gen');
@@ -64,11 +64,8 @@ test_gen('basic behavior', async () => {
 		},
 	};
 	const genModulesByInputPath = [modA, modB, modC];
-	const genResults = await runGen(
-		nodeFilesystem,
-		genModulesByInputPath,
-		async (_fs, id, contents) =>
-			id.endsWith('outputB.ts') ? `${contents}/*FORMATTED*/` : contents,
+	const genResults = await runGen(fs, genModulesByInputPath, async (_fs, id, contents) =>
+		id.endsWith('outputB.ts') ? `${contents}/*FORMATTED*/` : contents,
 	);
 	t.is(genResults.inputCount, 3);
 	t.is(genResults.outputCount, 4);
@@ -149,7 +146,7 @@ test_gen('failing gen function', async () => {
 		},
 	};
 	const genModulesByInputPath: GenModuleMeta[] = [modA, modB];
-	const genResults = await runGen(nodeFilesystem, genModulesByInputPath);
+	const genResults = await runGen(fs, genModulesByInputPath);
 	t.is(genResults.inputCount, 2);
 	t.is(genResults.outputCount, 1);
 	t.is(genResults.successes.length, 1);

--- a/src/project/packageJson.ts
+++ b/src/project/packageJson.ts
@@ -27,7 +27,7 @@ export const loadPackageJson = async (
 ): Promise<PackageJson> => {
 	if (isThisProjectGro) return loadGroPackageJson(fs, forceRefresh);
 	if (!packageJson || forceRefresh) {
-		packageJson = await fs.readJson(join(paths.root, 'package.json'));
+		packageJson = JSON.parse(await fs.readFile(join(paths.root, 'package.json'), 'utf8'));
 	}
 	return packageJson!;
 };
@@ -36,7 +36,7 @@ export const loadGroPackageJson = async (
 	forceRefresh = false,
 ): Promise<GroPackageJson> => {
 	if (!groPackageJson || forceRefresh) {
-		groPackageJson = await fs.readJson(join(groPaths.root, 'package.json'));
+		groPackageJson = JSON.parse(await fs.readFile(join(groPaths.root, 'package.json'), 'utf8'));
 	}
 	return groPackageJson!;
 };

--- a/src/project/rollup-plugin-plain-css.ts
+++ b/src/project/rollup-plugin-plain-css.ts
@@ -66,7 +66,7 @@ export const plainCssPlugin = (opts: InitialOptions): Plugin => {
 			// despite using `{skipSelf: true}`. So we manually resolve the id.
 			const resolvedId = resolve(dirname(importer), importee);
 			if (sortIndexById.has(resolvedId)) return resolvedId; // this doesn't account for import order changing while in watch mode
-			if (!(await fs.pathExists(resolvedId))) return null; // allow node imports like `normalize.css`
+			if (!(await fs.exists(resolvedId))) return null; // allow node imports like `normalize.css`
 			sortIndexById.set(resolvedId, currentSortIndex);
 			currentSortIndex++;
 			return resolvedId;

--- a/src/server.task.ts
+++ b/src/server.task.ts
@@ -38,7 +38,7 @@ export const task: Task<{}, TaskEvents> = {
 	description: 'start API server',
 	run: async ({fs, dev, events, log}) => {
 		const serverPath = toApiServerBuildPath(dev);
-		if (!(await fs.pathExists(serverPath))) {
+		if (!(await fs.exists(serverPath))) {
 			log.error(red('server path does not exist:'), serverPath);
 			throw Error(`API server failed to start due to missing file: ${serverPath}`);
 		}

--- a/src/server/https.ts
+++ b/src/server/https.ts
@@ -23,10 +23,7 @@ export const loadHttpsCredentials = async (
 	certFile = DEFAULT_CERT_FILE,
 	keyFile = DEFAULT_CERTKEY_FILE,
 ): Promise<HttpsCredentials | null> => {
-	const [certExists, keyExists] = await Promise.all([
-		fs.pathExists(certFile),
-		fs.pathExists(keyFile),
-	]);
+	const [certExists, keyExists] = await Promise.all([fs.exists(certFile), fs.exists(keyFile)]);
 	if (!certExists && !keyExists) return null;
 	if (certExists && !keyExists) {
 		log.warn('https cert exists but the key file does not', keyFile);

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -27,7 +27,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		const timings = new Timings();
 
 		// build if needed
-		if (!(await fs.pathExists(paths.dist))) {
+		if (!(await fs.exists(paths.dist))) {
 			log.info(green('dist not detected; building'));
 			const timingToBuild = timings.start('build');
 			await invokeTask('build');

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -245,8 +245,8 @@ const shouldBuildProject = async (fs: Filesystem, sourceId: string): Promise<boo
 	// don't try to compile Gro's own codebase from outside of it
 	if (!isThisProjectGro && isGroId(sourceId)) return false;
 	// if this is Gro, ensure the build directory exists, because tests aren't in dist/
-	if (isThisProjectGro && !(await fs.pathExists(paths.build))) return true;
+	if (isThisProjectGro && !(await fs.exists(paths.build))) return true;
 	// ensure the build file for the source id exists in the default dev build
 	const buildId = toImportId(sourceId, true, PRIMARY_NODE_BUILD_CONFIG_NAME);
-	return !(await fs.pathExists(buildId));
+	return !(await fs.exists(buildId));
 };

--- a/src/task/runTask.test.ts
+++ b/src/task/runTask.test.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from 'events';
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
-import {nodeFilesystem} from '../fs/node.js';
+import {fs} from '../fs/node.js';
 
 import {runTask} from './runTask.js';
 
@@ -11,7 +11,7 @@ const test_runTask = suite('runTask');
 test_runTask('passes args and returns output', async () => {
 	const args = {a: 1, _: []};
 	const result = await runTask(
-		nodeFilesystem,
+		fs,
 		{
 			name: 'testTask',
 			id: 'foo/testTask',
@@ -35,7 +35,7 @@ test_runTask('invokes a sub task', async () => {
 	let invokedTaskName;
 	let invokedArgs;
 	const result = await runTask(
-		nodeFilesystem,
+		fs,
 		{
 			name: 'testTask',
 			id: 'foo/testTask',
@@ -65,7 +65,7 @@ test_runTask('invokes a sub task', async () => {
 test_runTask('failing task', async () => {
 	let err;
 	const result = await runTask(
-		nodeFilesystem,
+		fs,
 		{
 			name: 'testTask',
 			id: 'foo/testTask',

--- a/src/task/taskModule.test.ts
+++ b/src/task/taskModule.test.ts
@@ -6,7 +6,7 @@ import {validateTaskModule, loadTaskModule, loadTaskModules} from './taskModule.
 import * as actualTestTaskModule from '../test.task.js';
 import * as testTaskModule from './fixtures/testTaskModule.taskFixture.js';
 import * as testInvalidTaskModule from './fixtures/testInvalidTaskModule.js';
-import {nodeFilesystem} from '../fs/node.js';
+import {fs} from '../fs/node.js';
 
 /* test_validateTaskModule */
 const test_validateTaskModule = suite('validateTaskModule');
@@ -66,10 +66,7 @@ test_loadTaskModule.run();
 const test_loadTaskModules = suite('loadTaskModules');
 
 test_loadTaskModules('basic behavior', async () => {
-	const result = await loadTaskModules(nodeFilesystem, [
-		resolve('src/test'),
-		resolve('src/test.task.ts'),
-	]);
+	const result = await loadTaskModules(fs, [resolve('src/test'), resolve('src/test.task.ts')]);
 	t.ok(result.ok);
 	t.is(result.modules.length, 1);
 	t.is(result.modules[0].mod, actualTestTaskModule);

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -22,7 +22,7 @@ export const task: Task = {
 		const testsBuildDir = toBuildOutPath(dev, PRIMARY_NODE_BUILD_CONFIG_NAME);
 
 		// TODO cleaner way to detect & rebuild?
-		if (!(await fs.pathExists(testsBuildDir))) {
+		if (!(await fs.exists(testsBuildDir))) {
 			const timingToLoadConfig = timings.start('load config');
 			const config = await loadGroConfig(fs, dev);
 			timingToLoadConfig();
@@ -34,7 +34,7 @@ export const task: Task = {
 			// Projects may not define any artifacts for the Node build,
 			// and we don't force anything out in that case,
 			// so just exit early if that happens.
-			if (!(await fs.pathExists(testsBuildDir))) {
+			if (!(await fs.exists(testsBuildDir))) {
 				log.info('no tests found');
 				return;
 			}

--- a/src/utils/map.test.ts
+++ b/src/utils/map.test.ts
@@ -8,20 +8,30 @@ const test_sortMap = suite('sortMap');
 
 test_sortMap('basic behavior', () => {
 	t.equal(
-		sortMap(
-			new Map([
-				['d', 1],
-				['a', 1],
-				['c', 1],
-				['b', 1],
-			]),
+		Array.from(
+			sortMap(
+				new Map([
+					['A', 1],
+					['B', 1],
+					['C', 1],
+					['d', 1],
+					['a', 1],
+					['c', 1],
+					['b', 1],
+				]),
+			).keys(),
 		),
-		new Map([
-			['a', 1],
-			['b', 1],
-			['c', 1],
-			['d', 1],
-		]),
+		Array.from(
+			new Map([
+				['a', 1],
+				['A', 1],
+				['b', 1],
+				['B', 1],
+				['c', 1],
+				['C', 1],
+				['d', 1],
+			]).keys(),
+		),
 	);
 });
 

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -1,5 +1,7 @@
 export const sortMap = <T extends Map<any, any>>(map: T, comparator = compareSimpleMapEntries): T =>
 	new Map([...map].sort(comparator)) as T;
 
-export const compareSimpleMapEntries = (a: [any, any], b: [any, any]): number =>
-	a[0] > b[0] ? 1 : -1;
+export const compareSimpleMapEntries = (a: [any, any], b: [any, any]): number => {
+	const aKey = a[0];
+	return typeof aKey === 'string' ? aKey.localeCompare(b[0]) : a[0] > b[0] ? 1 : -1;
+};

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -14,11 +14,10 @@ export const toPathParts = (path: string): string[] => {
 	const segments = toPathSegments(path);
 	let currentPath = path[0] === '/' ? '/' : '';
 	return segments.map((segment) => {
-		if (!currentPath || currentPath === '/') {
-			currentPath += segment;
-		} else {
-			currentPath += '/' + segment;
+		if (currentPath && currentPath !== '/') {
+			currentPath += '/';
 		}
+		currentPath += segment;
 		return currentPath;
 	});
 };


### PR DESCRIPTION
This expands the `Filesystem` interface and related abstractions with an abstract `Fs` class that is implemented in 1) Node via `fs-extra` and our existing interface in `src/fs/node.ts` and 2) memory via `src/fs/memory.ts`, added in this PR.

Things are in progress and there's a lot of details to get right. The goal is to run some `Filer` tests using a `MemoryFs`.