### PR TITLE
fix npm link

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Gro changelog
 
+## 0.20.1
+
+- upgrade to npm 7 and its v2 lockfile
+  ([#174](https://github.com/feltcoop/gro/pull/174),
+  [#175](https://github.com/feltcoop/gro/pull/175))
+
 ## 0.20.0
 
 - **break**: rework the `Filesystem` interfaces

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "start": "gro",
     "test": "gro test",
-    "bootstrap": "rm -rf .gro dist && esbuild src/**/*.ts src/*.ts --outdir=.gro/prod/node/; cp -r .gro/prod/node/ dist/ && npm link",
+    "bootstrap": "rm -rf .gro dist && esbuild src/**/*.ts src/*.ts --outdir=dist; npm link",
     "dev": "clear && npm run bootstrap && gro dev",
     "build": "clear && npm run bootstrap && gro build",
     "buildprod": "npm run build && rm -rf .gro",

--- a/src/fs/testModule.ts
+++ b/src/fs/testModule.ts
@@ -25,8 +25,9 @@ export const isTestBuildFile = (path: string): boolean => TEST_BUILD_FILE_MATCHE
 
 // Artifacts include typings and sourcemaps.
 export const TEST_BUILD_ARTIFACT_MATCHER = /.+\.test\.(js\.map|d\.ts|d\.ts\.map)$/;
+export const TEST_BUILD_FIXTURES_MATCHER = /\/fixtures\//;
 export const isTestBuildArtifact = (path: string): boolean =>
-	TEST_BUILD_ARTIFACT_MATCHER.test(path);
+	TEST_BUILD_ARTIFACT_MATCHER.test(path) || TEST_BUILD_FIXTURES_MATCHER.test(path);
 
 export const findTestModules = (
 	fs: Filesystem,

--- a/src/project/dist.task.ts
+++ b/src/project/dist.task.ts
@@ -29,7 +29,8 @@ export const task: Task = {
 			}),
 		);
 
-		// TODO this fixes the npm 7 linking issue, but it probably should be fixed a different way
+		// TODO this fixes the npm 7 linking issue, but it probably should be fixed a different way.
+		// Why is this needed here but not when we call `npm run bootstrap` and get esbuild outputs?
 		const chmodResult = await spawnProcess('chmod', ['+x', 'dist/cli/gro.js']);
 		if (!chmodResult.ok) log.error(`CLI chmod failed with code ${chmodResult.code}`);
 

--- a/src/project/dist.task.ts
+++ b/src/project/dist.task.ts
@@ -4,6 +4,7 @@ import {isTestBuildFile, isTestBuildArtifact} from '../fs/testModule.js';
 import {printPath} from '../utils/print.js';
 import {loadGroConfig} from '../config/config.js';
 import {printBuildConfig} from '../config/buildConfig.js';
+import {spawnProcess} from '../utils/process.js';
 
 export const task: Task = {
 	description: 'create and link the distribution',
@@ -27,6 +28,10 @@ export const task: Task = {
 				});
 			}),
 		);
+
+		// TODO this fixes the npm 7 linking issue, but it probably should be fixed a different way
+		const chmodResult = await spawnProcess('chmod', ['+x', 'dist/cli/gro.js']);
+		if (!chmodResult.ok) log.error(`CLI chmod failed with code ${chmodResult.code}`);
 
 		await invokeTask('project/link');
 	},


### PR DESCRIPTION
This fixes `npm link` for npm version 7. I'm totally stumped as to why this change is needed, and why it works just fine for the `esbuild` outputs but not `tsc`. I couldn't find any npm docs describing anything around this, except that `npm link` was rewritten for v7. Hopefully this fix is stable.