### PR TITLE
fix build to copy files to dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It includes:
   unless it's a deliberate tradeoff
 - integrated [`fs`](src/fs/filesystem.ts) that works in [Node](src/fs/node.ts)
   (modeled & implemented with [`fs-extra`](https://github.com/jprichardson/node-fs-extra),
-  which is a drop-in replacement for Node's `fs`) and in
+  which is a drop-in replacement for Node's `fs` with better semantics) and in
   [memory](src/fs/memory.ts) (aka the browser/serviceworkers/node/etc)
   (TODO more, like a `localStorage` & GitHub repo)
 - testing with [uvu](https://github.com/lukeed/uvu)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.20.5
+
+- fix `gro build` to copy files to `dist/`
+  ([#179](https://github.com/feltcoop/gro/pull/179))
+
 ## 0.20.4
 
 - fix `gro deploy` to first pull the remote deploy branch

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.20.5
 
-- fix `gro build` to copy files to `dist/`
+- fix `gro build` to copy files to `dist/` with `src/build/dist.ts` helper
   ([#179](https://github.com/feltcoop/gro/pull/179))
 
 ## 0.20.4

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.20.5
 
-- fix `gro build` to copy files to `dist/` with `src/build/dist.ts` helper
+- fix `gro build` to copy files to `dist/` with `src/build/dist.ts` helper `copyDist`
   ([#179](https://github.com/feltcoop/gro/pull/179))
 
 ## 0.20.4

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -153,7 +153,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 				});
 				await build.promise;
 
-				// TODO might need to be refactored
+				// TODO might need to be refactored, like `filters` should be `buildConfig.input`
 				// copy static prod files into `dist/`
 				await copyDist(fs, buildConfig, dev, distCount, log, filters);
 			}),

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -131,20 +131,20 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		const distCount = config.builds.filter((b) => b.dist).length;
 		await Promise.all(
 			buildConfigsToBuild.map(async (buildConfig) => {
-				const inputFiles = await resolveInputFiles(fs, buildConfig);
-				if (!inputFiles.length) {
+				const {files, filters} = await resolveInputFiles(fs, buildConfig);
+				if (!files.length) {
 					log.trace('no input files in', printBuildConfigLabel(buildConfig));
 					return;
 				}
 				const outputDir = `${DIST_DIR}${toBuildExtension(
-					sourceIdToBasePath(ensureEnd(toCommonBaseDir(inputFiles), '/')), // TODO refactor when fixing the trailing `/`
+					sourceIdToBasePath(ensureEnd(toCommonBaseDir(files), '/')), // TODO refactor when fixing the trailing `/`
 				)}`;
-				log.info('building', printBuildConfigLabel(buildConfig), outputDir, inputFiles);
+				log.info('building', printBuildConfigLabel(buildConfig), outputDir, files);
 				const build = createBuild({
 					fs,
 					dev,
 					sourcemap: config.sourcemap,
-					inputFiles,
+					inputFiles: files,
 					outputDir,
 					mapInputOptions,
 					mapOutputOptions,
@@ -155,7 +155,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 
 				// TODO might need to be refactored
 				// copy static prod files into `dist/`
-				await copyDist(fs, buildConfig, dev, distCount, log);
+				await copyDist(fs, buildConfig, dev, distCount, log, filters);
 			}),
 		);
 		timingToBuild();

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -149,6 +149,8 @@ export const task: Task<TaskArgs, TaskEvents> = {
 					esbuildOptions,
 				});
 				await build.promise;
+
+				// TODO copy static files
 			}),
 		);
 		timingToBuild();

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -153,8 +153,8 @@ export const task: Task<TaskArgs, TaskEvents> = {
 				});
 				await build.promise;
 
-				// copy static files into `dist/`
-				// if (buildConfig.dist) { // TODO should we guard like this or just do that inside `copyDist`?
+				// TODO might need to be refactored
+				// copy static prod files into `dist/`
 				await copyDist(fs, buildConfig, dev, distCount, log);
 			}),
 		);

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -526,7 +526,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 		}
 		let inputBuildConfigs: Set<BuildConfig> | null = null;
 		for (const buildConfig of this.buildConfigs) {
-			if (isInputToBuildConfig(file.id, buildConfig)) {
+			if (isInputToBuildConfig(file.id, buildConfig.input)) {
 				(inputBuildConfigs || (inputBuildConfigs = new Set())).add(buildConfig);
 				(promises || (promises = [])).push(this.addSourceFileToBuild(file, buildConfig, true));
 			}
@@ -817,7 +817,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 							this.addSourceFileToBuild(
 								addedSourceFile as BuildableSourceFile,
 								buildConfig,
-								isInputToBuildConfig(addedSourceFile.id, buildConfig),
+								isInputToBuildConfig(addedSourceFile.id, buildConfig.input),
 							),
 						);
 					}

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -6,7 +6,7 @@ import type StrictEventEmitter from 'strict-event-emitter-types';
 import type {Filesystem} from '../fs/filesystem.js';
 import {createFilerDir} from '../build/FilerDir.js';
 import type {FilerDir, FilerDirChangeCallback} from '../build/FilerDir.js';
