### PR TITLE
support extensionless imports to internal modules temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > For now, consider Gro's free software
 > [free as in puppy](https://twitter.com/GalaxyKate/status/1371159136684105728),
 > meaning you're aware it's a lot of work to maintain,
-> and you're allowing it into your home anyway.
+> and you're inviting it into your home anyway.
 > Docs are lacking, some things are in progress, and it might pee on your stuff.
 > ([caveat emptor](https://en.wikipedia.org/wiki/Caveat_emptor):
 > it's darn cute and quickly becomes a member of the family)

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.21.6
 
-- hack: add temporary support for extensionless import paths for internal modules
+- hack: add temporary support for extensionless import paths to internal modules
   ([#186](https://github.com/feltcoop/gro/pull/186))
 
 ## 0.21.5

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.21.6
 
-- hack: add support for extensionless import paths for internal modules
+- hack: add temporary support for extensionless import paths for internal modules
   ([#186](https://github.com/feltcoop/gro/pull/186))
 
 ## 0.21.5

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Gro changelog
 
+## 0.21.6
+
+- hack: add support for extensionless import paths for internal modules
+  ([#186](https://github.com/feltcoop/gro/pull/186))
+
 ## 0.21.5
 
 - export config types and helpers from root

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -46,6 +46,7 @@ export const postprocess = (
 				const end = d > -1 ? e - 1 : e;
 				const specifier = contents.substring(start, end);
 				if (specifier === 'import.meta') continue;
+				let buildId: string;
 				let finalSpecifier = specifier; // this is the raw specifier, but pre-mapped for common externals
 				const isExternalImport = isExternalModule(specifier);
 				const isExternalImportedByExternal = source.id === EXTERNALS_SOURCE_ID;
@@ -53,7 +54,6 @@ export const postprocess = (
 				let mappedSpecifier = isExternal
 					? toBuildExtension(specifier)
 					: hack_toBuildExtensionWithPossiblyExtensionlessSpecifier(specifier);
-				let buildId: string;
 				if (!isExternalImport && isExternalImportedByExternal) {
 					// handle common externals, imports internal to the externals
 					if (isBrowser) {

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -174,10 +174,12 @@ const shouldModifyDotJs = (sourceId: string): boolean => {
 // because now we can't extract the extension from a user-provided specifier. Gack!
 // Exposing this hack to user config is something that's probably needed,
 // but we'd much prefer to remove it completely, and force internal import paths to conform to spec.
-const HACK_EXTENSIONLESS_EXTENSIONS = new Set([SVELTE_EXTENSION, JS_EXTENSION, TS_EXTENSION]);
 const hack_toBuildExtensionWithPossiblyExtensionlessSpecifier = (specifier: string): string => {
 	const extension = extname(specifier);
 	return !extension || !HACK_EXTENSIONLESS_EXTENSIONS.has(extension)
 		? specifier + JS_EXTENSION
 		: toBuildExtension(specifier);
 };
+
+// This hack is needed so we treat imports like `foo.task` as `foo.task.js`, not a `.task` file.
+const HACK_EXTENSIONLESS_EXTENSIONS = new Set([SVELTE_EXTENSION, JS_EXTENSION, TS_EXTENSION]);

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -46,9 +46,12 @@ export const postprocess = (
 				const specifier = contents.substring(start, end);
 				if (specifier === 'import.meta') continue;
 				let finalSpecifier = specifier; // this is the raw specifier, but pre-mapped for common externals
+				console.log('specifier', specifier);
 				let mappedSpecifier = toBuildExtension(specifier);
+				console.log('mappedSpecifier', mappedSpecifier);
 				let buildId: string;
 				const isExternalImport = isExternalModule(specifier);
+				console.log('isExternalImport', isExternalImport);
 				if (!isExternalImport && source.id === EXTERNALS_SOURCE_ID) {
 					// handle common externals, imports internal to the externals
 					if (isBrowser) {

--- a/src/docs/philosophy.md
+++ b/src/docs/philosophy.md
@@ -17,7 +17,7 @@ and Gro's philosophy will change over time.
 
 ### we want tools that are:
 
-- **specific**: designed for our use cases and workflows, natural fits for their domain
+- **specific**: designed for our use cases and workflows; coordinated; natural fits for their domain
 - **sharp**: powerful, efficient, productive, lean, wieldy
 - **automated**: leverage laziness to its full potential, with wisdom; see prior _point_
 - **customizable**: happypath defaults and full control when you need it

--- a/src/docs/philosophy.md
+++ b/src/docs/philosophy.md
@@ -17,7 +17,7 @@ and Gro's philosophy will change over time.
 
 ### we want tools that are:
 
-- **specific**: designed for our use cases and workflows; coordinated; natural fits for their domain
+- **specific**: designed for our use cases and workflows; natural fits for the domain; coordinated
 - **sharp**: powerful, efficient, productive, lean, wieldy
 - **automated**: leverage laziness to its full potential, with wisdom; see prior _point_
 - **customizable**: happypath defaults and full control when you need it


### PR DESCRIPTION
This is adds support for extensionless import paths for internal TS/JS modules, like `import from './to/thing'`. Currently, Gro only supports `'./to/thing.js'`.

This does not apply to external modules, those imported with a bare specifier like `import from 'svelte/store'` and their internal imports.

I've been resisting this change, because it's off-spec; ESM requires a file extension, and Gro has always gone all-in on ESM. So it feels wrong, but I think we have no choice if we want interop with SvelteKit/Vite:

The problem is a combination of TypeScript (issues/38149) and Vite (issues/61) behavior. (not linking because of backlink spam)

So which tool is really *wrong* here? I'm not really sure the spec has a good answer for this combination of tools. I currently believe I'd want to change TypeScript to allow `.ts` extensions, and those would be rewritten by the builder to `.js`, but this may be missing important context. In isolation, the reasoning can make good sense for each tool, but Vite+TypeScript in combination is incompatible with Gro's spec-following. This lack of tool coordination is one of the prime reasons Gro even exists! Gro allowing off-spec imports is the smoothest path *right now*, but this is one of the things we may break compatibility for [when Gro can offer a substitute for Vite with SvelteKit](https://github.com/feltcoop/gro/issues/106). Supporting multiple input path forms that don't conform to spec is a serious smell to me.

Svelte files still require the full extension.

This is the first time I'm prefixing names in the code with `hack_`- feels appropriate, because this is not a long-term stable feature.