### PR TITLE
add `no-watch` arg to `gro dev`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,8 +14,12 @@
   ([#207](https://github.com/feltcoop/gro/pull/207))
 - **break**: change `validate_build_configs` function signature
   ([#207](https://github.com/feltcoop/gro/pull/207))
+- add `no-watch` arg to `gro dev`
+  ([#208](https://github.com/feltcoop/gro/pull/208))
 - fix clean
   ([#207](https://github.com/feltcoop/gro/pull/207))
+- rename cert args in `gro dev` and `gro serve`
+  ([#208](https://github.com/feltcoop/gro/pull/208))
 
 ## 0.26.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -16,9 +16,7 @@
   ([#207](https://github.com/feltcoop/gro/pull/207))
 - add `no-watch` arg to `gro dev`
   ([#208](https://github.com/feltcoop/gro/pull/208))
-- fix clean
-  ([#207](https://github.com/feltcoop/gro/pull/207))
-- rename cert args in `gro dev` and `gro serve`
+- rename some args in `gro dev` and `gro serve`
   ([#208](https://github.com/feltcoop/gro/pull/208))
 
 ## 0.26.2

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.27.0
 
 - **break**: convert to `snake_case` from `camelCase`
-  ([#211](https://github.com/feltcoop/gro/pull/211))
+  ([#210](https://github.com/feltcoop/gro/pull/210))
 - **break**: rename `'system'` build from `'node'`
   ([#207](https://github.com/feltcoop/gro/pull/207))
 - **break**: add `'config'` build to simplify internals

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.27.0
 
 - **break**: convert to `snake_case` from `camelCase`
-  ([#208](https://github.com/feltcoop/gro/pull/208))
+  ([#211](https://github.com/feltcoop/gro/pull/211))
 - **break**: rename `'system'` build from `'node'`
   ([#207](https://github.com/feltcoop/gro/pull/207))
 - **break**: add `'config'` build to simplify internals
@@ -15,9 +15,9 @@
 - **break**: change `validate_build_configs` function signature
   ([#207](https://github.com/feltcoop/gro/pull/207))
 - add `no-watch` arg to `gro dev`
-  ([#208](https://github.com/feltcoop/gro/pull/208))
+  ([#211](https://github.com/feltcoop/gro/pull/211))
 - rename some args in `gro dev` and `gro serve`
-  ([#208](https://github.com/feltcoop/gro/pull/208))
+  ([#211](https://github.com/feltcoop/gro/pull/211))
 
 ## 0.26.2
 

--- a/src/clean.task.ts
+++ b/src/clean.task.ts
@@ -4,7 +4,9 @@ import type {Task} from './task/task.js';
 import {clean} from './fs/clean.js';
 
 export interface Task_Args {
+	build?: boolean; // !`/.gro`
 	'no-build'?: boolean; // !`/.gro`
+	dist?: boolean; // !`/dist`
 	'no-dist'?: boolean; // !`/dist`
 	sveltekit?: boolean; // `/.svelte-kit`
 	nodemodules: boolean; // `/nodemodules`
@@ -21,8 +23,8 @@ export const task: Task<Task_Args> = {
 		await clean(
 			fs,
 			{
-				build: !args['no-build'],
-				dist: !args['no-dist'],
+				build: !args.build,
+				dist: !args.dist,
 				sveltekit: !!args.sveltekit,
 				nodemodules: !!args.nodemodules,
 			},

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -96,7 +96,7 @@ export const task: Task<Task_Args, Task_Events> = {
 		// TODO restart functionality
 		const timing_to_create_gro_server = timings.start('create dev server');
 		// TODO write docs and validate args, maybe refactor, see also `serve.task.ts`
-		const https = args['insecure']
+		const https = args.insecure
 			? null
 			: await load_https_credentials(fs, log, args.cert, args.certkey);
 		const server = create_gro_server({filer, host: config.host, port: config.port, https});

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -21,9 +21,10 @@ import {
 } from './build/default_build_config.js';
 
 export interface Task_Args {
-	nocert?: boolean;
-	certfile?: string;
-	certkeyfile?: string;
+	'no-watch'?: boolean;
+	'no-cert'?: boolean;
+	cert?: string;
+	certkey?: string;
 }
 
 export interface Dev_Task_Context {
@@ -45,6 +46,8 @@ export interface Task_Events {
 export const task: Task<Task_Args, Task_Events> = {
 	description: 'start dev server',
 	run: async ({fs, dev, log, args, events}) => {
+		const watch = !args['no-watch'];
+
 		const timings = new Timings();
 
 		// Support SvelteKit builds alongside Gro
@@ -68,6 +71,7 @@ export const task: Task<Task_Args, Task_Events> = {
 			build_configs: config.builds,
 			target: config.target,
 			sourcemap: config.sourcemap,
+			watch,
 		});
 		timing_to_create_filer();
 		events.emit('dev.create_filer', filer);
@@ -75,9 +79,9 @@ export const task: Task<Task_Args, Task_Events> = {
 		// TODO restart functionality
 		const timing_to_create_gro_server = timings.start('create dev server');
 		// TODO write docs and validate args, maybe refactor, see also `serve.task.ts`
-		const https = args.nocert
+		const https = args['no-cert']
 			? null
-			: await load_https_credentials(fs, log, args.certfile, args.certkeyfile);
+			: await load_https_credentials(fs, log, args.cert, args.certkey);
 		const server = create_gro_server({filer, host: config.host, port: config.port, https});
 		timing_to_create_gro_server();
 		events.emit('dev.create_server', server);

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -10,8 +10,8 @@ export interface Task_Args {
 	host?: string;
 	port?: string | number;
 	insecure?: boolean;
-	certfile?: string;
-	certkeyfile?: string;
+	cert?: string;
+	certkey?: string;
 }
 
 export const task: Task<Task_Args> = {
@@ -30,7 +30,7 @@ export const task: Task<Task_Args> = {
 		// TODO write docs and validate args, maybe refactor, see also `dev.task.ts`
 		const https = args.insecure
 			? null
-			: await load_https_credentials(fs, log, args.certfile, args.certkeyfile);
+			: await load_https_credentials(fs, log, args.cert, args.certkey);
 
 		const server = create_gro_server({filer, host, port, https});
 		log.info(`serving on ${server.host}:${server.port}`, ...served_dirs);


### PR DESCRIPTION
Currently `gro dev` is hardcoded to watch mode, but it can be nice to run `gro dev` and just see the outputs without needing to startup and close the server, so `gro dev --no-watch` should do the trick now.