### PR TITLE
fix clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ for making web frontends, servers, and libraries.
 It includes:
 
 - [build system](/src/docs/build.md)
-  for [Svelte](https://github.com/sveltejs/svelte) UIs and Node servers and libraries
+  for [Svelte](https://github.com/sveltejs/svelte) UIs, Node servers/libraries, and other things
   - [unbundled development](/src/docs/dev.md)
     inspired by [Snowpack](https://github.com/pikapkg/snowpack) and using its
     [esinstall](https://github.com/snowpackjs/snowpack/tree/main/esinstall)

--- a/README.md
+++ b/README.md
@@ -188,11 +188,11 @@ see [contributing.md🌄](./contributing.md)
 ## credits :turtle:<sub>:turtle:</sub><sub><sub>:turtle:</sub></sub>
 
 Gro builds on
-[Svelte](https://github.com/sveltejs/svelte) ∙
-[Rollup](https://github.com/rollup/rollup) ∙
 [TypeScript](https://github.com/microsoft/TypeScript) ∙
+[Svelte](https://github.com/sveltejs/svelte) ∙
 [esbuild](https://github.com/evanw/esbuild) ∙
 [esinstall](https://github.com/snowpackjs/snowpack/tree/main/esinstall) ∙
+[Rollup](https://github.com/rollup/rollup) ∙
 [uvu](https://github.com/lukeed/uvu) ∙
 [fs-extra](https://github.com/jprichardson/node-fs-extra) ∙
 [Prettier](https://github.com/prettier/prettier) ∙

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
   ([#209](https://github.com/feltcoop/gro/pull/209))
 - fix typemaps for production builds
   ([#209](https://github.com/feltcoop/gro/pull/209))
+- fix clean
+  ([#207](https://github.com/feltcoop/gro/pull/207))
 
 ## 0.26.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
   ([#207](https://github.com/feltcoop/gro/pull/207))
 - **break**: build configs now fail to validate if any input path strings do not exist
   ([#207](https://github.com/feltcoop/gro/pull/207))
+- **break**: rename `loadConfig` from `loadGroConfig`
+  ([#207](https://github.com/feltcoop/gro/pull/207))
 - fix clean
   ([#207](https://github.com/feltcoop/gro/pull/207))
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
   ([#207](https://github.com/feltcoop/gro/pull/207))
 - **break**: rename `loadConfig` from `loadGroConfig`
   ([#207](https://github.com/feltcoop/gro/pull/207))
+- **break**: change `validateBuildConfigs` function signature
+  ([#207](https://github.com/feltcoop/gro/pull/207))
 - fix clean
   ([#207](https://github.com/feltcoop/gro/pull/207))
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - **break**: rename `'system'` build from `'node'`
   ([#207](https://github.com/feltcoop/gro/pull/207))
+- **break**: add `'config'` build to simplify internals
+  ([#207](https://github.com/feltcoop/gro/pull/207))
 - **break**: build configs now fail to validate if any input path strings do not exist
   ([#207](https://github.com/feltcoop/gro/pull/207))
 - **break**: rename `loadConfig` from `loadGroConfig`

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,18 @@
 # changelog
 
+## 0.27.0
+
+- **break**: rename `'system'` build from `'node'`
+  ([#207](https://github.com/feltcoop/gro/pull/207))
+- fix clean
+  ([#207](https://github.com/feltcoop/gro/pull/207))
+
 ## 0.26.2
 
 - support publishing library builds
   ([#209](https://github.com/feltcoop/gro/pull/209))
 - fix typemaps for production builds
   ([#209](https://github.com/feltcoop/gro/pull/209))
-- fix clean
-  ([#207](https://github.com/feltcoop/gro/pull/207))
 
 ## 0.26.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - **break**: rename `'system'` build from `'node'`
   ([#207](https://github.com/feltcoop/gro/pull/207))
+- **break**: build configs now fail to validate if any input path strings do not exist
+  ([#207](https://github.com/feltcoop/gro/pull/207))
 - fix clean
   ([#207](https://github.com/feltcoop/gro/pull/207))
 

--- a/src/adapt/gro-adapter-node-library.ts
+++ b/src/adapt/gro-adapter-node-library.ts
@@ -17,8 +17,8 @@ import {
 	TS_TYPE_EXTENSION,
 } from '../paths.js';
 import {NODE_LIBRARY_BUILD_NAME} from '../build/defaultBuildConfig.js';
-import {BuildName, printBuildConfigLabel} from '../build/buildConfig.js';
-import {resolveInputFiles} from '../build/utils.js';
+import type {BuildName} from '../build/buildConfig.js';
+import {printBuildConfigLabel, toInputFiles} from '../build/buildConfig.js';
 import {runRollup} from '../build/rollup.js';
 import type {MapInputOptions, MapOutputOptions, MapWatchOptions} from '../build/rollup.js';
 import type {PathStats} from '../fs/pathData.js';
@@ -69,7 +69,7 @@ export const createAdapter = ({
 				throw Error(`Unknown build config: ${buildName}`);
 			}
 
-			const {files /* , filters */} = await resolveInputFiles(fs, buildConfig);
+			const files = toInputFiles(buildConfig.input);
 
 			const timingToBundleWithRollup = timings.start('bundle with rollup');
 			if (type === 'bundled') {

--- a/src/adapt/gro-adapter-node-library.ts
+++ b/src/adapt/gro-adapter-node-library.ts
@@ -23,6 +23,10 @@ import {runRollup} from '../build/rollup.js';
 import type {MapInputOptions, MapOutputOptions, MapWatchOptions} from '../build/rollup.js';
 import type {PathStats} from '../fs/pathData.js';
 
+// TODO maybe add a `files` option to explicitly include source files,
+// and fall back to inferring from the build config
+// (it should probably accept the normal include/exclude filters from @rollup/pluginutils)
+
 export interface Options {
 	buildName: BuildName; // defaults to 'library'
 	dir: string; // defaults to `dist/${buildName}`

--- a/src/adapt/gro-adapter-node-library.ts
+++ b/src/adapt/gro-adapter-node-library.ts
@@ -25,8 +25,8 @@ import type {PathStats} from '../fs/pathData.js';
 
 export interface Options {
 	buildName: BuildName; // defaults to 'library'
-	type: 'unbundled' | 'bundled'; // defaults to 'unbundled'
 	dir: string; // defaults to `dist/${buildName}`
+	type: 'unbundled' | 'bundled'; // defaults to 'unbundled'
 	link: string | null; // path to `npm link`, defaults to null
 	// TODO currently these options are only available for 'bundled'
 	esm: boolean; // defaults to true
@@ -42,8 +42,8 @@ interface AdapterArgs {
 
 export const createAdapter = ({
 	buildName = NODE_LIBRARY_BUILD_NAME,
-	type = 'unbundled',
 	dir = `${paths.dist}${buildName}`,
+	type = 'unbundled',
 	link = null,
 	esm = true,
 	cjs = true,

--- a/src/adapt/gro-adapter-spa-frontend.ts
+++ b/src/adapt/gro-adapter-spa-frontend.ts
@@ -7,8 +7,7 @@ import {printTimings} from '@feltcoop/felt/utils/print.js';
 import type {Adapter} from './adapter.js';
 import {runRollup} from '../build/rollup.js';
 import {DIST_DIRNAME, sourceIdToBasePath, toBuildExtension, toImportId} from '../paths.js';
-import {resolveInputFiles} from '../build/utils.js';
-import {printBuildConfigLabel} from '../build/buildConfig.js';
+import {printBuildConfigLabel, toInputFiles} from '../build/buildConfig.js';
 import type {BuildName} from '../build/buildConfig.js';
 import {copyDist} from '../build/dist.js';
 import {BROWSER_BUILD_NAME} from '../build/defaultBuildConfig.js';
@@ -53,7 +52,7 @@ export const createAdapter = ({
 			const timingToBundle = timings.start('bundle');
 			await Promise.all(
 				buildConfigsToBuild.map(async (buildConfig) => {
-					const {files} = await resolveInputFiles(fs, buildConfig);
+					const files = toInputFiles(buildConfig.input);
 					if (!files.length) {
 						log.trace('no input files in', printBuildConfigLabel(buildConfig));
 						return;

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -4,7 +4,7 @@ import {toArray} from '@feltcoop/felt/utils/array.js';
 
 import type {Task, Args} from './task/task.js';
 import type {MapInputOptions, MapOutputOptions, MapWatchOptions} from './build/rollup.js';
-import {loadGroConfig} from './config/config.js';
+import {loadConfig} from './config/config.js';
 import type {GroConfig} from './config/config.js';
 import type {TaskEvents as ServerTaskEvents} from './server.task.js';
 import type {AdapterContext, Adapter} from './adapt/adapter.js';
@@ -46,7 +46,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		events.emit('build.buildTypes');
 
 		const timingToLoadConfig = timings.start('load config');
-		const config = await loadGroConfig(fs, dev);
+		const config = await loadConfig(fs, dev);
 		timingToLoadConfig();
 		events.emit('build.createConfig', config);
 

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -36,7 +36,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 
 		const timings = new Timings(); // TODO belongs in ctx
 
-		await clean(fs, {buildProd: false}, log); // TODO hack fix
+		await clean(fs, {buildProd: true}, log);
 
 		// Build all types so they're available.
 		// TODO refactor? maybe lazily build types only when a builder wants them

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -27,7 +27,7 @@ import type {
 } from './builder.js';
 import {inferEncoding} from '../fs/encoding.js';
 import type {Encoding} from '../fs/encoding.js';
-import {isPrimaryBuildConfig, printBuildConfigLabel} from '../build/buildConfig.js';
+import {isSystemBuildConfig, printBuildConfigLabel} from '../build/buildConfig.js';
 import type {BuildConfig} from '../build/buildConfig.js';
 import {DEFAULT_ECMA_SCRIPT_TARGET} from '../build/defaultBuildConfig.js';
 import type {EcmaScriptTarget} from './tsBuildHelpers.js';
@@ -120,7 +120,7 @@ export const initOptions = (opts: InitialOptions): Options => {
 							dev,
 							(
 								buildConfigs.find((c) => c.platform === 'browser') ||
-								buildConfigs.find((c) => isPrimaryBuildConfig(c))!
+								buildConfigs.find((c) => isSystemBuildConfig(c))!
 							).name,
 							'',
 							buildDir,

--- a/src/build/buildConfig.test.ts
+++ b/src/build/buildConfig.test.ts
@@ -176,6 +176,7 @@ test_normalizeBuildConfigs.run();
 const test_validateBuildConfigs = suite('validateBuildConfigs');
 
 test_validateBuildConfigs('basic behavior', () => {
+	t.ok(validateBuildConfigs(normalizeBuildConfigs([])).ok);
 	t.ok(validateBuildConfigs(normalizeBuildConfigs([{name: 'node', platform: 'node', input}])).ok);
 	t.ok(
 		validateBuildConfigs(
@@ -196,6 +197,14 @@ test_validateBuildConfigs('basic behavior', () => {
 				{name: 'browser2', platform: 'browser', input},
 				{name: 'browser3', platform: 'browser', input},
 			]),
+		).ok,
+	);
+});
+
+test_validateBuildConfigs('fails with input path that does not exist', () => {
+	t.not.ok(
+		validateBuildConfigs(
+			normalizeBuildConfigs([{name: 'node', platform: 'node', input: 'no_such_file.ts'}]),
 		).ok,
 	);
 });

--- a/src/build/buildConfig.test.ts
+++ b/src/build/buildConfig.test.ts
@@ -4,7 +4,7 @@ import {join} from 'path';
 
 import {normalizeBuildConfigs, validateBuildConfigs} from './buildConfig.js';
 import {paths} from '../paths.js';
-import {PRIMARY_NODE_BUILD_CONFIG} from './defaultBuildConfig.js';
+import {SYSTEM_BUILD_CONFIG} from './defaultBuildConfig.js';
 
 const input = [paths.source.substring(0, paths.source.length - 1)]; // TODO fix when trailing slash is removed
 
@@ -62,7 +62,7 @@ test_normalizeBuildConfigs('adds a primary build config', () => {
 		{name: 'node3', platform: 'node', input},
 	]);
 	t.equal(buildConfig, [
-		PRIMARY_NODE_BUILD_CONFIG,
+		SYSTEM_BUILD_CONFIG,
 		{name: 'node1', platform: 'node', input},
 		{name: 'node2', platform: 'node', input},
 		{name: 'node3', platform: 'node', input},
@@ -76,7 +76,7 @@ test_normalizeBuildConfigs('declares a single dist', () => {
 		{name: 'node3', platform: 'node', input},
 	]);
 	t.equal(buildConfig, [
-		PRIMARY_NODE_BUILD_CONFIG,
+		SYSTEM_BUILD_CONFIG,
 		{name: 'node1', platform: 'node', input},
 		{name: 'node2', platform: 'node', input},
 		{name: 'node3', platform: 'node', input},
@@ -92,7 +92,7 @@ test_normalizeBuildConfigs('ensures a primary config for each platform', () => {
 		{name: 'browser3', platform: 'browser', input},
 	]);
 	t.equal(buildConfig, [
-		PRIMARY_NODE_BUILD_CONFIG,
+		SYSTEM_BUILD_CONFIG,
 		{name: 'node1', platform: 'node', input},
 		{name: 'node2', platform: 'node', input},
 		{name: 'browser1', platform: 'browser', input},
@@ -110,7 +110,7 @@ test_normalizeBuildConfigs('makes all dist when none is', () => {
 		{name: 'browser2', platform: 'browser', input},
 	]);
 	t.equal(buildConfig, [
-		PRIMARY_NODE_BUILD_CONFIG,
+		SYSTEM_BUILD_CONFIG,
 		{name: 'node1', platform: 'node', input},
 		{name: 'node2', platform: 'node', input},
 		{name: 'node3', platform: 'node', input},

--- a/src/build/buildConfig.test.ts
+++ b/src/build/buildConfig.test.ts
@@ -4,22 +4,31 @@ import {join} from 'path';
 
 import {normalizeBuildConfigs, validateBuildConfigs} from './buildConfig.js';
 import {paths} from '../paths.js';
-import {SYSTEM_BUILD_CONFIG} from './defaultBuildConfig.js';
+import {CONFIG_BUILD_CONFIG, SYSTEM_BUILD_CONFIG} from './defaultBuildConfig.js';
 
 const input = [paths.source.substring(0, paths.source.length - 1)]; // TODO fix when trailing slash is removed
+const FAKE_CONFIG_INPUT_RAW = 'other_gro.config2.ts';
+const FAKE_CONFIG_INPUT_NORMALIZED = [`${paths.source}other_gro.config2.ts`];
 
 /* test_normalizeBuildConfigs */
 const test_normalizeBuildConfigs = suite('normalizeBuildConfigs');
 
 test_normalizeBuildConfigs('normalizes a plain config', () => {
-	const buildConfig = normalizeBuildConfigs([{name: 'system', platform: 'node', input: '.'}]);
-	t.equal(buildConfig, [{name: 'system', platform: 'node', input}]);
+	const buildConfig = normalizeBuildConfigs([
+		{name: 'config', platform: 'node', input: FAKE_CONFIG_INPUT_RAW},
+		{name: 'system', platform: 'node', input: '.'},
+	]);
+	t.equal(buildConfig, [
+		{name: 'config', platform: 'node', input: FAKE_CONFIG_INPUT_NORMALIZED},
+		{name: 'system', platform: 'node', input},
+	]);
 });
 
 test_normalizeBuildConfigs('normalizes inputs', () => {
 	const inputPath = join(paths.source, 'foo');
 	const inputFilter = () => true;
 	const buildConfig = normalizeBuildConfigs([
+		{name: 'config', platform: 'node', input: FAKE_CONFIG_INPUT_RAW},
 		{name: 'system', platform: 'node', input: '.'},
 		{name: 'node2', platform: 'node', input: paths.source},
 		{name: 'node3', platform: 'node', input},
@@ -29,6 +38,7 @@ test_normalizeBuildConfigs('normalizes inputs', () => {
 		{name: 'node7', platform: 'node', input: [inputPath, inputFilter]},
 	]);
 	t.equal(buildConfig, [
+		{name: 'config', platform: 'node', input: FAKE_CONFIG_INPUT_NORMALIZED},
 		{name: 'system', platform: 'node', input},
 		{name: 'node2', platform: 'node', input},
 		{name: 'node3', platform: 'node', input},
@@ -55,14 +65,47 @@ test_normalizeBuildConfigs('normalizes inputs', () => {
 	]);
 });
 
-test_normalizeBuildConfigs('adds a primary build config', () => {
+test_normalizeBuildConfigs('adds missing config and system configs', () => {
 	const buildConfig = normalizeBuildConfigs([
 		{name: 'node1', platform: 'node', input},
 		{name: 'node2', platform: 'node', input},
 		{name: 'node3', platform: 'node', input},
 	]);
 	t.equal(buildConfig, [
+		CONFIG_BUILD_CONFIG,
 		SYSTEM_BUILD_CONFIG,
+		{name: 'node1', platform: 'node', input},
+		{name: 'node2', platform: 'node', input},
+		{name: 'node3', platform: 'node', input},
+	]);
+});
+
+test_normalizeBuildConfigs('adds a missing config build config', () => {
+	const buildConfig = normalizeBuildConfigs([
+		SYSTEM_BUILD_CONFIG,
+		{name: 'node1', platform: 'node', input},
+		{name: 'node2', platform: 'node', input},
+		{name: 'node3', platform: 'node', input},
+	]);
+	t.equal(buildConfig, [
+		CONFIG_BUILD_CONFIG,
+		SYSTEM_BUILD_CONFIG,
+		{name: 'node1', platform: 'node', input},
+		{name: 'node2', platform: 'node', input},
+		{name: 'node3', platform: 'node', input},
+	]);
+});
+
+test_normalizeBuildConfigs('adds a missing system build config', () => {
+	const buildConfig = normalizeBuildConfigs([
+		CONFIG_BUILD_CONFIG,
+		{name: 'node1', platform: 'node', input},
+		{name: 'node2', platform: 'node', input},
+		{name: 'node3', platform: 'node', input},
+	]);
+	t.equal(buildConfig, [
+		SYSTEM_BUILD_CONFIG,
+		CONFIG_BUILD_CONFIG,
 		{name: 'node1', platform: 'node', input},
 		{name: 'node2', platform: 'node', input},
 		{name: 'node3', platform: 'node', input},
@@ -76,6 +119,7 @@ test_normalizeBuildConfigs('declares a single dist', () => {
 		{name: 'node3', platform: 'node', input},
 	]);
 	t.equal(buildConfig, [
+		CONFIG_BUILD_CONFIG,
 		SYSTEM_BUILD_CONFIG,
 		{name: 'node1', platform: 'node', input},
 		{name: 'node2', platform: 'node', input},
@@ -92,6 +136,7 @@ test_normalizeBuildConfigs('ensures a primary config for each platform', () => {
 		{name: 'browser3', platform: 'browser', input},
 	]);
 	t.equal(buildConfig, [
+		CONFIG_BUILD_CONFIG,
 		SYSTEM_BUILD_CONFIG,
 		{name: 'node1', platform: 'node', input},
 		{name: 'node2', platform: 'node', input},
@@ -110,6 +155,7 @@ test_normalizeBuildConfigs('makes all dist when none is', () => {
 		{name: 'browser2', platform: 'browser', input},
 	]);
 	t.equal(buildConfig, [
+		CONFIG_BUILD_CONFIG,
 		SYSTEM_BUILD_CONFIG,
 		{name: 'node1', platform: 'node', input},
 		{name: 'node2', platform: 'node', input},

--- a/src/build/buildConfig.test.ts
+++ b/src/build/buildConfig.test.ts
@@ -12,15 +12,15 @@ const input = [paths.source.substring(0, paths.source.length - 1)]; // TODO fix 
 const test_normalizeBuildConfigs = suite('normalizeBuildConfigs');
 
 test_normalizeBuildConfigs('normalizes a plain config', () => {
-	const buildConfig = normalizeBuildConfigs([{name: 'node', platform: 'node', input: '.'}]);
-	t.equal(buildConfig, [{name: 'node', platform: 'node', input}]);
+	const buildConfig = normalizeBuildConfigs([{name: 'system', platform: 'node', input: '.'}]);
+	t.equal(buildConfig, [{name: 'system', platform: 'node', input}]);
 });
 
 test_normalizeBuildConfigs('normalizes inputs', () => {
 	const inputPath = join(paths.source, 'foo');
 	const inputFilter = () => true;
 	const buildConfig = normalizeBuildConfigs([
-		{name: 'node', platform: 'node', input: '.'},
+		{name: 'system', platform: 'node', input: '.'},
 		{name: 'node2', platform: 'node', input: paths.source},
 		{name: 'node3', platform: 'node', input},
 		{name: 'node4', platform: 'node', input: 'foo'},
@@ -29,7 +29,7 @@ test_normalizeBuildConfigs('normalizes inputs', () => {
 		{name: 'node7', platform: 'node', input: [inputPath, inputFilter]},
 	]);
 	t.equal(buildConfig, [
-		{name: 'node', platform: 'node', input},
+		{name: 'system', platform: 'node', input},
 		{name: 'node2', platform: 'node', input},
 		{name: 'node3', platform: 'node', input},
 		{

--- a/src/build/buildConfig.ts
+++ b/src/build/buildConfig.ts
@@ -28,6 +28,12 @@ export interface InputFilter {
 	(id: string): boolean;
 }
 
+export const toInputFiles = (input: readonly BuildConfigInput[]): string[] =>
+	input.filter((input) => typeof input === 'string') as string[];
+
+export const toInputFilters = (input: readonly BuildConfigInput[]): InputFilter[] =>
+	input.filter((input) => typeof input !== 'string') as InputFilter[];
+
 // The partial was originally this calculated type, but it's a lot less readable.
 // export type BuildConfigPartial = PartialExcept<
 // 	OmitStrict<BuildConfig, 'input'> & {readonly input: string | string[]},

--- a/src/build/buildConfig.ts
+++ b/src/build/buildConfig.ts
@@ -21,6 +21,7 @@ export interface BuildConfig<TPlatformTarget extends string = PlatformTarget> {
 	readonly input: readonly BuildConfigInput[];
 }
 
+// `string` inputs must be a relative or absolute path to a source file
 export type BuildConfigInput = string | InputFilter;
 
 export interface InputFilter {

--- a/src/build/buildConfig.ts
+++ b/src/build/buildConfig.ts
@@ -4,7 +4,7 @@ import {blue, gray} from '@feltcoop/felt/utils/terminal.js';
 import type {Result, Flavored} from '@feltcoop/felt/utils/types.js';
 
 import {paths} from '../paths.js';
-import {PRIMARY_NODE_BUILD_CONFIG, PRIMARY_NODE_BUILD_NAME} from './defaultBuildConfig.js';
+import {SYSTEM_BUILD_CONFIG, SYSTEM_BUILD_NAME} from './defaultBuildConfig.js';
 
 // See `../docs/config.md` for documentation.
 
@@ -36,7 +36,7 @@ export interface BuildConfigPartial {
 export type PlatformTarget = 'node' | 'browser';
 
 export const isPrimaryBuildConfig = (config: BuildConfig): boolean =>
-	config.name === PRIMARY_NODE_BUILD_NAME;
+	config.name === SYSTEM_BUILD_NAME;
 
 export const normalizeBuildConfigs = (
 	partials: readonly (BuildConfigPartial | null)[],
@@ -57,7 +57,7 @@ export const normalizeBuildConfigs = (
 		}
 	}
 	if (!hasPrimaryBuildConfig) {
-		buildConfigs.unshift(PRIMARY_NODE_BUILD_CONFIG);
+		buildConfigs.unshift(SYSTEM_BUILD_CONFIG);
 	}
 
 	return buildConfigs;
@@ -74,13 +74,13 @@ export const validateBuildConfigs = (buildConfigs: BuildConfig[]): Result<{}, {r
 			reason: `The field 'gro.builds' in package.json must be an array`,
 		};
 	}
-	const primaryBuildConfig = buildConfigs.find((b) => b.name === PRIMARY_NODE_BUILD_NAME);
+	const primaryBuildConfig = buildConfigs.find((b) => b.name === SYSTEM_BUILD_NAME);
 	if (!primaryBuildConfig) {
 		return {
 			ok: false,
 			reason:
 				`The field 'gro.builds' in package.json must have` +
-				` a 'node' config named '${PRIMARY_NODE_BUILD_NAME}'`,
+				` a 'node' config named '${SYSTEM_BUILD_NAME}'`,
 		};
 	}
 	const names: Set<BuildName> = new Set();

--- a/src/build/buildConfig.ts
+++ b/src/build/buildConfig.ts
@@ -10,6 +10,8 @@ import {
 	SYSTEM_BUILD_CONFIG,
 	SYSTEM_BUILD_NAME,
 } from './defaultBuildConfig.js';
+import {validateInputFiles} from './utils.js';
+import type {Filesystem} from '../fs/filesystem.js';
 
 // See `../docs/config.md` for documentation.
 
@@ -88,7 +90,10 @@ const normalizeBuildConfigInput = (input: BuildConfigPartial['input']): BuildCon
 	toArray(input as any[]).map((v) => (typeof v === 'string' ? resolve(paths.source, v) : v));
 
 // TODO replace this with JSON schema validation (or most of it at least)
-export const validateBuildConfigs = (buildConfigs: BuildConfig[]): Result<{}, {reason: string}> => {
+export const validateBuildConfigs = async (
+	fs: Filesystem,
+	buildConfigs: BuildConfig[],
+): Promise<Result<{}, {reason: string}>> => {
 	if (!Array.isArray(buildConfigs)) {
 		return {
 			ok: false,
@@ -136,6 +141,8 @@ export const validateBuildConfigs = (buildConfigs: BuildConfig[]): Result<{}, {r
 			};
 		}
 		names.add(buildConfig.name);
+		const validatedInput = await validateInputFiles(fs, toInputFiles(buildConfig.input));
+		if (!validatedInput.ok) return validatedInput;
 	}
 	return {ok: true};
 };

--- a/src/build/defaultBuildConfig.ts
+++ b/src/build/defaultBuildConfig.ts
@@ -14,10 +14,9 @@ export const GIT_DEPLOY_BRANCH = 'main'; // deploy and publish from this branch
 // for the Node platform has this value as its name.
 // This convention speeds up running tasks by standardizing where Gro can look for built files.
 // This restriction could be relaxed by using cached metadata, but this keeps things simple for now.
-export const PRIMARY_NODE_BUILD_NAME: BuildName = 'node';
-
-export const PRIMARY_NODE_BUILD_CONFIG: BuildConfig = {
-	name: PRIMARY_NODE_BUILD_NAME,
+export const SYSTEM_BUILD_NAME: BuildName = 'system';
+export const SYSTEM_BUILD_CONFIG: BuildConfig = {
+	name: SYSTEM_BUILD_NAME,
 	platform: 'node',
 	input: [createFilter(['**/*.{task,test,config,gen,gen.*}.ts', '**/fixtures/**'])],
 };

--- a/src/build/defaultBuildConfig.ts
+++ b/src/build/defaultBuildConfig.ts
@@ -10,15 +10,21 @@ export const DEFAULT_ECMA_SCRIPT_TARGET: EcmaScriptTarget = 'es2020';
 
 export const GIT_DEPLOY_BRANCH = 'main'; // deploy and publish from this branch
 
-// Gro currently enforces that the primary build config
-// for the Node platform has this value as its name.
+export const CONFIG_BUILD_NAME: BuildName = 'config';
+export const CONFIG_BUILD_CONFIG: BuildConfig = {
+	name: CONFIG_BUILD_NAME,
+	platform: 'node',
+	input: [`${paths.source}gro.config.ts`],
+};
+
+// Gro currently requires this system build config for Node tasks and tests.
 // This convention speeds up running tasks by standardizing where Gro can look for built files.
 // This restriction could be relaxed by using cached metadata, but this keeps things simple for now.
 export const SYSTEM_BUILD_NAME: BuildName = 'system';
 export const SYSTEM_BUILD_CONFIG: BuildConfig = {
 	name: SYSTEM_BUILD_NAME,
 	platform: 'node',
-	input: [createFilter(['**/*.{task,test,config,gen,gen.*}.ts', '**/fixtures/**'])],
+	input: [createFilter(['**/*.{task,test,gen,gen.*}.ts', '**/fixtures/**'])],
 };
 
 const NODE_LIBRARY_PATH = 'index.ts';

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -1,8 +1,13 @@
-import {createFilter} from '@rollup/pluginutils';
 import {createHash} from 'crypto';
 import {resolve} from 'path';
 
-import type {BuildConfig, BuildConfigInput, InputFilter} from '../build/buildConfig.js';
+import {
+	BuildConfig,
+	BuildConfigInput,
+	InputFilter,
+	toInputFiles,
+	toInputFilters,
+} from '../build/buildConfig.js';
 import type {Filesystem} from '../fs/filesystem.js';
 import {basePathToSourceId, paths, toBuildBasePath, toSourceExtension} from '../paths.js';
 import type {BuildDependency} from './builder.js';
@@ -57,22 +62,22 @@ export const resolveInputFiles = async (
 	fs: Filesystem,
 	buildConfig: BuildConfig,
 ): Promise<ResolvedInputFiles> => {
-	const resolved: ResolvedInputFiles = {files: [], filters: []};
-	await Promise.all(
-		buildConfig.input.map(async (input) => {
-			if (typeof input === 'string') {
-				if (await fs.exists(input)) {
-					resolved.files.push(input);
-				} else {
-					throw Error(`Input file does not exist: ${input}`);
-				}
-			} else {
-				resolved.filters.push(input);
+	const resolved: ResolvedInputFiles = {
+		files: toInputFiles(buildConfig.input),
+		filters: toInputFilters(buildConfig.input),
+	};
+	await validateInputFiles(fs, resolved.files);
+	return resolved;
+};
+
+export const validateInputFiles = (fs: Filesystem, files: string[]): Promise<any> =>
+	Promise.all(
+		files.map(async (input) => {
+			if (!(await fs.exists(input))) {
+				throw Error(`Input file does not exist: ${input}`);
 			}
 		}),
 	);
-	return resolved;
-};
 
 export const isInputToBuildConfig = (id: string, inputs: readonly BuildConfigInput[]): boolean => {
 	for (const input of inputs) {

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -64,7 +64,7 @@ export const resolveInputFiles = async (
 				if (await fs.exists(input)) {
 					resolved.files.push(input);
 				} else {
-					resolved.filters.push(createFilter(input));
+					throw Error(`Input file does not exist: ${input}`);
 				}
 			} else {
 				resolved.filters.push(input);

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,11 +1,11 @@
 import {test} from 'uvu';
 import * as t from 'uvu/assert';
 
-import {loadGroConfig} from './config.js';
+import {loadConfig} from './config.js';
 import {fs} from '../fs/node.js';
 
-test('loadGroConfig', async () => {
-	const config = await loadGroConfig(fs, true);
+test('loadConfig', async () => {
+	const config = await loadConfig(fs, true);
 	t.ok(config);
 });
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -23,6 +23,7 @@ import {
 	SYSTEM_BUILD_CONFIG,
 	DEFAULT_ECMA_SCRIPT_TARGET,
 	NODE_LIBRARY_BUILD_NAME,
+	CONFIG_BUILD_CONFIG,
 } from '../build/defaultBuildConfig.js';
 import type {EcmaScriptTarget} from '../build/tsBuildHelpers.js';
 import type {ServedDirPartial} from '../build/servedDir.js';
@@ -145,6 +146,15 @@ export const loadConfig = async (
 		return cachedConfig;
 	}
 
+	// TODO I think this is correct?
+	const {buildSourceDirectory} = await import('../build/buildSourceDirectory.js');
+	const bootstrap_config = await toConfig(
+		{builds: [CONFIG_BUILD_CONFIG], sourcemap: dev},
+		options,
+		configSourceId,
+	);
+	await buildSourceDirectory(fs, config, dev, log);
+
 	const log = new SystemLogger(printLogLabel('config'));
 	const options: GroConfigCreatorOptions = {fs, log, dev, config: null as any};
 	const defaultConfig = await toConfig(createDefaultConfig, options, '');
@@ -160,6 +170,7 @@ export const loadConfig = async (
 			const {buildSourceDirectory} = await import('../build/buildSourceDirectory.js');
 			await buildSourceDirectory(
 				fs,
+				// TOOD should be a `BOOTSTRAP_CONFIG` or something
 				// TODO feels hacky, the `sourcemap` in particular
 				await toConfig({builds: [SYSTEM_BUILD_CONFIG], sourcemap: dev}, options, configSourceId),
 				dev,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,7 +19,7 @@ import {
 import type {AdaptBuilds} from '../adapt/adapter.js';
 import type {BuildConfig, BuildConfigPartial} from '../build/buildConfig.js';
 import {
-	PRIMARY_NODE_BUILD_CONFIG,
+	SYSTEM_BUILD_CONFIG,
 	DEFAULT_ECMA_SCRIPT_TARGET,
 	NODE_LIBRARY_BUILD_NAME,
 } from '../build/defaultBuildConfig.js';
@@ -151,17 +151,13 @@ export const loadGroConfig = async (
 	if (await fs.exists(configSourceId)) {
 		// The project has a `gro.config.ts`, so import it.
 		// If it's not already built, we need to bootstrap the config and use it to compile everything.
-		const configBuildId = toBuildOutPath(dev, PRIMARY_NODE_BUILD_CONFIG.name, CONFIG_BUILD_PATH);
+		const configBuildId = toBuildOutPath(dev, SYSTEM_BUILD_CONFIG.name, CONFIG_BUILD_PATH);
 		if (!(await fs.exists(configBuildId))) {
 			const {buildSourceDirectory} = await import('../build/buildSourceDirectory.js');
 			await buildSourceDirectory(
 				fs,
 				// TODO feels hacky, the `sourcemap` in particular
-				await toConfig(
-					{builds: [PRIMARY_NODE_BUILD_CONFIG], sourcemap: dev},
-					options,
-					configSourceId,
-				),
+				await toConfig({builds: [SYSTEM_BUILD_CONFIG], sourcemap: dev}, options, configSourceId),
 				dev,
 				log,
 			);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -134,7 +134,7 @@ const applyConfig = (config: GroConfig) => {
 	configureLogLevel(config.logLevel);
 };
 
-export const loadGroConfig = async (
+export const loadConfig = async (
 	fs: Filesystem,
 	dev: boolean,
 	applyConfigToSystem = true,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -199,7 +199,7 @@ export const toConfig = async (
 
 	const config = normalizeConfig(extendedConfig);
 
-	const validateResult = validateConfig(config);
+	const validateResult = await validateConfig(options.fs, config);
 	if (!validateResult.ok) {
 		throw Error(`Invalid Gro config at '${path}': ${validateResult.reason}`);
 	}
@@ -214,8 +214,11 @@ const validateConfigModule = (configModule: any): Result<{}, {reason: string}> =
 	return {ok: true};
 };
 
-const validateConfig = (config: GroConfig): Result<{}, {reason: string}> => {
-	const buildConfigsResult = validateBuildConfigs(config.builds);
+const validateConfig = async (
+	fs: Filesystem,
+	config: GroConfig,
+): Promise<Result<{}, {reason: string}>> => {
+	const buildConfigsResult = await validateBuildConfigs(fs, config.builds);
 	if (!buildConfigsResult.ok) return buildConfigsResult;
 	return {ok: true};
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -12,7 +12,8 @@ import {toArray} from '@feltcoop/felt/utils/array.js';
 
 import {paths, toBuildOutPath, CONFIG_BUILD_PATH, DIST_DIRNAME} from '../paths.js';
 import {
-	isPrimaryBuildConfig,
+	isSystemBuildConfig,
+	isConfigBuildConfig,
 	normalizeBuildConfigs,
 	validateBuildConfigs,
 } from '../build/buildConfig.js';
@@ -58,8 +59,9 @@ export interface GroConfig {
 	readonly port: number;
 	readonly logLevel: LogLevel;
 	readonly serve?: ServedDirPartial[];
-	readonly primaryNodeBuildConfig: BuildConfig;
-	readonly primaryBrowserBuildConfig: BuildConfig | null;
+	readonly configBuildConfig: BuildConfig;
+	readonly systemBuildConfig: BuildConfig;
+	readonly primaryBrowserBuildConfig: BuildConfig | null; // TODO improve this, too rigid
 }
 
 export interface GroConfigPartial {
@@ -226,7 +228,8 @@ const normalizeConfig = (config: GroConfigPartial): GroConfig => {
 				? config.publish
 				: toDefaultPublishDirs(buildConfigs),
 		target: config.target || DEFAULT_ECMA_SCRIPT_TARGET,
-		primaryNodeBuildConfig: buildConfigs.find((b) => isPrimaryBuildConfig(b))!,
+		configBuildConfig: buildConfigs.find((b) => isConfigBuildConfig(b))!,
+		systemBuildConfig: buildConfigs.find((b) => isSystemBuildConfig(b))!,
 		// TODO instead of `primary` build configs, we want to be able to mount any number of them at once,
 		// so this is a temp hack that just chooses the first browser build
 		primaryBrowserBuildConfig: buildConfigs.find((b) => b.platform === 'browser') || null,

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -3,7 +3,7 @@ import {ENV_LOG_LEVEL, LogLevel} from '@feltcoop/felt/utils/log.js';
 import type {GroConfigCreator, GroConfigPartial} from './config.js';
 import {
 	hasNodeLibrary,
-	PRIMARY_NODE_BUILD_CONFIG,
+	SYSTEM_BUILD_CONFIG,
 	NODE_LIBRARY_BUILD_CONFIG,
 	hasSvelteKitFrontend,
 } from '../build/defaultBuildConfig.js';
@@ -39,7 +39,7 @@ export const config: GroConfigCreator = async ({fs}) => {
 	]);
 	const partial: GroConfigPartial = {
 		builds: [
-			PRIMARY_NODE_BUILD_CONFIG,
+			SYSTEM_BUILD_CONFIG,
 			enableNodeLibrary ? NODE_LIBRARY_BUILD_CONFIG : null,
 			// enableApiServer ? API_SERVER_BUILD_CONFIG : null,
 			// enableGroFrontend ? toDefaultBrowserBuild() : null, // TODO configure asset paths

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -127,7 +127,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 };
 
 const getDefaultServedDirs = (config: GroConfig): ServedDirPartial[] => {
-	const buildConfigToServe = config.primaryBrowserBuildConfig ?? config.primaryNodeBuildConfig;
+	const buildConfigToServe = config.primaryBrowserBuildConfig ?? config.systemBuildConfig;
 	const buildOutDirToServe = toBuildOutPath(true, buildConfigToServe.name, '');
 	return [buildOutDirToServe];
 };

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -10,7 +10,7 @@ import {paths, toBuildOutPath, isThisProjectGro} from './paths.js';
 import {createGroServer} from './server/server.js';
 import type {GroServer} from './server/server.js';
 import type {GroConfig} from './config/config.js';
-import {loadGroConfig} from './config/config.js';
+import {loadConfig} from './config/config.js';
 import type {ServedDirPartial} from './build/servedDir.js';
 import {loadHttpsCredentials} from './server/https.js';
 import {
@@ -54,7 +54,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		}
 
 		const timingToLoadConfig = timings.start('load config');
-		const config = await loadGroConfig(fs, dev);
+		const config = await loadConfig(fs, dev);
 		timingToLoadConfig();
 		events.emit('dev.createConfig', config);
 

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -34,7 +34,7 @@ import type {GroConfigCreator} from '@feltcoop/gro';
 
 export const config: GroConfigCreator = async () => {
 	return {
-		builds: [{name: 'node', platform: 'node', input: 'index.ts'}],
+		builds: [{name: 'server', platform: 'node', input: 'index.ts'}],
 	};
 };
 ```

--- a/src/docs/options.md
+++ b/src/docs/options.md
@@ -56,8 +56,8 @@ export const initOptions = (opts: InitialOptions): Options => ({
 	// Preferring `null` over `undefined` bypasses this whole mess.
 	b: null,
 
-	// Because `c` can be `undefined`, it must default to `undefined`!
-	c: undefined,
+	// Because `c` can be `undefined`, it must default to `undefined`! and it's optional:
+	// c: undefined,
 
 	// We always omit `undefined` values from the initial options
 	// so callers can be assured type safety.

--- a/src/fs/modules.ts
+++ b/src/fs/modules.ts
@@ -7,7 +7,7 @@ import {printError} from '@feltcoop/felt/utils/print.js';
 import {loadSourcePathDataByInputPath, loadSourceIdsByInputPath} from '../fs/inputPath.js';
 import type {PathStats, PathData} from './pathData.js';
 import {toImportId, pathsFromId, printPath, printPathOrGroPath} from '../paths.js';
-import {PRIMARY_NODE_BUILD_NAME} from '../build/defaultBuildConfig.js';
+import {SYSTEM_BUILD_NAME} from '../build/defaultBuildConfig.js';
 import type {Filesystem} from './filesystem.js';
 
 /*
@@ -36,7 +36,7 @@ export const loadModule = async <T>(
 	id: string,
 	validate?: (mod: Record<string, any>) => mod is T,
 	dev = process.env.NODE_ENV !== 'production',
-	buildName = PRIMARY_NODE_BUILD_NAME,
+	buildName = SYSTEM_BUILD_NAME,
 ): Promise<LoadModuleResult<ModuleMeta<T>>> => {
 	let mod;
 	try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,7 @@ export type {
 	GroConfigCreatorOptions,
 } from './config/config.js';
 // also export the build config stuff
-export {
-	normalizeBuildConfigs,
-	validateBuildConfigs,
-	isPrimaryBuildConfig,
-} from './build/buildConfig.js';
+export {normalizeBuildConfigs, validateBuildConfigs} from './build/buildConfig.js';
 export type {BuildConfig, BuildName, BuildConfigPartial} from './build/buildConfig.js';
 
 // these seem useful and generic enough to export to users

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export type {Task, TaskContext} from './task/task.js';
 export type {Gen, GenContext} from './gen/gen.js';
 
 // export all of the main config helpers and types
-export {loadGroConfig, toConfig} from './config/config.js';
+export {loadConfig, toConfig} from './config/config.js';
 export type {
 	GroConfig,
 	GroConfigPartial,

--- a/src/publish.task.ts
+++ b/src/publish.task.ts
@@ -9,7 +9,7 @@ import type {Task} from './task/task.js';
 import {loadPackageJson} from './utils/packageJson.js';
 import {GIT_DEPLOY_BRANCH} from './build/defaultBuildConfig.js';
 import type {Filesystem} from './fs/filesystem.js';
-import {loadGroConfig} from './config/config.js';
+import {loadConfig} from './config/config.js';
 import {buildSourceDirectory} from './build/buildSourceDirectory.js';
 
 // publish.task.ts
@@ -54,7 +54,7 @@ export const task: Task<TaskArgs> = {
 		await spawnProcess('git', ['pull']);
 
 		// Build, check, then create the final artifacts:
-		const config = await loadGroConfig(fs, dev);
+		const config = await loadConfig(fs, dev);
 		if (config.publish === null) {
 			throw Error('config.publish is null, so this package cannot be published');
 		}

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -9,7 +9,7 @@ export interface TaskArgs {
 	serve?: ServedDirPartial[]; // takes priority over the CLI arg "_" above
 	host?: string;
 	port?: string | number;
-	nocert?: boolean;
+	insecure?: boolean;
 	certfile?: string;
 	certkeyfile?: string;
 }
@@ -28,7 +28,7 @@ export const task: Task<TaskArgs> = {
 		await filer.init();
 
 		// TODO write docs and validate args, maybe refactor, see also `dev.task.ts`
-		const https = args.nocert
+		const https = args.insecure
 			? null
 			: await loadHttpsCredentials(fs, log, args.certfile, args.certkeyfile);
 

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -7,7 +7,7 @@ import {printTimings} from '@feltcoop/felt/utils/print.js';
 import type {Task} from './task/task.js';
 import {DIST_DIRNAME, paths, sourceIdToBasePath, toBuildExtension} from './paths.js';
 import type {GroConfig} from './config/config.js';
-import {loadGroConfig} from './config/config.js';
+import {loadConfig} from './config/config.js';
 import type {BuildConfig} from './build/buildConfig.js';
 import {resolveInputFiles} from './build/utils.js';
 import {hasApiServer, hasSvelteKitFrontend, toApiServerPort} from './build/defaultBuildConfig.js';
@@ -36,7 +36,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		}
 
 		const timingToLoadConfig = timings.start('load config');
-		const config = await loadGroConfig(fs, dev);
+		const config = await loadConfig(fs, dev);
 		timingToLoadConfig();
 
 		// detect if we're in a SvelteKit project, and prefer that to Gro's system for now

--- a/src/start.task.ts
+++ b/src/start.task.ts
@@ -9,7 +9,7 @@ import {DIST_DIRNAME, paths, sourceIdToBasePath, toBuildExtension} from './paths
 import type {GroConfig} from './config/config.js';
 import {loadConfig} from './config/config.js';
 import type {BuildConfig} from './build/buildConfig.js';
-import {resolveInputFiles} from './build/utils.js';
+import {toInputFiles} from './build/buildConfig.js';
 import {hasApiServer, hasSvelteKitFrontend, toApiServerPort} from './build/defaultBuildConfig.js';
 import type {TaskArgs as ServeTaskArgs} from './serve.task.js';
 import {toSvelteKitBasePath} from './build/sveltekitHelpers.js';
@@ -56,7 +56,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 					// TODO this needs to be changed, might need to configure on each `buildConfig`
 					// maybe `dist: ['/path/to']` or `dist: {'/path/to': ...}`
 					config.builds.map(async (buildConfig) =>
-						(await resolveInputFiles(fs, buildConfig)).files.map((input) => ({
+						toInputFiles(buildConfig.input).map((input) => ({
 							buildConfig,
 							input,
 						})),

--- a/src/task/README.md
+++ b/src/task/README.md
@@ -12,7 +12,7 @@
 
 ## what
 
-A Gro task is just a function with some metadata.
+A Gro task is just a function with some optional metadata.
 Gro prefers conventions and code over configuration,
 and its task runner leverages the filesystem as the API
 and defers composition to the user in regular TypeScript modules.
@@ -20,8 +20,9 @@ and defers composition to the user in regular TypeScript modules.
 - Gro automatically discovers [all `*.task.ts` files](../docs/tasks.md)
   in your source directory, so creating a new task is as simple as creating a new file -
   no configuration or scaffolding commands needed!
-- task definitions are just objects with an async `run` function and some metadata,
+- task definitions are just objects with an async `run` function and some optional properties,
   so composing tasks is explicit in your code, just like any other module
+  (but there's also the helper `invokeTask`: see more below)
 - on the command line, tasks replace the concept of commands,
   so running them is as simple as `gro <task>`,
   and in code the task object's `run` function has access to CLI args
@@ -30,6 +31,9 @@ and defers composition to the user in regular TypeScript modules.
   (tasks are copy-paste friendly! just update the imports)
 - the task execution environment is filesystem agnostic by default; `run` receives a
   [`TaskContext` argument](#user-content-types-task-and-taskcontext) with an `fs` property
+- the `TaskContext` provides a rich baseline context object
+  for both dev env and one-off script authoring and execution,
+  enriching the APIs of both Gro and userland with its portable and extensibile affordances
 - it's fast because it imports only the modules that your chosen tasks need
 
 The task runner's purpose is to provide an ergonomic interface

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -100,11 +100,11 @@ export const invokeTask = async (
 				log.info('building project to run task');
 				const timingToLoadConfig = timings.start('load config');
 				// TODO probably do this as a separate process
-				// also this is messy, the `loadGroConfig` does some hacky config loading,
+				// also this is messy, the `loadConfig` does some hacky config loading,
 				// and then we end up building twice - can it be done in a single pass?
-				const {loadGroConfig} = await import('../config/config.js');
+				const {loadConfig} = await import('../config/config.js');
 				const bootstrappingDev = true; // this does not inherit from the `dev` arg or `process.env.NODE_ENV`
-				const config = await loadGroConfig(fs, bootstrappingDev);
+				const config = await loadConfig(fs, bootstrappingDev);
 				timingToLoadConfig();
 				const timingToBuildProject = timings.start('build project');
 				const {buildSourceDirectory} = await import('../build/buildSourceDirectory.js');

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -24,7 +24,7 @@ import {
 import {findModules, loadModules} from '../fs/modules.js';
 import {loadTaskModule} from './taskModule.js';
 import {loadGroPackageJson} from '../utils/packageJson.js';
-import {PRIMARY_NODE_BUILD_NAME} from '../build/defaultBuildConfig.js';
+import {SYSTEM_BUILD_NAME} from '../build/defaultBuildConfig.js';
 import type {Filesystem} from '../fs/filesystem.js';
 
 /*
@@ -257,6 +257,6 @@ const shouldBuildProject = async (fs: Filesystem, sourceId: string): Promise<boo
 	// if this is Gro, ensure the build directory exists, because tests aren't in dist/
 	if (isThisProjectGro && !(await fs.exists(paths.build))) return true;
 	// ensure the build file for the source id exists in the default dev build
-	const buildId = toImportId(sourceId, true, PRIMARY_NODE_BUILD_NAME);
+	const buildId = toImportId(sourceId, true, SYSTEM_BUILD_NAME);
 	return !(await fs.exists(buildId));
 };

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -5,7 +5,7 @@ import {spawnProcess} from '@feltcoop/felt/utils/process.js';
 import type {Task} from './task/task.js';
 import {TaskError} from './task/task.js';
 import {toBuildOutPath, toRootPath} from './paths.js';
-import {PRIMARY_NODE_BUILD_NAME} from './build/defaultBuildConfig.js';
+import {SYSTEM_BUILD_NAME} from './build/defaultBuildConfig.js';
 import {loadGroConfig} from './config/config.js';
 import {buildSourceDirectory} from './build/buildSourceDirectory.js';
 
@@ -23,7 +23,7 @@ export const task: Task = {
 
 		const timings = new Timings();
 
-		const testsBuildDir = toBuildOutPath(dev, PRIMARY_NODE_BUILD_NAME);
+		const testsBuildDir = toBuildOutPath(dev, SYSTEM_BUILD_NAME);
 
 		// TODO cleaner way to detect & rebuild?
 		if (!(await fs.exists(testsBuildDir))) {

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -6,7 +6,7 @@ import type {Task} from './task/task.js';
 import {TaskError} from './task/task.js';
 import {toBuildOutPath, toRootPath} from './paths.js';
 import {SYSTEM_BUILD_NAME} from './build/defaultBuildConfig.js';
-import {loadGroConfig} from './config/config.js';
+import {loadConfig} from './config/config.js';
 import {buildSourceDirectory} from './build/buildSourceDirectory.js';
 
 // Runs the project's tests: `gro test [...args]`
@@ -28,7 +28,7 @@ export const task: Task = {
 		// TODO cleaner way to detect & rebuild?
 		if (!(await fs.exists(testsBuildDir))) {
 			const timingToLoadConfig = timings.start('load config');
-			const config = await loadGroConfig(fs, dev);
+			const config = await loadConfig(fs, dev);
 			timingToLoadConfig();
 
 			const timingToPrebuild = timings.start('prebuild');


### PR DESCRIPTION
Thought I had a fix in #203, turns out I was just hitting happy code paths.

This issue is a little scary in how deep seated it is, and the possible outcomes include publishing stale files to npm. Unacceptable! 

Gro's build and task system are interlinked, which has great API and UX payoffs, but the internal system is complex, and further, it's more complicated than needed for reasons that are no longer relevant.

I think the correct fix involves rethinking the Gro system build, which is currently the one named `"node"`. Things have changed significantly since I designed the original system thanks to the speed of `esbuild` -- I knew I was hacking around a simple, correct system to get acceptable performance, and now we can remove those hacks without impacting UX too much, I think/hope.