### PR TITLE
change gro gen to handle failed formatting gracefully

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.21.1
+
+- change `gro gen` to handle failed formatting gracefully
+  ([#181](https://github.com/feltcoop/gro/pull/181))
+
 ## 0.21.0
 
 - **break**: change `gro clean` args to longhand and

--- a/src/gen.task.ts
+++ b/src/gen.task.ts
@@ -52,7 +52,7 @@ export const task: Task<TaskArgs> = {
 
 		// run `gen` on each of the modules
 		const stopTimingToGenerateCode = timings.start('generate code'); // TODO this ignores `genResults.elapsed` - should it return `Timings` instead?
-		const genResults = await runGen(fs, loadModulesResult.modules, formatFile);
+		const genResults = await runGen(fs, loadModulesResult.modules, formatFile, log);
 		stopTimingToGenerateCode();
 
 		const failCount = genResults.failures.length;


### PR DESCRIPTION
This makes `gro gen` pass through files that fail to format. It'll log the best error it can.