### PR TITLE
fix deploy to pull the remote branch

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## 0.20.3
 
+- fix `gro deploy` to first pull the remote deploy branch
+  ([#178](https://github.com/feltcoop/gro/pull/178))
+
+## 0.20.3
+
 - fix production builds
   ([#177](https://github.com/feltcoop/gro/pull/177))
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Gro changelog
 
-## 0.20.3
+## 0.20.4
 
 - fix `gro deploy` to first pull the remote deploy branch
   ([#178](https://github.com/feltcoop/gro/pull/178))

--- a/contributing.md
+++ b/contributing.md
@@ -9,7 +9,7 @@ I don't want to spend much time on support outside of our needs.
 But I do want to give away the source code in case it can help!
 (and be improved? I'm not selfish for me, I'm selfish for the code, you see)
 The license is MIT, so you're free to use and repurpose it without our permission.
-We have so much work to do and Gro is just a low level tool.
+We have much work to do and Gro is just a low level tool.
 time is precious🌄
 
 Example: Gro doesn't support Windows. That's not great.

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -25,6 +25,7 @@ const DIST_DIRNAME = basename(DIST_DIR);
 const WORKTREE_DIRNAME = 'worktree';
 const WORKTREE_DIR = `${paths.root}${WORKTREE_DIRNAME}`;
 const DEPLOY_BRANCH = 'deploy';
+const ORIGIN = 'origin';
 const INITIAL_FILE = 'package.json'; // this is a single file that's copied into the new branch to bootstrap it
 const TEMP_PREFIX = '__TEMP__';
 const GIT_ARGS = {cwd: WORKTREE_DIR};
@@ -104,7 +105,7 @@ export const task: Task<TaskArgs> = {
 			// Set up the deployment worktree in the dist directory.
 			await spawnProcess('git', ['worktree', 'add', WORKTREE_DIRNAME, DEPLOY_BRANCH]);
 			// Pull the remote deploy branch.
-			const gitPullResult = await spawnProcess('git', ['pull', 'origin', DEPLOY_BRANCH], GIT_ARGS);
+			const gitPullResult = await spawnProcess('git', ['pull', ORIGIN, DEPLOY_BRANCH], GIT_ARGS);
 			if (!gitPullResult.ok) {
 				log.error(red(`failed git pull in deploy branch with exit code ${gitPullResult.code}`));
 				await cleanGitWorktree();
@@ -127,7 +128,7 @@ export const task: Task<TaskArgs> = {
 			// commit the changes
 			await spawnProcess('git', ['add', '.', '-f'], GIT_ARGS);
 			await spawnProcess('git', ['commit', '-m', 'deployment'], GIT_ARGS);
-			await spawnProcess('git', ['push', 'origin', DEPLOY_BRANCH], GIT_ARGS);
+			await spawnProcess('git', ['push', ORIGIN, DEPLOY_BRANCH], GIT_ARGS);
 		} catch (err) {
 			log.error(red('updating git failed:'), printError(err));
 			await cleanGitWorktree();


### PR DESCRIPTION
This fixes the `gro deploy` task in situations where your local `deploy` branch exists but is behind the remote. It should now `git pull` first from the remote.