### PR TITLE
force push to deploy branch

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.21.3
+
+- force push on `gro deploy`
+  ([#183](https://github.com/feltcoop/gro/pull/183))
+
 ## 0.21.2
 
 - ignore error on failed `git pull` during `gro deploy`

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -123,7 +123,7 @@ export const task: Task<TaskArgs> = {
 			// commit the changes
 			await spawnProcess('git', ['add', '.', '-f'], GIT_ARGS);
 			await spawnProcess('git', ['commit', '-m', 'deployment'], GIT_ARGS);
-			await spawnProcess('git', ['push', ORIGIN, DEPLOY_BRANCH], GIT_ARGS);
+			await spawnProcess('git', ['push', ORIGIN, DEPLOY_BRANCH, '-f'], GIT_ARGS);
 		} catch (err) {
 			log.error(red('updating git failed:'), printError(err));
 			await cleanGitWorktree();


### PR DESCRIPTION
I think this is the desired behavior. Maybe we need an optional override. We treat the `deploy` branch as disposable, so I see no harm.