### PR TITLE
fix gro publish

### DIFF
--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -22,7 +22,7 @@ export const task: Task = {
 		const findGenModulesResult = await findGenModules(fs);
 		if (findGenModulesResult.ok) {
 			log.info('checking that generated files have not changed');
-			await invokeTask('gen', {...args, check: true});
+			await invokeTask('gen', {...args, check: true, _: []});
 		} else if (findGenModulesResult.type !== 'inputDirectoriesWithNoFiles') {
 			for (const reason of findGenModulesResult.reasons) {
 				log.error(reason);

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -34,8 +34,11 @@ const GIT_ARGS = {cwd: WORKTREE_DIR};
 export const task: Task<TaskArgs> = {
 	description: 'deploy to static hosting',
 	dev: false,
-	run: async ({fs, invokeTask, args, log}): Promise<void> => {
+	run: async ({fs, invokeTask, args, log, dev}): Promise<void> => {
 		const {branch, dry, clean} = args;
+		if (dev) {
+			log.warn('building in development mode; normally this is only for diagnostics');
+		}
 
 		const sourceBranch = branch || GIT_DEPLOY_BRANCH;
 

--- a/src/publish.task.ts
+++ b/src/publish.task.ts
@@ -25,8 +25,11 @@ export interface TaskArgs {
 
 export const task: Task<TaskArgs> = {
 	description: 'bump version, publish to npm, and sync to GitHub',
-	run: async ({fs, args, log, invokeTask}): Promise<void> => {
+	run: async ({fs, args, log, invokeTask, dev}): Promise<void> => {
 		const {branch = GIT_DEPLOY_BRANCH, dry = false} = args;
+		if (dev) {
+			log.warn('building in development mode; normally this is only for diagnostics');
+		}
 
 		const versionIncrement = args._[0];
 		validateVersionIncrement(versionIncrement);

--- a/src/publish.task.ts
+++ b/src/publish.task.ts
@@ -25,6 +25,7 @@ export interface TaskArgs {
 
 export const task: Task<TaskArgs> = {
 	description: 'bump version, publish to npm, and sync to GitHub',
+	dev: false,
 	run: async ({fs, args, log, invokeTask, dev}): Promise<void> => {
 		const {branch = GIT_DEPLOY_BRANCH, dry = false} = args;
 		if (dev) {

--- a/src/publish.task.ts
+++ b/src/publish.task.ts
@@ -35,6 +35,8 @@ export const task: Task<TaskArgs> = {
 		await confirmWithUser(fs, versionIncrement, log);
 
 		// Make sure we're on the right branch:
+		// TODO see how the deploy task uses git, probably do that instead
+		await spawnProcess('git', ['fetch', 'origin', branch]);
 		await spawnProcess('git', ['checkout', branch]);
 
 		// And updated to the latest:


### PR DESCRIPTION
I ran into at least a couple issues with #189. The first bug I found is related to arg forwarding - `gro gen` was being invoked from `gro publish <version>` and receiving its `version` arg. Not intended! Something to be more mindful of, and maybe improve with patterns or helpers.