### PR TITLE
export config from root

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.21.5
+
+- export config types and helpers from root
+  ([#185](https://github.com/feltcoop/gro/pull/185))
+
 ## 0.21.4
 
 - export `UnreachableError` and time utils from root

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export type {Gen, GenContext} from './gen/gen.js';
 
 // this is a lot of explicit exports (all of them),
 // but almost everything else is explicit, so..
+export {loadGroConfig, toConfig} from './config/config.js';
 export type {
 	GroConfig,
 	GroConfigPartial,
@@ -10,7 +11,6 @@ export type {
 	GroConfigCreator,
 	GroConfigCreatorOptions,
 } from './config/config.js';
-export {loadGroConfig, toConfig} from './config/config.js';
 
 // by definition, these are generic, so just export everything
 export * from './utils/types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,17 @@
 export type {Task, TaskContext} from './task/task.js';
 export type {Gen, GenContext} from './gen/gen.js';
 
+// this is a lot of explicit exports (all of them),
+// but almost everything else is explicit, so..
+export type {
+	GroConfig,
+	GroConfigPartial,
+	GroConfigModule,
+	GroConfigCreator,
+	GroConfigCreatorOptions,
+} from './config/config.js';
+export {loadGroConfig, toConfig} from './config/config.js';
+
 // by definition, these are generic, so just export everything
 export * from './utils/types.js';
 


### PR DESCRIPTION
pretty self explanatory - this was intended to be public API, and we're moving away from deep imports (until **the typescript feature** lands)