-import {mapDependencyToSourceId} from './utils.js';
+import {isInputToBuildConfig, mapDependencyToSourceId} from './utils.js';
 import type {MapDependencyToSourceId} from './utils.js';
 import {EXTERNALS_BUILD_DIR_ROOT_PREFIX, JS_EXTENSION, paths, toBuildOutPath} from '../paths.js';
 import {nulls, omitUndefined} from '../utils/object.js';
@@ -526,7 +526,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 		}
 		let inputBuildConfigs: Set<BuildConfig> | null = null;
 		for (const buildConfig of this.buildConfigs) {
-			if (isInputToBuildConfig(file, buildConfig)) {
+			if (isInputToBuildConfig(file.id, buildConfig)) {
 				(inputBuildConfigs || (inputBuildConfigs = new Set())).add(buildConfig);
 				(promises || (promises = [])).push(this.addSourceFileToBuild(file, buildConfig, true));
 			}
@@ -817,7 +817,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 							this.addSourceFileToBuild(
 								addedSourceFile as BuildableSourceFile,
 								buildConfig,
-								isInputToBuildConfig(addedSourceFile as BuildableSourceFile, buildConfig),
+								isInputToBuildConfig(addedSourceFile.id, buildConfig),
 							),
 						);
 					}
@@ -1150,18 +1150,6 @@ const createFilerDirs = (
 		}
 	}
 	return dirs;
