### PR TITLE
fix publish

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # changelog
 
-## 0.24.0
+## 0.23.7
 
 - fix `gro publish` arg forwarding to `npm version`
   ([#200](https://github.com/feltcoop/gro/pull/200))

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.24.0
+
+- fix `gro publish` to initialize scoped packages
+  ([#200](https://github.com/feltcoop/gro/pull/200))
+
 ## 0.23.6
 
 - tweak publish steps to handle failure better

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.24.0
 
+- fix `gro publish` arg forwarding to `npm version`
+  ([#200](https://github.com/feltcoop/gro/pull/200))
 - fix `gro publish` to initialize scoped packages
   ([#200](https://github.com/feltcoop/gro/pull/200))
 

--- a/src/publish.task.ts
+++ b/src/publish.task.ts
@@ -60,7 +60,7 @@ export const task: Task<TaskArgs> = {
 			return;
 		}
 
-		await spawnProcess('npm', ['version', ...process.argv.slice(3)]);
+		await spawnProcess('npm', ['version', versionIncrement]);
 		await spawnProcess('git', ['push']);
 		await spawnProcess('git', ['push', '--tags']);
 		const publishArgs = ['publish'];

--- a/src/publish.task.ts
+++ b/src/publish.task.ts
@@ -39,7 +39,7 @@ export const task: Task<TaskArgs> = {
 		validateVersionIncrement(versionIncrement);
 
 		// Confirm with the user that we're doing what they expect:
-		await confirmWithUser(fs, versionIncrement, log);
+		const publishContext = await confirmWithUser(fs, versionIncrement, log);
 
 		// Make sure we're on the right branch:
 		// TODO see how the deploy task uses git, probably do that instead
@@ -63,7 +63,11 @@ export const task: Task<TaskArgs> = {
 		await spawnProcess('npm', ['version', ...process.argv.slice(3)]);
 		await spawnProcess('git', ['push']);
 		await spawnProcess('git', ['push', '--tags']);
-		await spawnProcess('npm', ['publish']);
+		const publishArgs = ['publish'];
+		if (!publishContext.previousChangelogVersion) {
+			publishArgs.push('--access', 'public');
+		}
+		await spawnProcess('npm', publishArgs);
 	},
 };
 
@@ -71,9 +75,9 @@ const confirmWithUser = async (
 	fs: Filesystem,
 	versionIncrement: string,
 	log: Logger,
-): Promise<void> => {
+): Promise<PublishContext> => {
 	const readline = createReadlineInterface({input: process.stdin, output: process.stdout});
-	await new Promise<void>(async (resolve) => {
+	return new Promise<PublishContext>(async (resolve) => {
 		const [
 			[currentChangelogVersion, previousChangelogVersion],
 			currentPackageVersion,
@@ -144,7 +148,7 @@ const confirmWithUser = async (
 				}
 				log.info(rainbow('proceeding'));
 				readline.close();
-				resolve();
+				resolve(publishContext);
 			},
 		);
 	});


### PR DESCRIPTION
This fixes two issues with `gro publish`:

- `npm version` args no longer conflict with task args
- initialize scoped packages so npm will accept them