### PR TITLE
properly detect unclean git state for `gro deploy`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.25.2
+
+- properly detect unclean git state for `gro deploy`
+  ([#205](https://github.com/feltcoop/gro/pull/205))
+
 ## 0.25.1
 
 - add `.nojekyll` support to frontend adapters for GitHub Pages compatibility

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -45,9 +45,21 @@ export const task: Task<TaskArgs> = {
 		const sourceBranch = branch || GIT_DEPLOY_BRANCH;
 
 		// Exit early if the git working directory has any unstaged or staged changes.
-		const gitDiffResult = await spawnProcess('git', ['diff-index', '--quiet', 'HEAD']);
-		if (!gitDiffResult.ok) {
-			log.error(red('git working directory is unclean~ please commit or stash to proceed'));
+		// unstaged changes: `git diff --exit-code`
+		// staged uncommitted changes: `git diff --cached --exit-code`
+		const gitDiffUnstagedResult = await spawnProcess('git', ['diff', '--exit-code', '--quiet']);
+		if (!gitDiffUnstagedResult.ok) {
+			log.error(red('git has unstaged changes: please commit or stash to proceed'));
+			return;
+		}
+		const gitDiffStagedResult = await spawnProcess('git', [
+			'diff',
+			'--exit-code',
+			'--cached',
+			'--quiet',
+		]);
+		if (!gitDiffStagedResult.ok) {
+			log.error(red('git has staged but uncommitted changes: please commit or stash to proceed'));
 			return;
 		}
 

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -46,7 +46,7 @@ export const task: Task<TaskArgs> = {
 
 		// Exit early if the git working directory has any unstaged or staged changes.
 		// unstaged changes: `git diff --exit-code`
-		// staged uncommitted changes: `git diff --cached --exit-code`
+		// staged uncommitted changes: `git diff --exit-code --cached`
 		const gitDiffUnstagedResult = await spawnProcess('git', ['diff', '--exit-code', '--quiet']);
 		if (!gitDiffUnstagedResult.ok) {
 			log.error(red('git has unstaged changes: please commit or stash to proceed'));


### PR DESCRIPTION
This makes `gro deploy` properly check the status of the git working directory. The old strategy had some weird issues. It's likely we'll want to extract this to a helper for other tasks in the future.