### PR TITLE
rework gro clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ gro format --check # check that all source files are formatted
 
 ```bash
 gro clean # delete all build artifacts from the filesystem
+gro clean --svelte --nodemodules --git # deletes dirs and prunes git branches
 ```
 
 ```bash

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,10 @@
 # Gro changelog
 
-## 0.20.5
+## 0.21.0
 
+- **break**: change `gro clean` args to longhand and
+  add option `--git` to prune dead branches
+  ([#180](https://github.com/feltcoop/gro/pull/180))
 - fix `gro build` to copy files to `dist/` with `src/build/dist.ts` helper `copyDist`
   ([#179](https://github.com/feltcoop/gro/pull/179))
 

--- a/src/clean.task.ts
+++ b/src/clean.task.ts
@@ -3,7 +3,7 @@ import {clean} from './fs/clean.js';
 import {spawnProcess} from './utils/process.js';
 
 export interface TaskArgs {
-	'no-build'?: boolean; // !`/build`
+	'no-build'?: boolean; // !`/.gro`
 	'no-dist'?: boolean; // !`/dist`
 	svelte?: boolean; // `/.svelte`
 	nodemodules: boolean; // `/node_modules`

--- a/src/clean.task.ts
+++ b/src/clean.task.ts
@@ -1,26 +1,36 @@
 import type {Task} from './task/task.js';
 import {clean} from './fs/clean.js';
+import {spawnProcess} from './utils/process.js';
 
 export interface TaskArgs {
-	B?: boolean; // !build
-	D?: boolean; // !dist
-	s?: boolean; // .svelte
-	n?: boolean; // node_modules
+	'no-build'?: boolean; // !`/build`
+	'no-dist'?: boolean; // !`/dist`
+	svelte?: boolean; // `/.svelte`
+	nodemodules: boolean; // `/node_modules`
+	git?: boolean; // `git remote prune origin`
 }
 
+// TODO customize
+const ORIGIN = 'origin';
+
 export const task: Task<TaskArgs> = {
-	description: 'remove temporary dev and build files',
+	description: 'remove temporary dev and build files, and optionally prune git branches',
 	run: async ({fs, log, args}): Promise<void> => {
 		// TODO document with mdsvex
 		await clean(
 			fs,
 			{
-				build: !args.B,
-				dist: !args.D,
-				svelteKit: !!args.s,
-				nodeModules: !!args.n,
+				build: !args['no-build'],
+				dist: !args['no-dist'],
+				svelteKit: !!args.svelte,
+				nodeModules: !!args.nodemodules,
 			},
 			log,
 		);
+
+		// lop off unwanted git branches
+		if (args.git) {
+			await spawnProcess('git', ['remote', 'prune', ORIGIN]);
+		}
 	},
 };

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -9,7 +9,7 @@ What is a `Task`? See [`src/tasks/README.md`](../task).
 - [build](../build.task.ts) - build the project
 - [cert](../cert.task.ts) - creates a self-signed cert for https with openssl
 - [check](../check.task.ts) - check that everything is ready to commit
-- [clean](../clean.task.ts) - remove temporary dev and build files
+- [clean](../clean.task.ts) - remove temporary dev and build files, and prune git branches
 - [deploy](../deploy.task.ts) - deploy to static hosting
 - [dev](../dev.task.ts) - start dev server
 - [format](../format.task.ts) - format source files

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -9,7 +9,7 @@ What is a `Task`? See [`src/tasks/README.md`](../task).
 - [build](../build.task.ts) - build the project
 - [cert](../cert.task.ts) - creates a self-signed cert for https with openssl
 - [check](../check.task.ts) - check that everything is ready to commit
-- [clean](../clean.task.ts) - remove temporary dev and build files, and prune git branches
+- [clean](../clean.task.ts) - remove temporary dev and build files, and optionally prune git branches
 - [deploy](../deploy.task.ts) - deploy to static hosting
 - [dev](../dev.task.ts) - start dev server
 - [format](../format.task.ts) - format source files


### PR DESCRIPTION
This reworks the `gro clean` task to have human-readable args. It also adds the `--git` option, so `gro clean --git`, to prune dead git branches. (be careful!)

It's technically a breaking change so up to 21 we go.