### PR TITLE
add nojekyll for GitHub pages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.25.1
+
+- add `.nojekyll` support to frontend adapters for GitHub pages compatibility
+  ([#203](https://github.com/feltcoop/gro/pull/203))
+
 ## 0.25.0
 
 - **break**: upgrade to latest SvelteKit, changing the dir `.svelte` to `.svelte-kit`

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.25.1
 
 - add `.nojekyll` support to frontend adapters for GitHub Pages compatibility
-  ([#203](https://github.com/feltcoop/gro/pull/203))
+  ([#204](https://github.com/feltcoop/gro/pull/204))
 
 ## 0.25.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.25.1
 
-- add `.nojekyll` support to frontend adapters for GitHub pages compatibility
+- add `.nojekyll` support to frontend adapters for GitHub Pages compatibility
   ([#203](https://github.com/feltcoop/gro/pull/203))
 
 ## 0.25.0

--- a/src/adapt/gro-adapter-node-library.ts
+++ b/src/adapt/gro-adapter-node-library.ts
@@ -15,11 +15,11 @@ import {NODE_LIBRARY_BUILD_NAME} from '../build/defaultBuildConfig.js';
 import {BuildConfig, BuildName, printBuildConfigLabel} from '../build/buildConfig.js';
 import {EMPTY_OBJECT} from '../utils/object.js';
 import {UnreachableError} from '../utils/error.js';
-import {stripEnd} from '../utils/string.js';
 import {resolveInputFiles} from '../build/utils.js';
 import {runRollup} from '../build/rollup.js';
 import type {MapInputOptions, MapOutputOptions, MapWatchOptions} from '../build/rollup.js';
 import type {PathStats} from '../fs/pathData.js';
+import {stripTrailingSlash} from '../utils/path.js';
 
 // TODO this adapter behaves as if it owns the dist/ directory, how to compose?
 
@@ -72,7 +72,7 @@ export const createAdapter = ({
 	dir = DIST_DIRNAME,
 	link = null,
 }: Partial<Options> = EMPTY_OBJECT): Adapter<AdapterArgs> => {
-	dir = stripEnd(dir, '/');
+	dir = stripTrailingSlash(dir);
 	const count = builds.length;
 	if (!count) throw Error('No builds provided');
 	const buildOptionsByBuildName: Map<BuildName, AdaptBuildOptions> = new Map(

--- a/src/adapt/gro-adapter-node-library.ts
+++ b/src/adapt/gro-adapter-node-library.ts
@@ -81,7 +81,6 @@ export const createAdapter = ({
 	return {
 		name: '@feltcoop/gro-adapter-node-library',
 		begin: async ({fs}) => {
-			// TODO this doesn't compose - need to either change this, or add helper machinery around it
 			await fs.remove(dir);
 		},
 		adapt: async ({config, fs, dev, log, args}) => {

--- a/src/adapt/gro-adapter-spa-frontend.ts
+++ b/src/adapt/gro-adapter-spa-frontend.ts
@@ -8,7 +8,7 @@ import {
 	toImportId,
 } from '../paths.js';
 import {resolveInputFiles} from '../build/utils.js';
-import {toCommonBaseDir} from '../utils/path.js';
+import {stripTrailingSlash, toCommonBaseDir} from '../utils/path.js';
 import {printBuildConfigLabel} from '../build/buildConfig.js';
 import type {BuildName} from '../build/buildConfig.js';
 import {ensureEnd} from '../utils/string.js';
@@ -36,6 +36,7 @@ export const createAdapter = ({
 	dir = DIST_DIRNAME,
 	target = DEFAULT_TARGET,
 }: Partial<Options> = EMPTY_OBJECT): Adapter => {
+	dir = stripTrailingSlash(dir);
 	return {
 		name: '@feltcoop/gro-adapter-spa-frontend',
 		begin: async ({fs}) => {

--- a/src/adapt/gro-adapter-sveltekit-frontend.ts
+++ b/src/adapt/gro-adapter-sveltekit-frontend.ts
@@ -29,7 +29,6 @@ export const createAdapter = ({
 		adapt: async ({fs, log}) => {
 			const timings = new Timings();
 
-			// Build with SvelteKit.
 			const timingToBuildSvelteKit = timings.start('build SvelteKit');
 			await spawnProcess('npx', ['svelte-kit', 'build']);
 			timingToBuildSvelteKit();

--- a/src/adapt/gro-adapter-sveltekit-frontend.ts
+++ b/src/adapt/gro-adapter-sveltekit-frontend.ts
@@ -29,7 +29,7 @@ export const createAdapter = ({
 		adapt: async ({fs, log}) => {
 			const timings = new Timings();
 
-			// Handle any SvelteKit build.
+			// Build with SvelteKit.
 			const timingToBuildSvelteKit = timings.start('build SvelteKit');
 			await spawnProcess('npx', ['svelte-kit', 'build']);
 			timingToBuildSvelteKit();

--- a/src/adapt/gro-adapter-sveltekit-frontend.ts
+++ b/src/adapt/gro-adapter-sveltekit-frontend.ts
@@ -3,14 +3,28 @@ import {Timings} from '../utils/time.js';
 import {DIST_DIRNAME, SVELTE_KIT_BUILD_DIRNAME} from '../paths.js';
 import {spawnProcess} from '../utils/process.js';
 import {printTimings} from '../utils/print.js';
+import {EMPTY_OBJECT} from '../utils/object.js';
+import {stripTrailingSlash} from '../utils/path.js';
 
-// TODO name? is it actually specific to frontends? or is this more about bundling?
+const NOJEKYLL = '.nojekyll';
+const DEFAULT_TARGET = 'github_pages';
 
-export const createAdapter = (): Adapter => {
+export interface Options {
+	dir: string;
+	svelteKitDir: string;
+	target: 'github_pages' | 'static';
+}
+
+export const createAdapter = ({
+	dir = DIST_DIRNAME,
+	svelteKitDir = SVELTE_KIT_BUILD_DIRNAME,
+	target = DEFAULT_TARGET,
+}: Partial<Options> = EMPTY_OBJECT): Adapter => {
+	dir = stripTrailingSlash(dir);
 	return {
 		name: '@feltcoop/gro-adapter-sveltekit-frontend',
 		begin: async ({fs}) => {
-			await fs.remove(DIST_DIRNAME);
+			await fs.remove(dir);
 		},
 		adapt: async ({fs, log}) => {
 			const timings = new Timings();
@@ -21,8 +35,19 @@ export const createAdapter = (): Adapter => {
 			timingToBuildSvelteKit();
 
 			const timingToBuild = timings.start('copy build');
-			await fs.move(SVELTE_KIT_BUILD_DIRNAME, DIST_DIRNAME);
+			await fs.move(svelteKitDir, dir);
 			timingToBuild();
+
+			// GitHub pages processes everything with Jekyll by default,
+			// breaking things like files and dirs prefixed with an underscore.
+			// This adds a `.nojekyll` file to the root of the output
+			// to tell GitHub Pages to treat the outputs as plain static files.
+			if (target === 'github_pages') {
+				const nojekyllPath = `${dir}/${NOJEKYLL}`;
+				if (!(await fs.exists(nojekyllPath))) {
+					await fs.writeFile(nojekyllPath, '', 'utf8');
+				}
+			}
 
 			printTimings(timings, log);
 		},

--- a/src/adapt/gro-adapter-sveltekit-frontend.ts
+++ b/src/adapt/gro-adapter-sveltekit-frontend.ts
@@ -34,9 +34,9 @@ export const createAdapter = ({
 			await spawnProcess('npx', ['svelte-kit', 'build']);
 			timingToBuildSvelteKit();
 
-			const timingToBuild = timings.start('copy build');
+			const timingToCopyDist = timings.start('copy build to dist');
 			await fs.move(svelteKitDir, dir);
-			timingToBuild();
+			timingToCopyDist();
 
 			// GitHub pages processes everything with Jekyll by default,
 			// breaking things like files and dirs prefixed with an underscore.

--- a/src/fs/memory.test.ts
+++ b/src/fs/memory.test.ts
@@ -4,9 +4,8 @@ import {dirname, resolve} from 'path';
 
 import {fs as memoryFs, MemoryFs} from './memory.js';
 import {toFsId} from './filesystem.js';
-import {stripEnd} from '../utils/string.js';
 import {toPathParts} from '../utils/path.js';
-import {toRootPath} from '../paths.js';
+import {stripTrailingSlash, toRootPath} from '../paths.js';
 
 // TODO organize these test suites better
 // TODO generic fs test suite
@@ -331,7 +330,7 @@ test_ensureDir('normalize paths', async ({fs}) => {
 
 		const endsWithSlash = path.endsWith('/');
 		// TODO maybe add a `stripLast` instead of this
-		const testPath2 = endsWithSlash ? stripEnd(path, '/') : `${path}/`;
+		const testPath2 = endsWithSlash ? stripTrailingSlash(path) : `${path}/`;
 		await testNormalizePaths(endsWithSlash ? path : testPath2, endsWithSlash ? testPath2 : path);
 	}
 });

--- a/src/fs/memory.test.ts
+++ b/src/fs/memory.test.ts
@@ -4,8 +4,8 @@ import {dirname, resolve} from 'path';
 
 import {fs as memoryFs, MemoryFs} from './memory.js';
 import {toFsId} from './filesystem.js';
-import {toPathParts} from '../utils/path.js';
-import {stripTrailingSlash, toRootPath} from '../paths.js';
+import {stripTrailingSlash, toPathParts} from '../utils/path.js';
+import {toRootPath} from '../paths.js';
 
 // TODO organize these test suites better
 // TODO generic fs test suite

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -2,7 +2,7 @@ import {join, basename} from 'path';
 import {fileURLToPath} from 'url';
 import type {BuildName} from './build/buildConfig.js';
 
-import {replaceExtension} from './utils/path.js';
+import {replaceExtension, stripTrailingSlash} from './utils/path.js';
 import {stripStart} from './utils/string.js';
 
 /*
@@ -69,7 +69,7 @@ export interface Paths {
 }
 
 export const createPaths = (root: string): Paths => {
-	root = ensureTrailingSlash(root);
+	root = stripTrailingSlash(root) + '/';
 	const source = `${root}${SOURCE_DIR}`;
 	const build = `${root}${BUILD_DIR}`;
 	return {
@@ -97,7 +97,7 @@ export const sourceIdToBasePath = (sourceId: string, p = paths): string =>
 export const basePathToSourceId = (basePath: string, p = paths): string => `${p.source}${basePath}`;
 
 export const toBuildOutDir = (dev: boolean, buildDir = paths.build): string =>
-	`${ensureTrailingSlash(buildDir)}${toBuildOutDirname(dev)}`;
+	`${stripTrailingSlash(buildDir)}/${toBuildOutDirname(dev)}`;
 export const toBuildOutDirname = (dev: boolean): BuildOutDirname =>
 	dev ? BUILD_DIRNAME_DEV : BUILD_DIRNAME_PROD;
 export const BUILD_DIRNAME_DEV = 'dev';
@@ -106,12 +106,6 @@ export type BuildOutDirname = 'dev' | 'prod';
 
 export const TYPES_BUILD_DIRNAME = 'types';
 export const toTypesBuildDir = (p = paths) => `${p.build}${TYPES_BUILD_DIRNAME}`;
-
-// TODO this is only needed because of how we added `/` to all directories above
-// fix those and remove this!
-function ensureTrailingSlash(s: string): string {
-	return s[s.length - 1] === '/' ? s : s + '/';
-}
 
 export const toBuildOutPath = (
 	dev: boolean,

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,7 +1,7 @@
 import {extname, basename, dirname} from 'path';
 
-export const stripTrailingSlash = (s: string): string =>
-	s[s.length - 1] === '/' ? s.substring(0, s.length - 1) : s;
+export const stripTrailingSlash = (p: string): string =>
+	p[p.length - 1] === '/' ? p.substring(0, p.length - 1) : p;
 
 // Note this treats `foo.d.ts` as `.ts` - compound extensions should use `stripEnd`
 export const replaceExtension = (path: string, newExtension: string): string => {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -3,7 +3,7 @@ import {extname, basename, dirname} from 'path';
 export const stripTrailingSlash = (s: string): string =>
 	s[s.length - 1] === '/' ? s.substring(0, s.length - 1) : s;
 
-// Note this treats `a.d.ts` as `.ts` - compound extensions should use `stripEnd`
+// Note this treats `foo.d.ts` as `.ts` - compound extensions should use `stripEnd`
 export const replaceExtension = (path: string, newExtension: string): string => {
 	const {length} = extname(path);
 	return (length === 0 ? path : path.substring(0, path.length - length)) + newExtension;

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,5 +1,9 @@
 import {extname, basename, dirname} from 'path';
 
+export const stripTrailingSlash = (s: string): string =>
+	s[s.length - 1] === '/' ? s.substring(0, s.length - 1) : s;
+
+// Note this treats `a.d.ts` as `.ts` - compound extensions should use `stripEnd`
 export const replaceExtension = (path: string, newExtension: string): string => {
 	const {length} = extname(path);
 	return (length === 0 ? path : path.substring(0, path.length - length)) + newExtension;


### PR DESCRIPTION
GitHub pages processes static deployments with Jekyll by default. Aside from being unnecessary, it also breaks things like any files or directories prefixed with an underscore. This PR adds functionality to the adapters to do this automatically, with configurable escape hatches.