### PR TITLE
refactor gro prod build

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.20.2
+
+- refactor Gro's production build
+  ([#176](https://github.com/feltcoop/gro/pull/176))
+
 ## 0.20.1
 
 - upgrade to npm 7 and its v2 lockfile

--- a/src/fs/testModule.ts
+++ b/src/fs/testModule.ts
@@ -21,13 +21,14 @@ export const loadTestModule = (id: string): Promise<LoadModuleResult<TestModuleM
 	loadModule(id, validateTestModule);
 
 export const TEST_BUILD_FILE_MATCHER = /\.test\.js$/;
-export const isTestBuildFile = (path: string): boolean => TEST_BUILD_FILE_MATCHER.test(path);
+export const TEST_BUILD_FIXTURES_MATCHER = /\/fixtures(\/|$)/; // TODO combine with the above?
+export const isTestBuildFile = (path: string): boolean =>
+	TEST_BUILD_FILE_MATCHER.test(path) || TEST_BUILD_FIXTURES_MATCHER.test(path);
 
 // Artifacts include typings and sourcemaps.
 export const TEST_BUILD_ARTIFACT_MATCHER = /\.test\.(js\.map|d\.ts|d\.ts\.map)$/;
-export const TEST_BUILD_FIXTURES_MATCHER = /\/fixtures\//;
 export const isTestBuildArtifact = (path: string): boolean =>
-	TEST_BUILD_ARTIFACT_MATCHER.test(path) || TEST_BUILD_FIXTURES_MATCHER.test(path);
+	TEST_BUILD_ARTIFACT_MATCHER.test(path);
 
 export const findTestModules = (
 	fs: Filesystem,

--- a/src/project/dist.task.ts
+++ b/src/project/dist.task.ts
@@ -22,10 +22,7 @@ export const task: Task = {
 						? paths.dist
 						: `${paths.dist}${printBuildConfig(buildConfig)}`;
 				log.info(`copying ${printPath(buildOutDir)} to ${printPath(distOutDir)}`);
-				return fs.copy(buildOutDir, distOutDir, {
-					overwrite: false, // let the TypeScript output take priority, but allow other files like Svelte
-					filter: (id) => isDistFile(id),
-				});
+				return fs.copy(buildOutDir, distOutDir, {filter: (src) => isDistFile(src)});
 			}),
 		);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     // "allowJs": false, // Allow javascript files to be compiled.
     // "checkJs": false, // Report errors in .js files.
     // "outFile": "./", // Concatenate and emit output to single file.
-    "outDir": "dist", // Redirect output structure to the directory.
+    "outDir": ".gro/prod/node", // Redirect output structure to the directory.
     "rootDir": "src", // Specify the root directory of input files. Use to control the output directory structure with `--outDir`.
     // "project": "", // Compile a project given a valid configuration file.
 


### PR DESCRIPTION
This refactors how Gro creates its production build. It fixes an issue where non-dist files were being included.