### PR TITLE
separate source meta for dev and prod

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.24.1
+
+- separate source meta for dev and prod
+  ([#201](https://github.com/feltcoop/gro/pull/201))
+
 ## 0.24.0
 
 - **break**: extend config with detected defaults

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -37,8 +37,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 
 		const timings = new Timings(); // TODO belongs in ctx
 
-		// TODO properly clean
-		await clean(fs, {dist: true}, log);
+		await clean(fs, {buildProd: true, dist: true}, log);
 
 		// Build all types so they're available.
 		// TODO refactor? maybe lazily build types only when a builder wants them

--- a/src/build/Filer.test.ts
+++ b/src/build/Filer.test.ts
@@ -94,8 +94,8 @@ test_Filer('basic build usage with no watch', async ({fs}) => {
 		'/a/b/src',
 		'/a/b/src/entrypoint.ts',
 		'/c',
-		'/c/src',
-		'/c/src/entrypoint.ts.json',
+		'/c/dev_meta',
+		'/c/dev_meta/entrypoint.ts.json',
 	]);
 	t.ok(fs._files.has(entryId));
 

--- a/src/build/buildFile.ts
+++ b/src/build/buildFile.ts
@@ -7,7 +7,6 @@ import {basename, dirname, extname} from 'path';
 import {loadContents} from './load.js';
 import type {BuildableSourceFile} from './sourceFile.js';
 import type {BuildConfig} from '../build/buildConfig.js';
-import {toBuildOutDirname} from '../paths.js';
 import type {Filesystem} from '../fs/filesystem.js';
 
 export type BuildFile = TextBuildFile | BinaryBuildFile;
@@ -83,13 +82,10 @@ export const reconstructBuildFiles = async (
 	fs: Filesystem,
 	sourceMeta: SourceMeta,
 	buildConfigs: readonly BuildConfig[],
-	dev: boolean,
 ): Promise<Map<BuildConfig, BuildFile[]>> => {
 	const buildFiles: Map<BuildConfig, BuildFile[]> = new Map();
-	const builds = sourceMeta.data.builds[toBuildOutDirname(dev)];
-	if (!builds) return buildFiles;
 	await Promise.all(
-		builds.map(
+		sourceMeta.data.builds.map(
 			async (build): Promise<void> => {
 				const {id, name, dependencies, encoding} = build;
 				const filename = basename(id);

--- a/src/build/sourceFile.ts
+++ b/src/build/sourceFile.ts
@@ -11,7 +11,7 @@ import type {FilerFile} from './Filer.js';
 import type {SourceMeta} from './sourceMeta.js';
 import {UnreachableError} from '../utils/error.js';
 import {stripStart} from '../utils/string.js';
-import {EXTERNALS_BUILD_DIRNAME, toBuildOutDirname} from '../paths.js';
+import {EXTERNALS_BUILD_DIRNAME} from '../paths.js';
 import {isExternalBrowserModule} from '../utils/module.js';
 import type {BuildContext, BuildDependency} from './builder.js';
 
@@ -67,7 +67,7 @@ export const createSourceFile = async (
 	contents: string | Buffer,
 	filerDir: FilerDir,
 	sourceMeta: SourceMeta | undefined,
-	{fs, buildConfigs, dev}: BuildContext,
+	{fs, buildConfigs}: BuildContext,
 ): Promise<SourceFile> => {
 	let contentsBuffer: Buffer | undefined = encoding === null ? (contents as Buffer) : undefined;
 	let contentsHash: string | undefined = undefined;
@@ -84,10 +84,8 @@ export const createSourceFile = async (
 
 		// TODO not sure if `dirty` flag is the best solution here,
 		// or if it should be more widely used?
-		dirty =
-			contentsHash !== sourceMeta.data.contentsHash ||
-			!(toBuildOutDirname(dev) in sourceMeta.data.builds);
-		reconstructedBuildFiles = await reconstructBuildFiles(fs, sourceMeta, buildConfigs!, dev);
+		dirty = contentsHash !== sourceMeta.data.contentsHash || !sourceMeta.data.builds.length; // TODO is the length check right? maybe remove
+		reconstructedBuildFiles = await reconstructBuildFiles(fs, sourceMeta, buildConfigs!);
 	}
 	if (isExternalBrowserModule(id)) {
 		// externals

--- a/src/build/sourceFile.ts
+++ b/src/build/sourceFile.ts
@@ -84,7 +84,7 @@ export const createSourceFile = async (
 
 		// TODO not sure if `dirty` flag is the best solution here,
 		// or if it should be more widely used?
-		dirty = contentsHash !== sourceMeta.data.contentsHash || !sourceMeta.data.builds.length; // TODO is the length check right? maybe remove
+		dirty = contentsHash !== sourceMeta.data.contentsHash;
 		reconstructedBuildFiles = await reconstructBuildFiles(fs, sourceMeta, buildConfigs!);
 	}
 	if (isExternalBrowserModule(id)) {

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -26,7 +26,7 @@ export interface SourceMetaBuild {
 	readonly encoding: Encoding;
 }
 
-const CACHED_SOURCE_INFO_DIR_SUFFIX = '_meta'; // so `/.gro/dev_meta/` is metadata for `/.gro/dev`
+const CACHED_SOURCE_INFO_DIR_SUFFIX = '_meta'; // so `/.gro/dev_meta` is metadata for `/.gro/dev`
 export const toSourceMetaDir = (buildDir: string, dev: boolean): string =>
 	`${buildDir}${toBuildOutDirname(dev)}${CACHED_SOURCE_INFO_DIR_SUFFIX}`;
 

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -28,7 +28,7 @@ export interface SourceMetaBuild {
 
 const CACHED_SOURCE_INFO_DIR = 'src'; // so `/.gro/src/` is metadata for `/src`
 export const toSourceMetaDir = (buildDir: string, dev: boolean): string =>
-	`${buildDir}${CACHED_SOURCE_INFO_DIR}/${dev ? 'dev' : 'prod'}`;
+	`${buildDir}${CACHED_SOURCE_INFO_DIR}/${toBuildOutDirname(dev)}`;
 
 // TODO as an optimization, this should be debounced per file,
 // because we're writing per build config.

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -28,7 +28,7 @@ export interface SourceMetaBuild {
 
 const CACHED_SOURCE_INFO_DIR = 'src'; // so `/.gro/src/` is metadata for `/src`
 export const toSourceMetaDir = (buildDir: string, dev: boolean): string =>
-	`${buildDir}${CACHED_SOURCE_INFO_DIR}`;
+	`${buildDir}${CACHED_SOURCE_INFO_DIR}/${dev ? 'dev' : 'prod'}`;
 
 // TODO as an optimization, this should be debounced per file,
 // because we're writing per build config.
@@ -109,8 +109,9 @@ export const initSourceMeta = async ({
 	fs,
 	sourceMetaById,
 	buildDir,
+	dev,
 }: BuildContext): Promise<void> => {
-	const sourceMetaDir = toSourceMetaDir(buildDir);
+	const sourceMetaDir = toSourceMetaDir(buildDir, dev);
 	if (!(await fs.exists(sourceMetaDir))) return;
 	const files = await fs.findFiles(sourceMetaDir, undefined, null);
 	await Promise.all(

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -48,7 +48,7 @@ export const updateSourceMeta = async (
 	const otherBuilds = sourceMetaById.get(file.id)?.data.builds[otherOutDirname];
 
 	// create the new meta, not mutating the old
-	const cacheId = toSourceMetaId(file, buildDir);
+	const cacheId = toSourceMetaId(file, buildDir, dev);
 	const data: SourceMetaData = {
 		sourceId: file.id,
 		contentsHash: getFileContentsHash(file),
@@ -102,8 +102,8 @@ export const deleteSourceMeta = async (
 	}
 };
 
-const toSourceMetaId = (file: BuildableSourceFile, buildDir: string): string =>
-	`${buildDir}${CACHED_SOURCE_INFO_DIR}/${file.dirBasePath}${file.filename}${JSON_EXTENSION}`;
+const toSourceMetaId = (file: BuildableSourceFile, buildDir: string, dev: boolean): string =>
+	`${toSourceMetaDir(buildDir, dev)}/${file.dirBasePath}${file.filename}${JSON_EXTENSION}`;
 
 export const initSourceMeta = async ({
 	fs,

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -27,7 +27,8 @@ export interface SourceMetaBuild {
 }
 
 const CACHED_SOURCE_INFO_DIR = 'src'; // so `/.gro/src/` is metadata for `/src`
-export const toSourceMetaDir = (buildDir: string): string => `${buildDir}${CACHED_SOURCE_INFO_DIR}`;
+export const toSourceMetaDir = (buildDir: string, dev: boolean): string =>
+	`${buildDir}${CACHED_SOURCE_INFO_DIR}`;
 
 // TODO as an optimization, this should be debounced per file,
 // because we're writing per build config.

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -28,7 +28,7 @@ export interface SourceMetaBuild {
 
 const CACHED_SOURCE_INFO_DIR_SUFFIX = '_meta'; // so `/.gro/dev_meta/` is metadata for `/.gro/dev`
 export const toSourceMetaDir = (buildDir: string, dev: boolean): string =>
-	`${buildDir}${toBuildOutDirname(dev)}_${CACHED_SOURCE_INFO_DIR_SUFFIX}`;
+	`${buildDir}${toBuildOutDirname(dev)}${CACHED_SOURCE_INFO_DIR_SUFFIX}`;
 
 // TODO as an optimization, this should be debounced per file,
 // because we're writing per build config.

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -26,9 +26,9 @@ export interface SourceMetaBuild {
 	readonly encoding: Encoding;
 }
 
-const CACHED_SOURCE_INFO_DIR = 'src'; // so `/.gro/src/` is metadata for `/src`
+const CACHED_SOURCE_INFO_DIR_SUFFIX = '_meta'; // so `/.gro/dev_meta/` is metadata for `/.gro/dev`
 export const toSourceMetaDir = (buildDir: string, dev: boolean): string =>
-	`${buildDir}${CACHED_SOURCE_INFO_DIR}/${toBuildOutDirname(dev)}`;
+	`${buildDir}${toBuildOutDirname(dev)}_${CACHED_SOURCE_INFO_DIR_SUFFIX}`;
 
 // TODO as an optimization, this should be debounced per file,
 // because we're writing per build config.

--- a/src/client/sourceTree.ts
+++ b/src/client/sourceTree.ts
@@ -1,6 +1,5 @@
 import type {SourceMeta, SourceMetaBuild} from '../build/sourceMeta.js';
 import type {BuildConfig, BuildName} from '../build/buildConfig.js';
-import type {BuildOutDirname} from '../paths.js';
 import {deepEqual} from '../utils/equal.js';
 
 export interface SourceTree {
@@ -70,18 +69,13 @@ export const createSourceTree = (
 
 export const toSourceTreeMeta = (metas: SourceMeta[]): SourceTreeMeta[] => {
 	return metas.map((sourceMeta) => {
-		sourceMeta.data.builds;
 		const buildsByBuildName: Map<string, SourceMetaBuild[]> = new Map();
-		for (const mode in sourceMeta.data.builds) {
-			const builds = sourceMeta.data.builds[mode as BuildOutDirname];
-			if (!builds) continue;
-			for (const build of builds) {
-				let builds = buildsByBuildName.get(build.name);
-				if (builds === undefined) {
-					buildsByBuildName.set(build.name, (builds = []));
-				}
-				builds.push(build);
+		for (const build of sourceMeta.data.builds) {
+			let builds = buildsByBuildName.get(build.name);
+			if (builds === undefined) {
+				buildsByBuildName.set(build.name, (builds = []));
 			}
+			builds.push(build);
 		}
 		const treeMeta: SourceTreeMeta = {
 			...sourceMeta,

--- a/src/fs/clean.ts
+++ b/src/fs/clean.ts
@@ -1,8 +1,10 @@
+import {toSourceMetaDir} from '../build/sourceMeta.js';
 import {
 	NODE_MODULES_DIRNAME,
 	paths,
 	SVELTE_KIT_DEV_DIRNAME,
 	SVELTE_KIT_BUILD_DIRNAME,
+	toBuildOutDir,
 } from '../paths.js';
 import {EMPTY_ARRAY} from '../utils/array.js';
 import type {SystemLogger} from '../utils/log.js';
@@ -13,22 +15,43 @@ export const clean = async (
 	fs: Filesystem,
 	{
 		build = false,
+		buildDev = false,
+		buildProd = false,
 		dist = false,
 		svelteKit = false,
 		nodeModules = false,
-	}: {build?: boolean; dist?: boolean; svelteKit?: boolean; nodeModules?: boolean},
+	}: {
+		build?: boolean;
+		buildDev?: boolean;
+		buildProd?: boolean;
+		dist?: boolean;
+		svelteKit?: boolean;
+		nodeModules?: boolean;
+	},
 	log: SystemLogger,
 ) =>
 	Promise.all([
-		build ? cleanDir(fs, paths.build, log) : null,
-		dist ? cleanDir(fs, paths.dist, log) : null,
-		...(svelteKit
-			? [cleanDir(fs, SVELTE_KIT_DEV_DIRNAME, log), cleanDir(fs, SVELTE_KIT_BUILD_DIRNAME, log)]
+		build ? removeDir(fs, paths.build, log) : null,
+		...(!build && buildDev
+			? [
+					removeDir(fs, toBuildOutDir(true), log),
+					removeDir(fs, toSourceMetaDir(paths.build, true), log),
+			  ]
 			: EMPTY_ARRAY),
-		nodeModules ? cleanDir(fs, NODE_MODULES_DIRNAME, log) : null,
+		...(!build && buildProd
+			? [
+					removeDir(fs, toBuildOutDir(false), log),
+					removeDir(fs, toSourceMetaDir(paths.build, false), log),
+			  ]
+			: EMPTY_ARRAY),
+		dist ? removeDir(fs, paths.dist, log) : null,
+		...(svelteKit
+			? [removeDir(fs, SVELTE_KIT_DEV_DIRNAME, log), removeDir(fs, SVELTE_KIT_BUILD_DIRNAME, log)]
+			: EMPTY_ARRAY),
+		nodeModules ? removeDir(fs, NODE_MODULES_DIRNAME, log) : null,
 	]);
 
-export const cleanDir = async (fs: Filesystem, path: string, log: SystemLogger): Promise<void> => {
+export const removeDir = async (fs: Filesystem, path: string, log: SystemLogger): Promise<void> => {
 	if (await fs.exists(path)) {
 		log.info('removing', printPath(path));
 		await fs.remove(path);


### PR DESCRIPTION
This adds a fix to the build task, cleaning the production builds, by first splitting the source meta for dev and prod.

We're sticking to the invariant that the `Filer` can run in one mode or the other, but not both. This simplifies a whole lot of things, and you can always run a dev and prod filer concurrently.