### PR TITLE
generate types for production builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ gro format --check # check that all source files are formatted
 
 ```bash
 gro clean # delete all build artifacts from the filesystem
-gro clean --svelte --nodemodules --git # deletes dirs and prunes git branches
+gro clean --svelte --nodemodules --git # also deletes dirs and prunes git branches
 ```
 
 ```bash

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,9 @@
 
 ## 0.23.2
 
-- add optional type generation for production to `esbuild` builder
-  ([#194](https://github.com/feltcoop/gro/pull/194))
+- generate types for production builds
+  ([#194](https://github.com/feltcoop/gro/pull/194),
+  [#195](https://github.com/feltcoop/gro/pull/195))
 
 ## 0.23.1
 

--- a/src/adapt/gro-adapter-spa-frontend.ts
+++ b/src/adapt/gro-adapter-spa-frontend.ts
@@ -46,7 +46,7 @@ export const createAdapter = ({
 			const timingToBuild = timings.start('build');
 			await Promise.all(
 				buildConfigsToBuild.map(async (buildConfig) => {
-					const {files, filters} = await resolveInputFiles(fs, buildConfig);
+					const {files} = await resolveInputFiles(fs, buildConfig);
 					if (!files.length) {
 						log.trace('no input files in', printBuildConfigLabel(buildConfig));
 						return;
@@ -73,7 +73,6 @@ export const createAdapter = ({
 						dev,
 						toDistOutDir(buildConfig.name, buildConfigsToBuild.length, dir),
 						log,
-						filters,
 					);
 				}),
 			);

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -37,6 +37,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		const timings = new Timings(); // TODO belongs in ctx
 
 		// Build all types so they're available.
+		// TODO refactor? maybe lazily build types only when a builder wants them
 		const timingToBuildTypes = timings.start('buildTypes');
 		await generateTypes(paths.source, toTypesBuildDir(), true);
 		timingToBuildTypes();

--- a/src/build/dist.ts
+++ b/src/build/dist.ts
@@ -29,6 +29,7 @@ export const copyDist = async (
 			if (path === externalsDir) return false;
 			const stats = await fs.stat(path);
 			if (stats.isDirectory()) return true;
+			// typemaps are edited before copying, see below
 			if (path.endsWith(TS_TYPEMAP_EXTENSION)) {
 				typemapFiles.push(path);
 				return false;
@@ -45,8 +46,8 @@ export const copyDist = async (
 			const distOutPath = `${distOutDir}/${basePath}`;
 			const typemapSourcePath = relative(dirname(distOutPath), sourceId);
 			const typemap = JSON.parse(await fs.readFile(id, 'utf8'));
-			typemap.sources[0] = typemapSourcePath;
-			await fs.writeFile(distOutPath, JSON.stringify(typemap));
+			typemap.sources[0] = typemapSourcePath; // haven't seen any exceptions that would break this
+			return fs.writeFile(distOutPath, JSON.stringify(typemap));
 		}),
 	);
 };

--- a/src/build/dist.ts
+++ b/src/build/dist.ts
@@ -1,15 +1,16 @@
-import type {BuildConfig, InputFilter} from '../build/buildConfig.js';
+import {relative, dirname} from 'path';
+
+import type {BuildConfig} from '../build/buildConfig.js';
 import type {Filesystem} from '../fs/filesystem.js';
 import {
 	basePathToSourceId,
 	EXTERNALS_BUILD_DIRNAME,
 	toBuildBasePath,
 	toBuildOutPath,
-	toSourceExtension,
+	TS_TYPEMAP_EXTENSION,
 } from '../paths.js';
 import type {Logger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
-import {isInputToBuildConfig} from './utils.js';
 
 export const copyDist = async (
 	fs: Filesystem,
@@ -17,20 +18,35 @@ export const copyDist = async (
 	dev: boolean,
 	distOutDir: string,
 	log: Logger,
-	filters?: InputFilter[], // TODO this is hacky, should be `buildConfig.input` but we're using it to branch logic
 ): Promise<void> => {
 	const buildOutDir = toBuildOutPath(dev, buildConfig.name);
 	const externalsDir = toBuildOutPath(dev, buildConfig.name, EXTERNALS_BUILD_DIRNAME);
 	log.info(`copying ${printPath(buildOutDir)} to ${printPath(distOutDir)}`);
-	return fs.copy(buildOutDir, distOutDir, {
-		overwrite: false, // prioritize the artifacts from other build processes
-		filter: async (src) => {
-			if (src === externalsDir) return false;
-			const stats = await fs.stat(src);
+	const typemapFiles: string[] = [];
+	await fs.copy(buildOutDir, distOutDir, {
+		overwrite: false, // TODO this was old, not sure anymore: prioritizes the artifacts from other build processes
+		filter: async (path) => {
+			if (path === externalsDir) return false;
+			const stats = await fs.stat(path);
 			if (stats.isDirectory()) return true;
-			if (!filters) return true;
-			const sourceId = basePathToSourceId(toBuildBasePath(toSourceExtension(src)));
-			return isInputToBuildConfig(sourceId, filters);
+			if (path.endsWith(TS_TYPEMAP_EXTENSION)) {
+				typemapFiles.push(path);
+				return false;
+			}
+			return true;
 		},
 	});
+	// typemap files (.d.ts.map) need their `sources` property mapped back to the source directory
+	// based on the relative change from the build to the dist
+	await Promise.all(
+		typemapFiles.map(async (id) => {
+			const basePath = toBuildBasePath(id);
+			const sourceId = basePathToSourceId(basePath);
+			const distOutPath = `${distOutDir}/${basePath}`;
+			const typemapSourcePath = relative(dirname(distOutPath), sourceId);
+			const typemap = JSON.parse(await fs.readFile(id, 'utf8'));
+			typemap.sources[0] = typemapSourcePath;
+			await fs.writeFile(distOutPath, JSON.stringify(typemap));
+		}),
+	);
 };

--- a/src/build/dist.ts
+++ b/src/build/dist.ts
@@ -9,7 +9,6 @@ import {
 } from '../paths.js';
 import type {Logger} from '../utils/log.js';
 import {printPath} from '../utils/print.js';
-import {isTestBuildFile, isTestBuildArtifact} from '../fs/testModule.js';
 import {isInputToBuildConfig} from './utils.js';
 
 export const copyDist = async (
@@ -29,13 +28,9 @@ export const copyDist = async (
 			if (src === externalsDir) return false;
 			const stats = await fs.stat(src);
 			if (stats.isDirectory()) return true;
-			if (!isDistFile(src)) return false; // TODO refactor this out
 			if (!filters) return true;
 			const sourceId = basePathToSourceId(toBuildBasePath(toSourceExtension(src)));
 			return isInputToBuildConfig(sourceId, filters);
 		},
 	});
 };
-
-export const isDistFile = (path: string): boolean =>
-	!isTestBuildFile(path) && !isTestBuildArtifact(path);

--- a/src/build/esbuildBuilder.ts
+++ b/src/build/esbuildBuilder.ts
@@ -8,8 +8,9 @@ import {
 	JS_EXTENSION,
 	SOURCEMAP_EXTENSION,
 	toBuildOutPath,
-	TS_DEFS_EXTENSION,
+	TS_TYPE_EXTENSION,
 	TS_EXTENSION,
+	TS_TYPEMAP_EXTENSION,
 } from '../paths.js';
 import {omitUndefined} from '../utils/object.js';
 import type {Builder, BuildResult, TextBuild, TextBuildSource} from './builder.js';
@@ -105,15 +106,27 @@ export const createEsbuildBuilder = (opts: InitialOptions = {}): EsbuildBuilder 
 		}
 		// TODO hardcoding to generate types only in production builds, might want to change
 		if (!dev) {
+			const {types, typemap} = await (await loadGenerateTypes(fs))(source.id);
 			builds.push({
-				id: replaceExtension(jsId, TS_DEFS_EXTENSION),
-				filename: replaceExtension(jsFilename, TS_DEFS_EXTENSION),
+				id: replaceExtension(jsId, TS_TYPE_EXTENSION),
+				filename: replaceExtension(jsFilename, TS_TYPE_EXTENSION),
 				dir: outDir,
-				extension: TS_DEFS_EXTENSION,
+				extension: TS_TYPE_EXTENSION,
 				encoding: source.encoding,
-				contents: await (await loadGenerateTypes(fs))(source.id),
+				contents: types,
 				buildConfig,
 			});
+			if (typemap !== undefined) {
+				builds.push({
+					id: replaceExtension(jsId, TS_TYPEMAP_EXTENSION),
+					filename: replaceExtension(jsFilename, TS_TYPEMAP_EXTENSION),
+					dir: outDir,
+					extension: TS_TYPEMAP_EXTENSION,
+					encoding: source.encoding,
+					contents: typemap,
+					buildConfig,
+				});
+			}
 		}
 		const result: BuildResult<TextBuild> = {builds};
 		return result;

--- a/src/build/tsBuildHelpers.ts
+++ b/src/build/tsBuildHelpers.ts
@@ -1,5 +1,10 @@
 import type {Filesystem} from '../fs/filesystem.js';
-import {sourceIdToBasePath, toTypesBuildDir, TS_DEFS_EXTENSION} from '../paths.js';
+import {
+	sourceIdToBasePath,
+	toTypesBuildDir,
+	TS_TYPE_EXTENSION as TS_TYPE_EXTENSION,
+	TS_TYPEMAP_EXTENSION,
+} from '../paths.js';
 import {EMPTY_ARRAY} from '../utils/array.js';
 import {replaceExtension} from '../utils/path.js';
 import {spawnProcess} from '../utils/process.js';
@@ -28,7 +33,7 @@ export const generateTypes = async (
 	src: string,
 	dest: string,
 	sourcemap: boolean,
-	declarationMap: boolean = sourcemap,
+	typemap: boolean = sourcemap,
 	args: string[] = EMPTY_ARRAY,
 ) => {
 	const tscResult = await spawnProcess('npx', [
@@ -40,7 +45,7 @@ export const generateTypes = async (
 		'--sourceMap',
 		sourcemap ? 'true' : 'false',
 		'--declarationMap',
-		declarationMap ? 'true' : 'false',
+		typemap ? 'true' : 'false',
 		'--declaration',
 		'--emitDeclarationOnly',
 		...args,
@@ -51,16 +56,32 @@ export const generateTypes = async (
 };
 
 export interface GenerateTypesForFile {
-	(id: string): Promise<string>;
+	(id: string): Promise<GeneratedTypes>;
 }
 
+export interface GeneratedTypes {
+	types: string;
+	typemap?: string;
+}
+
+// This looks up types from the filesystem created by `generateTypes` for individual files.
+// This lets us do project-wide type compilation once and do cheap lookups from the global cache.
+// This strategy is used because the TypeScript compiler performs an order of magnitude slower
+// when it compiles type declarations for individual files compared to an entire project at once.
+// (there may be dramatic improvements to the individual file building strategy,
+// but I couldn't find them in a reasonable amount of time)
 export const toGenerateTypesForFile = async (fs: Filesystem): Promise<GenerateTypesForFile> => {
-	const results: Map<string, string> = new Map();
+	const results: Map<string, GeneratedTypes> = new Map();
 	return async (id) => {
 		if (results.has(id)) return results.get(id)!;
-		const typesBasePath = replaceExtension(sourceIdToBasePath(id), TS_DEFS_EXTENSION);
-		const typesFilePath = `${toTypesBuildDir()}/${typesBasePath}`; // TODO pass through `paths`, maybe from the `BuildContext`
-		const result = await fs.readFile(typesFilePath, 'utf8');
+		const rootPath = `${toTypesBuildDir()}/${sourceIdToBasePath(id)}`; // TODO pass through `paths`, maybe from the `BuildContext`
+		const typesId = replaceExtension(rootPath, TS_TYPE_EXTENSION);
+		const typemapId = replaceExtension(rootPath, TS_TYPEMAP_EXTENSION);
+		const [types, typemap] = await Promise.all([
+			fs.readFile(typesId, 'utf8'),
+			(async () => ((await fs.exists(typemapId)) ? fs.readFile(typemapId, 'utf8') : undefined))(),
+		]);
+		const result: GeneratedTypes = {types, typemap};
 		results.set(id, result);
 		return result;
 	};

--- a/src/build/tsBuildHelpers.ts
+++ b/src/build/tsBuildHelpers.ts
@@ -1,30 +1,15 @@
-import {readFileSync} from 'fs';
-import type {CompilerOptions} from 'typescript';
-import {isSourceId, TS_DEFS_EXTENSION, TS_EXTENSION} from '../paths.js';
-import {EMPTY_OBJECT} from '../utils/object.js';
-import {printPath} from '../utils/print.js';
-import {stripEnd} from '../utils/string.js';
-import type {BuildContext} from './builder.js';
+import type {Filesystem} from '../fs/filesystem.js';
+import {sourceIdToBasePath, toTypesBuildDir, TS_DEFS_EXTENSION} from '../paths.js';
+import {EMPTY_ARRAY} from '../utils/array.js';
+import {replaceExtension} from '../utils/path.js';
+import {spawnProcess} from '../utils/process.js';
 
 /*
 
 This uses the TypeScript compiler to generate types.
 
-There's a mismatch with the current usage versus Gro's systems;
-Gro builds files as individual units (minus the externals builder, see below),
-but I'm unable to find a compiler API that makes it straightforward and efficient
-to output a single file's type definitions.
-What I want may simply be impossible because of how the type system works.
-
-This problem manifests as builds taking around 10x longer than they should.
-
-It would be possible and efficient to generate types outside of Gro's normal build system,
-but right now I don't like those implications long term.
-Instead, I think there's a better design for Gro here,
-to expand its view of the world beyond individual files,
-which would also address the currently hacky implementation of the externals builder.
-
-These two use cases - externals and types - should be able to inform a better design.
+`toGenerateTypes` uses `tsc` directly,
+and `toGenerateTypesForFile` then looks up those results.
 
 */
 
@@ -39,61 +24,44 @@ export type EcmaScriptTarget =
 	| 'es2020'
 	| 'esnext';
 
-export interface GenerateTypes {
-	(id: string, contents: string): string;
+export const generateTypes = async (
+	src: string,
+	dest: string,
+	sourcemap: boolean,
+	declarationMap = sourcemap,
+	args: string[] = EMPTY_ARRAY,
+) => {
+	const tscResult = await spawnProcess('npx', [
+		'tsc',
+		'--outDir',
+		dest,
+		'--rootDir',
+		src,
+		'--sourceMap',
+		sourcemap ? 'true' : 'false',
+		'--declarationMap',
+		declarationMap ? 'true' : 'false',
+		'--declaration',
+		'--emitDeclarationOnly',
+		...args,
+	]);
+	if (!tscResult.ok) {
+		throw Error(`TypeScript failed to compile with code ${tscResult.code}`);
+	}
+};
+
+export interface GenerateTypesForFile {
+	(id: string): Promise<string>;
 }
 
-export const toGenerateTypes = async (
-	{log, findById}: BuildContext,
-	tsOptions: CompilerOptions = EMPTY_OBJECT,
-): Promise<GenerateTypes> => {
-	// We're lazily importing the TypeScript compiler because this module is loaded eagerly,
-	// but `toGenerateTypes` is only called in some circumstances at runtime. (like prod builds)
-	const ts = (await import('typescript')).default;
-
-	// This is safe because the returned function below is synchronous
-	let result: string;
+export const toGenerateTypesForFile = async (fs: Filesystem): Promise<GenerateTypesForFile> => {
 	const results: Map<string, string> = new Map();
-	let currentContents: string;
-	let currentId: string;
-
-	const options: CompilerOptions = {
-		...tsOptions,
-		declaration: true,
-		emitDeclarationOnly: true,
-		isolatedModules: true, // already had this restriction with Svelte, so no fancy const enums
-		// noResolve: true, // TODO doesn't generate the types correctly, but it makes it build fast!
-		skipLibCheck: true,
-	};
-
-	const host = ts.createCompilerHost(options);
-	host.writeFile = (fileName, data) => {
-		if (!fileName.endsWith(TS_DEFS_EXTENSION)) throw Error('TODO');
-		const fileNameTs = stripEnd(fileName, TS_DEFS_EXTENSION) + TS_EXTENSION;
-		if (fileNameTs === currentId) {
-			result = data;
-		}
-		results.set(fileNameTs, data);
-	};
-	host.readFile = (fileName) => {
-		if (fileName === currentId) {
-			return currentContents;
-		} else if (isSourceId(fileName)) {
-			return findById(fileName)!.contents as string;
-		} else {
-			// TODO externals - this is a problem because it's synchronous, can't use portable `fs.readFile`
-			return readFileSync(fileName, 'utf8');
-		}
-	};
-
-	return (id, contents) => {
+	return async (id) => {
 		if (results.has(id)) return results.get(id)!;
-		log.trace('generating types', printPath(id));
-		result = '';
-		currentId = id;
-		currentContents = contents;
-		const program = ts.createProgram([id], options, host);
-		program.emit();
+		const typesBasePath = replaceExtension(sourceIdToBasePath(id), TS_DEFS_EXTENSION);
+		const typesFilePath = `${toTypesBuildDir()}/${typesBasePath}`; // TODO pass through `paths`, maybe from the `BuildContext`
+		const result = await fs.readFile(typesFilePath, 'utf8');
+		results.set(id, result);
 		return result;
 	};
 };

--- a/src/build/tsBuildHelpers.ts
+++ b/src/build/tsBuildHelpers.ts
@@ -8,8 +8,8 @@ import {spawnProcess} from '../utils/process.js';
 
 This uses the TypeScript compiler to generate types.
 
-`toGenerateTypes` uses `tsc` directly,
-and `toGenerateTypesForFile` then looks up those results.
+The function `generateTypes` uses `tsc` to output all declarations to the filesystem,
+and then `toGenerateTypesForFile` looks up those cached results.
 
 */
 
@@ -28,7 +28,7 @@ export const generateTypes = async (
 	src: string,
 	dest: string,
 	sourcemap: boolean,
-	declarationMap = sourcemap,
+	declarationMap: boolean = sourcemap,
 	args: string[] = EMPTY_ARRAY,
 ) => {
 	const tscResult = await spawnProcess('npx', [

--- a/src/fs/testModule.ts
+++ b/src/fs/testModule.ts
@@ -20,16 +20,6 @@ export const isTestPath = (path: string): boolean => path.endsWith(TEST_FILE_SUF
 export const loadTestModule = (id: string): Promise<LoadModuleResult<TestModuleMeta>> =>
 	loadModule(id, validateTestModule);
 
-export const TEST_BUILD_FILE_MATCHER = /\.test\.js$/;
-export const TEST_BUILD_FIXTURES_MATCHER = /\/fixtures(\/|$)/; // TODO combine with the above?
-export const isTestBuildFile = (path: string): boolean =>
-	TEST_BUILD_FILE_MATCHER.test(path) || TEST_BUILD_FIXTURES_MATCHER.test(path);
-
-// Artifacts include typings and sourcemaps.
-export const TEST_BUILD_ARTIFACT_MATCHER = /\.test\.(js\.map|d\.ts|d\.ts\.map)$/;
-export const isTestBuildArtifact = (path: string): boolean =>
-	TEST_BUILD_ARTIFACT_MATCHER.test(path);
-
 export const findTestModules = (
 	fs: Filesystem,
 	inputPaths: string[] = [paths.source],

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -37,7 +37,8 @@ export const EXTERNALS_BUILD_DIR_ROOT_PREFIX = `/${EXTERNALS_BUILD_DIRNAME}/`;
 
 export const JS_EXTENSION = '.js';
 export const TS_EXTENSION = '.ts';
-export const TS_DEFS_EXTENSION = '.d.ts';
+export const TS_TYPE_EXTENSION = '.d.ts';
+export const TS_TYPEMAP_EXTENSION = '.d.ts.map'; // `declarationMap` -> `typemap` to match `sourcemap`
 export const CSS_EXTENSION = '.css';
 export const SVELTE_EXTENSION = '.svelte';
 export const SVELTE_JS_BUILD_EXTENSION = '.svelte.js';
@@ -137,7 +138,7 @@ export const toBuildBasePath = (buildId: string, buildDir = paths.build): string
 
 // TODO probably change this to use a regexp (benchmark?)
 export const hasSourceExtension = (path: string): boolean =>
-	(path.endsWith(TS_EXTENSION) && !path.endsWith(TS_DEFS_EXTENSION)) ||
+	(path.endsWith(TS_EXTENSION) && !path.endsWith(TS_TYPE_EXTENSION)) ||
 	path.endsWith(SVELTE_EXTENSION);
 
 // Can be used to map a source id from e.g. the cwd to gro's.

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -103,6 +103,9 @@ export const BUILD_DIRNAME_DEV = 'dev';
 export const BUILD_DIRNAME_PROD = 'prod';
 export type BuildOutDirname = 'dev' | 'prod';
 
+export const TYPES_BUILD_DIRNAME = 'types';
+export const toTypesBuildDir = (p = paths) => `${p.build}${TYPES_BUILD_DIRNAME}`;
+
 // TODO this is only needed because of how we added `/` to all directories above
 // fix those and remove this!
 function ensureTrailingSlash(s: string): string {


### PR DESCRIPTION
Continues the work in #194:

- [x] improve type generation for `.ts` files (TypeScript compiler does not like to be used 1 file at a time)
- [x] integrate with the build and adapters
- [x] add typemaps (aka declaration maps)
- [x] map typemap `sources` path for production builds (`.d.ts.map` files)

Punting on Svelte type generation for now. Here are some links for that:

- https://github.com/sveltejs/language-tools/tree/master/packages/svelte2tsx
- https://github.com/micha-lmxt/svelte-types-writer
- https://github.com/firefish5000/svelte2dts
- https://github.com/IBM/sveld
- https://github.com/material-svelte/material-svelte/tree/main/tools/svelte-type-generator