-};
-
-const isInputToBuildConfig = (
-	sourceFile: BuildableSourceFile,
-	buildConfig: BuildConfig,
-): boolean => {
-	for (const input of buildConfig.input) {
-		if (typeof input === 'string' ? sourceFile.id === input : input(sourceFile.id)) {
-			return true;
-		}
-	}
-	return false;
 };
 
 const addDependent = (

--- a/src/build/dist.ts
+++ b/src/build/dist.ts
@@ -1,10 +1,18 @@
-import type {BuildConfig} from '../config/buildConfig.js';
+import type {BuildConfig, InputFilter} from '../config/buildConfig.js';
 import type {Filesystem} from '../fs/filesystem.js';
-import {paths, toBuildOutPath} from '../paths.js';
+import {
+	basePathToSourceId,
+	EXTERNALS_BUILD_DIRNAME,
+	paths,
+	toBuildBasePath,
+	toBuildOutPath,
+	toSourceExtension,
+} from '../paths.js';
 import type {Logger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 import {printBuildConfig} from '../config/buildConfig.js';
 import {isTestBuildFile, isTestBuildArtifact} from '../fs/testModule.js';
+import {isInputToBuildConfig} from './utils.js';
 
 export const copyDist = async (
 	fs: Filesystem,
@@ -12,14 +20,24 @@ export const copyDist = async (
 	dev: boolean,
 	distCount: number,
 	log: Logger,
+	filters?: InputFilter[], // TODO this is hacky, should be `buildConfig.input` but we're using it to branch logic
 ): Promise<void> => {
 	if (!buildConfig.dist) return;
 	const buildOutDir = toBuildOutPath(dev, buildConfig.name);
 	const distOutDir = distCount === 1 ? paths.dist : `${paths.dist}${printBuildConfig(buildConfig)}`;
+	const externalsDir = toBuildOutPath(dev, buildConfig.name, EXTERNALS_BUILD_DIRNAME);
 	log.info(`copying ${printPath(buildOutDir)} to ${printPath(distOutDir)}`);
 	return fs.copy(buildOutDir, distOutDir, {
 		overwrite: false, // prioritize the artifacts from other build processes
-		filter: (src) => isDistFile(src),
+		filter: async (src) => {
+			if (src === externalsDir) return false;
+			const stats = await fs.stat(src);
+			if (stats.isDirectory()) return true;
+			if (!isDistFile(src)) return false; // TODO refactor this out
+			if (!filters) return true;
+			const sourceId = basePathToSourceId(toBuildBasePath(toSourceExtension(src)));
+			return isInputToBuildConfig(sourceId, filters);
+		},
 	});
 };
 

--- a/src/build/dist.ts
+++ b/src/build/dist.ts
@@ -4,7 +4,7 @@ import {paths, toBuildOutPath} from '../paths.js';
 import type {Logger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
 import {printBuildConfig} from '../config/buildConfig.js';
-import {isDistFile} from '../project/dist.task.js';
+import {isTestBuildFile, isTestBuildArtifact} from '../fs/testModule.js';
 
 export const copyDist = async (
 	fs: Filesystem,
@@ -22,3 +22,6 @@ export const copyDist = async (
 		filter: (src) => isDistFile(src),
 	});
 };
+
+export const isDistFile = (path: string): boolean =>
+	!isTestBuildFile(path) && !isTestBuildArtifact(path);

--- a/src/build/dist.ts
+++ b/src/build/dist.ts
@@ -1,0 +1,24 @@
+import type {BuildConfig} from '../config/buildConfig.js';
+import type {Filesystem} from '../fs/filesystem.js';
+import {paths, toBuildOutPath} from '../paths.js';
+import type {Logger} from '../utils/log.js';
+import {printPath} from '../utils/print.js';
+import {printBuildConfig} from '../config/buildConfig.js';
+import {isDistFile} from '../project/dist.task.js';
+
+export const copyDist = async (
+	fs: Filesystem,
+	buildConfig: BuildConfig,
+	dev: boolean,
+	distCount: number,
+	log: Logger,
+): Promise<void> => {
+	if (!buildConfig.dist) return;
+	const buildOutDir = toBuildOutPath(dev, buildConfig.name);
+	const distOutDir = distCount === 1 ? paths.dist : `${paths.dist}${printBuildConfig(buildConfig)}`;
+	log.info(`copying ${printPath(buildOutDir)} to ${printPath(distOutDir)}`);
+	return fs.copy(buildOutDir, distOutDir, {
+		overwrite: false, // prioritize the artifacts from other build processes
+		filter: (src) => isDistFile(src),
+	});
+};

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -58,3 +58,12 @@ export const resolveInputFiles = async (
 			),
 		)
 	).filter(Boolean);
+
+export const isInputToBuildConfig = (id: string, buildConfig: BuildConfig): boolean => {
+	for (const input of buildConfig.input) {
+		if (typeof input === 'string' ? id === input : input(id)) {
+			return true;
+		}
+	}
+	return false;
+};

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -49,7 +49,7 @@ export const addCssSourcemapFooter = (code: string, sourcemapPath: string): stri
 
 export interface ResolvedInputFiles {
 	files: string[];
-	filters: InputFilter[]; // TODO
+	filters: InputFilter[]; // TODO this may be an antipattern, consider removing it
 }
 
 // TODO use `resolveRawInputPaths`? consider the virtual fs - use the `Filer` probably

--- a/src/config/buildConfig.ts
+++ b/src/config/buildConfig.ts
@@ -16,7 +16,11 @@ export interface BuildConfig {
 	readonly primary: boolean;
 }
 
-type BuildConfigInput = string | ((id: string) => boolean);
+export type BuildConfigInput = string | InputFilter;
+
+export interface InputFilter {
+	(id: string): boolean;
+}
 
 // The partial was originally this calculated type, but it's a lot less readable.
 // export type BuildConfigPartial = PartialExcept<

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -79,9 +79,9 @@ export abstract class Fs implements Filesystem {
 // TODO try to implement some of these
 export interface FsCopyOptions {
 	// dereference?: boolean;
-	overwrite?: boolean;
+	overwrite?: boolean; // defaults to `true`
 	// preserveTimestamps?: boolean;
-	// errorOnExist?: boolean;
+	// errorOnExist?: boolean; // TODO implement this
 	filter?: FsCopyFilterSync | FsCopyFilterAsync;
 	// recursive?: boolean;
 }

--- a/src/project/dist.task.ts
+++ b/src/project/dist.task.ts
@@ -1,5 +1,4 @@
 import type {Task} from '../task/task.js';
-import {isTestBuildFile, isTestBuildArtifact} from '../fs/testModule.js';
 import {loadGroConfig} from '../config/config.js';
 import {spawnProcess} from '../utils/process.js';
 import {copyDist} from '../build/dist.js';
@@ -24,6 +23,3 @@ export const task: Task = {
 		await invokeTask('project/link');
 	},
 };
-
-export const isDistFile = (path: string): boolean =>
-	!isTestBuildFile(path) && !isTestBuildArtifact(path);

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -55,7 +55,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 					// TODO this needs to be changed, might need to configure on each `buildConfig`
 					// maybe `dist: ['/path/to']` or `dist: {'/path/to': ...}`
 					config.builds.map(async (buildConfig) =>
-						(await resolveInputFiles(fs, buildConfig)).map((inputFile) => ({
+						(await resolveInputFiles(fs, buildConfig)).files.map((inputFile) => ({
 							buildConfig,
 							inputFile,
 						})),


### PR DESCRIPTION
This appears to be a regression that appeared when we integrated SvelteKit. I'm not 100% sure how `dist/` should work in the build, but this seems stable enough, I think.