### PR TITLE
ignore error on failed git pull during deploy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.21.2
+
+- ignore error on failed `git pull` during `gro deploy`
+  ([#182](https://github.com/feltcoop/gro/pull/182))
+
 ## 0.21.1
 
 - change `gro gen` to handle failed formatting gracefully

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -104,13 +104,8 @@ export const task: Task<TaskArgs> = {
 		try {
 			// Set up the deployment worktree in the dist directory.
 			await spawnProcess('git', ['worktree', 'add', WORKTREE_DIRNAME, DEPLOY_BRANCH]);
-			// Pull the remote deploy branch.
-			const gitPullResult = await spawnProcess('git', ['pull', ORIGIN, DEPLOY_BRANCH], GIT_ARGS);
-			if (!gitPullResult.ok) {
-				log.error(red(`failed git pull in deploy branch with exit code ${gitPullResult.code}`));
-				await cleanGitWorktree();
-				return;
-			}
+			// Pull the remote deploy branch, ignoring failures
+			await spawnProcess('git', ['pull', ORIGIN, DEPLOY_BRANCH], GIT_ARGS);
 			// Populate the worktree dir with the new files.
 			// We're doing this rather than copying the directory
 			// because we need to preserve the existing worktree directory, or git breaks.


### PR DESCRIPTION
This allows the `gro deploy` `git pull` attempt to fail. The branch may not exist!