### PR TITLE
improve publishing changelog UX

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - fix typemap source path
   ([#198](https://github.com/feltcoop/gro/pull/198))
+- improve publishing changelog UX
+  ([#197](https://github.com/feltcoop/gro/pull/197))
 
 ## 0.23.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Gro changelog
+# changelog
 
 ## 0.23.4
 

--- a/src/publish.task.ts
+++ b/src/publish.task.ts
@@ -150,16 +150,23 @@ const confirmWithUser = async (
 	});
 };
 
+const CHANGELOG_PATH = 'changelog.md';
+
 // TODO document this better
 // TODO move where?
 // TODO refactor? this code is quick & worky
 const getChangelogVersions = async (
 	fs: Filesystem,
 ): Promise<[currentChangelogVersion?: string, previousChangelogVersion?: string]> => {
+	if (!(await fs.exists(CHANGELOG_PATH))) {
+		throw Error(`Publishing requires ${CHANGELOG_PATH} - please create it to continue`);
+	}
 	const changelogMatcher = /##.+/g;
-	const changelog = await fs.readFile('changelog.md', 'utf8');
+	const changelog = await fs.readFile(CHANGELOG_PATH, 'utf8');
 	const matchCurrent = changelog.match(changelogMatcher);
-	if (!matchCurrent) return [];
+	if (!matchCurrent) {
+		throw Error(`Changelog must have at least one version header, e.g. ## 0.1.0`);
+	}
 	return matchCurrent.slice(0, 2).map((line) => line.slice(2).trim()) as [string, string];
 };
 


### PR DESCRIPTION
`gro publish` depends on `changelog.md` so this helps the user along.