### PR TITLE
fix publish

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # changelog
 
+## 0.26.2
+
+- publish library build
+  ([#209](https://github.com/feltcoop/gro/pull/209))
+- fix typemaps for production builds
+  ([#209](https://github.com/feltcoop/gro/pull/209))
+
 ## 0.26.1
 
 - rename default `'library'` build from `'lib'`

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.26.2
 
-- publish library build
+- support publishing library builds
   ([#209](https://github.com/feltcoop/gro/pull/209))
 - fix typemaps for production builds
   ([#209](https://github.com/feltcoop/gro/pull/209))

--- a/src/adapt/gro-adapter-node-library.ts
+++ b/src/adapt/gro-adapter-node-library.ts
@@ -112,7 +112,7 @@ export const createAdapter = ({
 
 			const timingToCopyDist = timings.start('copy builds to dist');
 			const filter = type === 'bundled' ? bundledDistFilter : undefined;
-			await copyDist(fs, buildConfig, dev, dir, log, filter);
+			await copyDist(fs, buildConfig, dev, dir, log, filter, pack);
 			timingToCopyDist();
 
 			// If the output is treated as a package, it needs some special handling to get it ready.

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -10,7 +10,7 @@ import {omitUndefined} from '@feltcoop/felt/utils/object.js';
 import type {Assignable, Result} from '@feltcoop/felt/utils/types.js';
 import {toArray} from '@feltcoop/felt/utils/array.js';
 
-import {paths, toBuildOutPath, CONFIG_BUILD_PATH} from '../paths.js';
+import {paths, toBuildOutPath, CONFIG_BUILD_PATH, DIST_DIRNAME} from '../paths.js';
 import {
 	isPrimaryBuildConfig,
 	normalizeBuildConfigs,
@@ -21,6 +21,7 @@ import type {BuildConfig, BuildConfigPartial} from '../build/buildConfig.js';
 import {
 	PRIMARY_NODE_BUILD_CONFIG,
 	DEFAULT_ECMA_SCRIPT_TARGET,
+	NODE_LIBRARY_BUILD_NAME,
 } from '../build/defaultBuildConfig.js';
 import type {EcmaScriptTarget} from '../build/tsBuildHelpers.js';
 import type {ServedDirPartial} from '../build/servedDir.js';
@@ -49,6 +50,7 @@ This choice keeps things simple and flexible because:
 
 export interface GroConfig {
 	readonly builds: BuildConfig[];
+	readonly publish: string | null;
 	readonly adapt: AdaptBuilds;
 	readonly target: EcmaScriptTarget;
 	readonly sourcemap: boolean;
@@ -62,6 +64,7 @@ export interface GroConfig {
 
 export interface GroConfigPartial {
 	readonly builds?: (BuildConfigPartial | null)[] | BuildConfigPartial | null; // allow `null` for convenience
+	readonly publish?: string | null; // dir to publish: defaults to 'dist/library', or null if it doesn't exist -- TODO support multiple
 	readonly adapt?: AdaptBuilds;
 	readonly target?: EcmaScriptTarget;
 	readonly sourcemap?: boolean;
@@ -222,10 +225,16 @@ const normalizeConfig = (config: GroConfigPartial): GroConfig => {
 		adapt: () => null,
 		...omitUndefined(config),
 		builds: buildConfigs,
+		publish: config.publish || toDefaultPublishDirs(buildConfigs),
 		target: config.target || DEFAULT_ECMA_SCRIPT_TARGET,
 		primaryNodeBuildConfig: buildConfigs.find((b) => isPrimaryBuildConfig(b))!,
 		// TODO instead of `primary` build configs, we want to be able to mount any number of them at once,
 		// so this is a temp hack that just chooses the first browser build
 		primaryBrowserBuildConfig: buildConfigs.find((b) => b.platform === 'browser') || null,
 	};
+};
+
+const toDefaultPublishDirs = (buildConfigs: BuildConfig[]): string | null => {
+	const buildConfigToPublish = buildConfigs.find((b) => b.name === NODE_LIBRARY_BUILD_NAME);
+	return buildConfigToPublish ? `${DIST_DIRNAME}/${buildConfigToPublish.name}` : null;
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -225,7 +225,10 @@ const normalizeConfig = (config: GroConfigPartial): GroConfig => {
 		adapt: () => null,
 		...omitUndefined(config),
 		builds: buildConfigs,
-		publish: config.publish || toDefaultPublishDirs(buildConfigs),
+		publish:
+			config.publish || config.publish === null
+				? config.publish
+				: toDefaultPublishDirs(buildConfigs),
 		target: config.target || DEFAULT_ECMA_SCRIPT_TARGET,
 		primaryNodeBuildConfig: buildConfigs.find((b) => isPrimaryBuildConfig(b))!,
 		// TODO instead of `primary` build configs, we want to be able to mount any number of them at once,

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -75,6 +75,7 @@ The [`GroConfigPartial`](/src/gro.config.ts) is the return value of config files
 ```ts
 export interface GroConfigPartial {
 	readonly builds: (BuildConfigPartial | null)[] | BuildConfigPartial | null;
+	readonly publish?: string | null; // dir for `gro publish`, defaults to 'dist/library' if it exists
 	readonly adapt?: AdaptBuilds;
 	readonly target?: EcmaScriptTarget; // defaults to 'es2020'
 	readonly sourcemap?: boolean; // defaults to true in `dev`, false for prod

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -2,7 +2,7 @@ import {createFilter} from '@rollup/pluginutils';
 import {ENV_LOG_LEVEL, LogLevel} from '@feltcoop/felt/utils/log.js';
 
 // import {createDirectoryFilter} from './build/utils.js';
-import type {GroConfigCreator} from './config/config.js';
+import type {GroConfigCreator, GroConfigPartial} from './config/config.js';
 import {toBuildOutPath} from './paths.js';
 import {BROWSER_BUILD_NAME, NODE_LIBRARY_BUILD_CONFIG} from './build/defaultBuildConfig.js';
 
@@ -12,7 +12,7 @@ import {BROWSER_BUILD_NAME, NODE_LIBRARY_BUILD_CONFIG} from './build/defaultBuil
 export const config: GroConfigCreator = async ({dev}) => {
 	// TODO not this
 	const ASSET_PATHS = ['html', 'css', 'json', 'ico', 'png', 'jpg', 'webp', 'webm', 'mp3'];
-	return {
+	const partial: GroConfigPartial = {
 		builds: [
 			{
 				...NODE_LIBRARY_BUILD_CONFIG,
@@ -37,6 +37,7 @@ export const config: GroConfigCreator = async ({dev}) => {
 				  }
 				: null,
 		],
+		publish: '.',
 		sourcemap: dev,
 		logLevel: ENV_LOG_LEVEL ?? LogLevel.Trace,
 		serve: [
@@ -58,4 +59,5 @@ export const config: GroConfigCreator = async ({dev}) => {
 				}),
 			]),
 	};
+	return partial;
 };


### PR DESCRIPTION
This completes the new publishing strategy for Node libraries. The Gro config now supports publishing a single package to npm via the optional `publish` field - if it's a directory it'll `npm publish` from there, and if it's `null`, `gro publish` will fail with an error message. We'll add support for multiple packages in the future -- not sure what the best API is. (maybe declarative packages at `src/packages`?)

- [x] fix typemap paths in the production build
- [x] figure out the best way to publish from `dist/library/`