### PR TITLE
rename Filesystem.writeFile from outputFile

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## 0.22.0
 
 - **break**: rename `Filesystem.writeFile` from `outputFile`
+- **break**: upgrade to `fs-extra@10.0.0`
 
 ## 0.21.6
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Gro changelog
 
+## 0.22.0
+
+- **break**: rename `Filesystem.writeFile` from `outputFile`
+
 ## 0.21.6
 
 - hack: add temporary support for extensionless import paths to internal modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "es-module-lexer": "^0.4.1",
         "esbuild": "^0.9.3",
         "esinstall": "1.0.5",
-        "fs-extra": "^9.1.0",
+        "fs-extra": "^10.0.0",
         "kleur": "^4.1.4",
         "locate-character": "^2.0.5",
         "mri": "^1.1.6",
@@ -337,14 +337,6 @@
         "util": "0.10.3"
       }
     },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -575,17 +567,16 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -1284,11 +1275,6 @@
         "util": "0.10.3"
       }
     },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1469,11 +1455,10 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
       "requires": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "es-module-lexer": "^0.4.1",
     "esbuild": "^0.9.3",
     "esinstall": "1.0.5",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "kleur": "^4.1.4",
     "locate-character": "^2.0.5",
     "mri": "^1.1.6",

--- a/src/build/Filer.test.ts
+++ b/src/build/Filer.test.ts
@@ -24,9 +24,9 @@ test_Filer('basic serve usage', async ({fs}) => {
 	const bId = '/served/b.svelte';
 	const cId = '/served/c/c.svelte.md';
 
-	fs.outputFile(aId, 'a', 'utf8');
-	fs.outputFile(bId, 'b', 'utf8');
-	fs.outputFile(cId, 'c', 'utf8');
+	fs.writeFile(aId, 'a', 'utf8');
+	fs.writeFile(bId, 'b', 'utf8');
+	fs.writeFile(cId, 'c', 'utf8');
 
 	const filer = new Filer({
 		fs,
@@ -59,7 +59,7 @@ test_Filer('basic build usage with no watch', async ({fs}) => {
 	const rootId = '/a/b/src';
 	const entrypointFilename = 'entrypoint.ts';
 	const entryId = `${rootId}/${entrypointFilename}`;
-	fs.outputFile(entryId, 'export const a: number = 5;', 'utf8');
+	fs.writeFile(entryId, 'export const a: number = 5;', 'utf8');
 	const buildConfig: BuildConfig = {
 		name: 'test_build_config',
 		platform: 'node',

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -1021,7 +1021,7 @@ const syncBuildFilesToDisk = async (
 				throw new UnreachableError(change);
 			}
 			if (shouldOutputNewFile) {
-				await fs.outputFile(file.id, file.contents);
+				await fs.writeFile(file.id, file.contents);
 			}
 		}),
 	);

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -83,7 +83,7 @@ export const updateSourceMeta = async (
 
 	sourceMetaById.set(file.id, sourceMeta);
 	// this.log.trace('outputting source meta', gray(cacheId));
-	await fs.outputFile(cacheId, JSON.stringify(data, null, 2));
+	await fs.writeFile(cacheId, JSON.stringify(data, null, 2));
 };
 
 export const deleteSourceMeta = async (

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -10,7 +10,7 @@ export interface Filesystem {
 	stat: FsStat;
 	exists: FsExists;
 	readFile: FsReadFile;
-	outputFile: FsOutputFile;
+	writeFile: FsOutputFile;
 	remove: FsRemove;
 	move: FsMove;
 	copy: FsCopy;
@@ -66,7 +66,7 @@ export abstract class Fs implements Filesystem {
 	abstract stat: FsStat;
 	abstract exists: FsExists;
 	abstract readFile: FsReadFile;
-	abstract outputFile: FsOutputFile;
+	abstract writeFile: FsOutputFile;
 	abstract remove: FsRemove;
 	abstract move: FsMove;
 	abstract copy: FsCopy;

--- a/src/fs/importTs.ts
+++ b/src/fs/importTs.ts
@@ -96,7 +96,7 @@ const compileFileAndImports = async (
 
 	// write the result and compile depdencies in parallel
 	await Promise.all([
-		fs.outputFile(build.id, build.contents),
+		fs.writeFile(build.id, build.contents),
 		Promise.all(internalDepSourceIds.map((id) => compileFileAndImports(fs, id, buildConfig, ctx))),
 	]);
 

--- a/src/fs/memory.test.ts
+++ b/src/fs/memory.test.ts
@@ -27,32 +27,32 @@ const resetMemoryFs = ({fs}: SuiteContext) => fs._reset();
 
 const fakeTsContents = 'export const a = 5;';
 
-/* test_outputFile */
-const test_outputFile = suite('outputFile', suiteContext);
-test_outputFile.before.each(resetMemoryFs);
+/* test_writeFile */
+const test_writeFile = suite('writeFile', suiteContext);
+test_writeFile.before.each(resetMemoryFs);
 
-test_outputFile('basic behavior', async ({fs}) => {
+test_writeFile('basic behavior', async ({fs}) => {
 	for (const path of testPaths) {
 		fs._reset();
 		t.is(fs._files.size, 0);
 		const contents = 'hi';
-		await fs.outputFile(path, contents, 'utf8');
+		await fs.writeFile(path, contents, 'utf8');
 		t.is(fs._files.size, toPathParts(toFsId(path)).length + 1);
 		t.is(fs._find(toFsId(path))!.contents, contents);
 	}
 });
 
-test_outputFile('updates an existing file', async ({fs}) => {
+test_writeFile('updates an existing file', async ({fs}) => {
 	for (const path of testPaths) {
 		fs._reset();
 		t.is(fs._files.size, 0);
 		const contents1 = 'contents1';
-		await fs.outputFile(path, contents1, 'utf8');
+		await fs.writeFile(path, contents1, 'utf8');
 		const {size} = fs._files;
 		t.is(size, toPathParts(toFsId(path)).length + 1);
 		t.is(fs._find(toFsId(path))!.contents, contents1);
 		const contents2 = 'contents2';
-		await fs.outputFile(path, contents2, 'utf8');
+		await fs.writeFile(path, contents2, 'utf8');
 		t.is(fs._files.size, size); // count has not changed
 		t.is(fs._find(toFsId(path))!.contents, contents2);
 	}
@@ -63,8 +63,8 @@ test_outputFile('updates an existing file', async ({fs}) => {
 // TODO test that it creates the in-between directories
 // this will break the `length` checks!! can use the new length checks to check segment creation
 
-test_outputFile.run();
-/* /test_outputFile */
+test_writeFile.run();
+/* /test_writeFile */
 
 /* test_readFile */
 const test_readFile = suite('readFile', suiteContext);
@@ -74,7 +74,7 @@ test_readFile('basic behavior', async ({fs}) => {
 	for (const path of testPaths) {
 		fs._reset();
 		const contents = 'contents';
-		await fs.outputFile(path, contents, 'utf8');
+		await fs.writeFile(path, contents, 'utf8');
 		const found = await fs.readFile(path, 'utf8');
 		t.is(contents, found);
 	}
@@ -101,7 +101,7 @@ test_remove.before.each(resetMemoryFs);
 test_remove('basic behavior', async ({fs}) => {
 	for (const path of testPaths) {
 		fs._reset();
-		await fs.outputFile(path, 'contents', 'utf8');
+		await fs.writeFile(path, 'contents', 'utf8');
 		t.ok(fs._exists(path));
 		await fs.remove(path);
 		t.ok(!fs._exists(path));
@@ -110,9 +110,9 @@ test_remove('basic behavior', async ({fs}) => {
 
 test_remove('removes contained files and dirs', async ({fs}) => {
 	const path = '/a/b/c';
-	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir2/d.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/a.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir2/d.ts`, fakeTsContents);
 	t.is(fs._files.size, 10);
 	await fs.remove(`${path}/dir1`);
 	t.is(fs._files.size, 6);
@@ -133,7 +133,7 @@ test_move('basic behavior', async ({fs}) => {
 	const dest = '/testdest';
 	for (const path of testPaths) {
 		fs._reset();
-		await fs.outputFile(path, 'contents', 'utf8');
+		await fs.writeFile(path, 'contents', 'utf8');
 		t.ok(fs._exists(path));
 		t.ok(!fs._exists(dest));
 		await fs.move(path, dest);
@@ -144,9 +144,9 @@ test_move('basic behavior', async ({fs}) => {
 
 test_move('moves contained files and dirs', async ({fs}) => {
 	const path = '/a/b/c';
-	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir2/d.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/a.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir2/d.ts`, fakeTsContents);
 	t.is(fs._files.size, 10);
 	const newPath = '/a/e';
 	await fs.move(`${path}/dir1`, `${newPath}/dir1`); // TODO any special merge behavior?
@@ -168,8 +168,8 @@ test_move('handles move conflict with overwrite false', async ({fs}) => {
 	const filename2 = '2.ts';
 	const path1 = `${dir}/${filename1}`;
 	const path2 = `${dir}/${filename2}`;
-	await fs.outputFile(path1, fakeTsContents);
-	await fs.outputFile(path2, fakeTsContents);
+	await fs.writeFile(path1, fakeTsContents);
+	await fs.writeFile(path2, fakeTsContents);
 	t.is(fs._files.size, 5);
 	// TODO async `t.throws` or `t.rejects` ?
 	let failed = true;
@@ -190,8 +190,8 @@ test_move('handles move conflict with overwrite true', async ({fs}) => {
 	const filename2 = '2.ts';
 	const path1 = `${dir}/${filename1}`;
 	const path2 = `${dir}/${filename2}`;
-	await fs.outputFile(path1, fakeTsContents);
-	await fs.outputFile(path2, fakeTsContents);
+	await fs.writeFile(path1, fakeTsContents);
+	await fs.writeFile(path2, fakeTsContents);
 	t.is(fs._files.size, 5);
 	await fs.move(path1, path2, {overwrite: true});
 	t.ok(!fs._exists(path1));
@@ -220,7 +220,7 @@ test_copy('basic behavior', async ({fs}) => {
 	const dest = '/testdest';
 	for (const path of testPaths) {
 		fs._reset();
-		await fs.outputFile(path, 'contents', 'utf8');
+		await fs.writeFile(path, 'contents', 'utf8');
 		t.ok(fs._exists(path));
 		t.ok(!fs._exists(dest));
 		await fs.copy(path, dest);
@@ -231,10 +231,10 @@ test_copy('basic behavior', async ({fs}) => {
 
 test_copy('copies contained files and dirs', async ({fs}) => {
 	const path = '/a/b/c';
-	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/IGNORE.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir2/d.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/a.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/IGNORE.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir2/d.ts`, fakeTsContents);
 	t.is(fs._files.size, 11);
 	const newPath = '/a/e';
 	await fs.copy(`${path}/dir1`, `${newPath}/dir1`, {
@@ -261,8 +261,8 @@ test_copy('handles copy conflict with overwrite false', async ({fs}) => {
 	const filename2 = '2.ts';
 	const path1 = `${dir}/${filename1}`;
 	const path2 = `${dir}/${filename2}`;
-	await fs.outputFile(path1, fakeTsContents);
-	await fs.outputFile(path2, fakeTsContents);
+	await fs.writeFile(path1, fakeTsContents);
+	await fs.writeFile(path2, fakeTsContents);
 	t.is(fs._files.size, 5);
 	// TODO async `t.throws`
 	let failed = true;
@@ -283,8 +283,8 @@ test_copy('handles copy conflict with overwrite true', async ({fs}) => {
 	const filename2 = '2.ts';
 	const path1 = `${dir}/${filename1}`;
 	const path2 = `${dir}/${filename2}`;
-	await fs.outputFile(path1, fakeTsContents);
-	await fs.outputFile(path2, fakeTsContents);
+	await fs.writeFile(path1, fakeTsContents);
+	await fs.writeFile(path2, fakeTsContents);
 	t.is(fs._files.size, 5);
 	await fs.copy(path1, path2, {overwrite: true});
 	t.ok(fs._exists(path1));
@@ -346,7 +346,7 @@ test_readDir.before.each(resetMemoryFs);
 test_readDir('basic behavior', async ({fs}) => {
 	for (const path of testPaths) {
 		fs._reset();
-		await fs.outputFile(path, 'contents', 'utf8');
+		await fs.writeFile(path, 'contents', 'utf8');
 		t.ok(fs._exists(path));
 		const dir = dirname(path);
 		const paths = await fs.readDir(dir);
@@ -356,11 +356,11 @@ test_readDir('basic behavior', async ({fs}) => {
 
 test_readDir('readDirs contained files and dirs', async ({fs}) => {
 	const path = '/a/b/c';
-	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c1.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c2.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c3.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/d`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/a.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c1.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c2.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c3.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/d`, fakeTsContents);
 	const paths = await fs.readDir(`${path}/dir1`);
 	t.equal(paths, ['a.ts', 'b', 'b/c1.ts', 'b/c2.ts', 'b/c3.ts', 'd']);
 });
@@ -381,7 +381,7 @@ test_emptyDir.before.each(resetMemoryFs);
 test_emptyDir('basic behavior', async ({fs}) => {
 	for (const path of testPaths) {
 		fs._reset();
-		await fs.outputFile(path, 'contents', 'utf8');
+		await fs.writeFile(path, 'contents', 'utf8');
 		t.ok(fs._exists(path));
 		const {size} = fs._files;
 		const dir = dirname(path);
@@ -395,11 +395,11 @@ test_emptyDir('basic behavior', async ({fs}) => {
 
 test_emptyDir('emptyDirs contained files and dirs', async ({fs}) => {
 	const path = '/a/b/c';
-	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c1.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c2.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c3.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir2/d.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/a.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c1.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c2.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c3.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir2/d.ts`, fakeTsContents);
 	t.is(fs._files.size, 12);
 	await fs.emptyDir(`${path}/dir1`);
 	t.is(fs._files.size, 7);
@@ -421,7 +421,7 @@ test_findFiles('basic behavior', async ({fs}) => {
 	for (const path of testPaths) {
 		fs._reset();
 		const contents = 'contents';
-		await fs.outputFile(path, contents, 'utf8');
+		await fs.writeFile(path, contents, 'utf8');
 		let filterCallCount = 0;
 		const files = await fs.findFiles('.', () => (filterCallCount++, true));
 		const rootPath = toRootPath(toFsId(path));
@@ -435,13 +435,13 @@ test_findFiles('find a bunch of files and dirs', async ({fs}) => {
 	const path = '/a/b/c';
 	const ignoredPath = 'b/c2.ts';
 	let hasIgnoredPath = false;
-	await fs.outputFile(`${path}/dir1/a.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c1.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c2.ts`, fakeTsContents);
-	await fs.outputFile(`${path}/dir1/b/c3.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/a.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c1.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c2.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir1/b/c3.ts`, fakeTsContents);
 	await fs.ensureDir(`${path}/dir1/d`);
 	await fs.ensureDir(`${path}/dir1/e/f`);
-	await fs.outputFile(`${path}/dir2/2.ts`, fakeTsContents);
+	await fs.writeFile(`${path}/dir2/2.ts`, fakeTsContents);
 	const found = await fs.findFiles(
 		`${path}/dir1`,
 		({path}) => {

--- a/src/fs/memory.ts
+++ b/src/fs/memory.ts
@@ -99,7 +99,7 @@ export class MemoryFs extends Fs {
 		}
 		return file.contents || '';
 	};
-	outputFile = async (path: string, data: any, encoding: Encoding = 'utf8'): Promise<void> => {
+	writeFile = async (path: string, data: any, encoding: Encoding = 'utf8'): Promise<void> => {
 		const id = toFsId(path);
 
 		// does the file already exist? update if so
@@ -166,7 +166,7 @@ export class MemoryFs extends Fs {
 				output = true;
 			}
 			if (output) {
-				await this.outputFile(nodeDestId, srcNode.contents, srcNode.encoding);
+				await this.writeFile(nodeDestId, srcNode.contents, srcNode.encoding);
 			}
 		}
 	};

--- a/src/fs/node.ts
+++ b/src/fs/node.ts
@@ -31,7 +31,7 @@ export const fs: Filesystem = {
 	stat: fsExtra.stat,
 	exists: fsExtra.pathExists,
 	readFile: fsExtra.readFile,
-	outputFile: fsExtra.outputFile as FsOutputFile, // TODO incompatible encodings: is this an actual problem? or is `fs-extra` mistyped? test with `null`
+	writeFile: fsExtra.outputFile as FsOutputFile, // TODO incompatible encodings: is this an actual problem? or is `fs-extra` mistyped? test with `null`
 	remove: fsExtra.remove,
 	move: fsExtra.move,
 	copy: fsExtra.copy,

--- a/src/gen.task.ts
+++ b/src/gen.task.ts
@@ -94,7 +94,7 @@ export const task: Task<TaskArgs> = {
 					.map((result) =>
 						result.files.map((file) => {
 							log.info('writing', printPath(file.id), 'generated from', printPath(file.originId));
-							return fs.outputFile(file.id, file.contents);
+							return fs.writeFile(file.id, file.contents);
 						}),
 					)
 					.flat(),

--- a/src/project/rollup-plugin-output-css.ts
+++ b/src/project/rollup-plugin-output-css.ts
@@ -110,12 +110,12 @@ export const outputCssPlugin = (opts: InitialOptions): Plugin => {
 
 					log.info('writing css bundle and sourcemap', dest);
 					await Promise.all([
-						fs.outputFile(dest, finalCss),
-						fs.outputFile(sourcemapDest, cssSourcemap),
+						fs.writeFile(dest, finalCss),
+						fs.writeFile(sourcemapDest, cssSourcemap),
 					]);
 				} else {
 					log.info('writing css bundle', dest);
-					await fs.outputFile(dest, css);
+					await fs.writeFile(dest, css);
 				}
 			}
 		},


### PR DESCRIPTION
This renames the filesystem helper `outputFile` to `writeFile`. It's just an aesthetic choice (I think `read/write` is better than `read/output` for most people), and it's a non-goal to conform to the `fs-extra` interface. (the semantics of `fs-extra` are the source of truth for Gro's `Filesystem`, but Gro changes names and owns the external interface)