### PR TITLE
add typemap config option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,8 @@
   ([#214](https://github.com/feltcoop/gro/pull/214))
 - add `typemap` option to Gro config
   ([#215](https://github.com/feltcoop/gro/pull/215))
+- add `types` option to Gro config
+  ([#215](https://github.com/feltcoop/gro/pull/215))
 
 ## 0.26.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,8 @@
   ([#211](https://github.com/feltcoop/gro/pull/211))
 - optimize writing source meta to disk
   ([#214](https://github.com/feltcoop/gro/pull/214))
+- add `typemap` option to Gro config
+  ([#215](https://github.com/feltcoop/gro/pull/215))
 
 ## 0.26.2
 

--- a/src/build/build_source.ts
+++ b/src/build/build_source.ts
@@ -17,7 +17,7 @@ export const build_source = async (
 	log: Logger,
 	types: boolean = !dev,
 ): Promise<void> => {
-	log.info('building source directory', gray(dev ? 'development' : 'production'));
+	log.info('building source', gray(dev ? 'development' : 'production'));
 
 	const total_timing = create_stopwatch();
 	const timings = new Timings();
@@ -31,7 +31,7 @@ export const build_source = async (
 		// Build all types so they're available.
 		// TODO refactor? maybe lazily build types only when a builder wants them
 		const timing_to_types = timings.start('types');
-		await generate_types(paths.source, to_types_build_dir(), config.sourcemap);
+		await generate_types(paths.source, to_types_build_dir(), config.sourcemap, config.typemap);
 		timing_to_types();
 	}
 

--- a/src/build/build_source.ts
+++ b/src/build/build_source.ts
@@ -15,7 +15,6 @@ export const build_source = async (
 	config: Gro_Config,
 	dev: boolean,
 	log: Logger,
-	types: boolean = !dev,
 ): Promise<void> => {
 	log.info('building source', gray(dev ? 'development' : 'production'));
 
@@ -26,7 +25,7 @@ export const build_source = async (
 		log.info(`🕒 built in ${print_ms(total_timing())}`);
 	};
 
-	if (types) {
+	if (config.types) {
 		log.info('building types');
 		// Build all types so they're available.
 		// TODO refactor? maybe lazily build types only when a builder wants them
@@ -46,7 +45,7 @@ export const build_source = async (
 		watch: false,
 		target: config.target,
 		sourcemap: config.sourcemap,
-		types,
+		types: config.types,
 	});
 	timing_to_create_filer();
 

--- a/src/build/dist.ts
+++ b/src/build/dist.ts
@@ -75,7 +75,7 @@ export const copy_dist = async (
 	// typemap files (.d.ts.map) need their `sources` property mapped back to the source directory
 	// based on the relative change from the build to the dist
 	await Promise.all(
-		Array.from(typemap_files).map(async (id) => {
+		typemap_files.map(async (id) => {
 			const base_path = to_build_base_path(id);
 			const source_base_path = `${strip_end(base_path, TS_TYPEMAP_EXTENSION)}${TS_EXTENSION}`;
 			const dist_source_id = pack
@@ -91,7 +91,7 @@ export const copy_dist = async (
 
 	// TODO HACK -- see above, delete this
 	await Promise.all(
-		Array.from(hack_typemap_files).map(async (id) => {
+		hack_typemap_files.map(async (id) => {
 			const base_path = strip_start(id, to_types_build_dir()).substring(1);
 			const source_base_path = `${strip_end(base_path, TS_TYPEMAP_EXTENSION)}${TS_EXTENSION}`;
 			const dist_source_id = pack

--- a/src/build/dist.ts
+++ b/src/build/dist.ts
@@ -1,6 +1,6 @@
 import {relative, dirname} from 'path';
 import type {Logger} from '@feltcoop/felt/util/log.js';
-import {strip_end} from '@feltcoop/felt/util/string.js';
+import {strip_end, strip_start} from '@feltcoop/felt/util/string.js';
 
 import type {Build_Config} from '../build/build_config.js';
 import type {Filesystem} from '../fs/filesystem.js';
@@ -18,8 +18,8 @@ import {
 	to_types_build_dir,
 } from '../paths.js';
 
-// TODO make typemaps optional - how? on the `Build_Config`?
-// or as an arg? on the main Gro config?
+// TODO this has a huge hack to copy all types over to the dist because
+// we're not including `import type` imports as dependencies yet
 
 export const copy_dist = async (
 	fs: Filesystem,
@@ -33,37 +33,39 @@ export const copy_dist = async (
 	const build_out_dir = to_build_out_path(dev, build_config.name);
 	const externals_dir = to_build_out_path(dev, build_config.name, EXTERNALS_BUILD_DIRNAME);
 	log.info(`copying ${print_path(build_out_dir)} to ${print_path(dist_out_dir)}`);
-	let has_types = false;
-	const typemap_files: Set<string> = new Set(); // TODO convert to array when type hacks below are fixed
+	const copied_type_files: Set<string> = new Set(); // TODO HACK -- see above, delete this
+	const typemap_files: string[] = [];
 	await fs.copy(build_out_dir, dist_out_dir, {
 		filter: async (id) => {
 			if (id === externals_dir) return false;
 			const stats = await fs.stat(id);
 			if (filter && !filter(id, stats)) return false;
 			if (stats.isDirectory()) return true;
+			// TODO HACK -- see above, delete this
+			if (id.endsWith(TS_TYPE_EXTENSION) || id.endsWith(TS_TYPEMAP_EXTENSION)) {
+				copied_type_files.add(id);
+			}
 			// typemaps are edited before copying, see below
 			if (id.endsWith(TS_TYPEMAP_EXTENSION)) {
-				typemap_files.add(id);
+				typemap_files.push(id);
 				return false;
-			}
-			// TODO HACK for types -- see comment below
-			if (!has_types) {
-				if (id.endsWith(TS_TYPE_EXTENSION) || id.endsWith(TS_TYPEMAP_EXTENSION)) {
-					has_types = true;
-				}
 			}
 			return true;
 		},
 	});
 
-	// TODO HACK for types -- include all type files because
-	// we're not including `import type` imports as dependencies yet
-	if (has_types) {
+	// TODO HACK -- see above, delete this
+	const hack_typemap_files: string[] = [];
+	if (copied_type_files.size) {
 		await fs.copy(to_types_build_dir(), dist_out_dir, {
 			filter: async (id) => {
-				const should_copy = !typemap_files.has(id);
+				const stats = await fs.stat(id);
+				if (filter && !filter(id, stats)) return false;
+				if (stats.isDirectory()) return true;
+				const should_copy = !copied_type_files.has(id);
 				if (should_copy && id.endsWith(TS_TYPEMAP_EXTENSION)) {
-					typemap_files.add(id);
+					hack_typemap_files.push(id);
+					return false;
 				}
 				return should_copy;
 			},
@@ -75,6 +77,22 @@ export const copy_dist = async (
 	await Promise.all(
 		Array.from(typemap_files).map(async (id) => {
 			const base_path = to_build_base_path(id);
+			const source_base_path = `${strip_end(base_path, TS_TYPEMAP_EXTENSION)}${TS_EXTENSION}`;
+			const dist_source_id = pack
+				? `${dist_out_dir}/${SOURCE_DIRNAME}/${source_base_path}`
+				: `${paths.source}${source_base_path}`;
+			const dist_out_path = `${dist_out_dir}/${base_path}`;
+			const typemap_source_path = relative(dirname(dist_out_path), dist_source_id);
+			const typemap = JSON.parse(await fs.read_file(id, 'utf8'));
+			typemap.sources[0] = typemap_source_path; // haven't seen any exceptions that would break this
+			return fs.write_file(dist_out_path, JSON.stringify(typemap));
+		}),
+	);
+
+	// TODO HACK -- see above, delete this
+	await Promise.all(
+		Array.from(hack_typemap_files).map(async (id) => {
+			const base_path = strip_start(id, to_types_build_dir()).substring(1);
 			const source_base_path = `${strip_end(base_path, TS_TYPEMAP_EXTENSION)}${TS_EXTENSION}`;
 			const dist_source_id = pack
 				? `${dist_out_dir}/${SOURCE_DIRNAME}/${source_base_path}`

--- a/src/build/esbuild_builder.ts
+++ b/src/build/esbuild_builder.ts
@@ -5,7 +5,7 @@ import {omit_undefined} from '@feltcoop/felt/util/object.js';
 import {replace_extension} from '@feltcoop/felt/util/path.js';
 import {cyan} from '@feltcoop/felt/util/terminal.js';
 
-import type {Ecma_Script_Target, GenerateTypesForFile} from './ts_build_helpers.js';
+import type {Ecma_Script_Target, Generate_Types_For_File} from './ts_build_helpers.js';
 import {get_default_esbuild_options} from './esbuild_build_helpers.js';
 import {
 	JS_EXTENSION,
@@ -17,7 +17,7 @@ import {
 } from '../paths.js';
 import type {Builder, Build_Result, Text_Build, Text_Build_Source} from './builder.js';
 import {add_js_sourcemap_footer} from './utils.js';
-import {toGenerateTypesForFile} from './ts_build_helpers.js';
+import {to_generate_types_for_file} from './ts_build_helpers.js';
 import type {Filesystem} from '../fs/filesystem.js';
 
 export interface Options {
@@ -53,10 +53,10 @@ export const create_esbuild_builder = (opts: Initial_Options = {}): EsbuildBuild
 		return newEsbuildOptions;
 	};
 
-	let cachedGenerateTypes: Map<Filesystem, Promise<GenerateTypesForFile>> = new Map();
-	const load_generate_types = (fs: Filesystem): Promise<GenerateTypesForFile> => {
+	let cachedGenerateTypes: Map<Filesystem, Promise<Generate_Types_For_File>> = new Map();
+	const load_generate_types = (fs: Filesystem): Promise<Generate_Types_For_File> => {
 		if (cachedGenerateTypes.has(fs)) return cachedGenerateTypes.get(fs)!;
-		const promise = toGenerateTypesForFile(fs);
+		const promise = to_generate_types_for_file(fs);
 		cachedGenerateTypes.set(fs, promise);
 		return promise;
 	};

--- a/src/build/ts_build_helpers.ts
+++ b/src/build/ts_build_helpers.ts
@@ -15,7 +15,7 @@ import {
 This uses the TypeScript compiler to generate types.
 
 The function `generate_types` uses `tsc` to output all declarations to the filesystem,
-and then `toGenerateTypesForFile` looks up those cached results.
+and then `to_generate_types_for_file` looks up those cached results.
 
 */
 
@@ -37,7 +37,7 @@ export const generate_types = async (
 	typemap: boolean,
 	tsc_args: string[] = EMPTY_ARRAY,
 ) => {
-	const tscResult = await spawn_process('npx', [
+	const tsc_result = await spawn_process('npx', [
 		'tsc',
 		'--outDir',
 		dest,
@@ -51,16 +51,16 @@ export const generate_types = async (
 		'--emitDeclarationOnly',
 		...tsc_args,
 	]);
-	if (!tscResult.ok) {
-		throw Error(`TypeScript failed to compile with code ${tscResult.code}`);
+	if (!tsc_result.ok) {
+		throw Error(`TypeScript failed to compile with code ${tsc_result.code}`);
 	}
 };
 
-export interface GenerateTypesForFile {
-	(id: string): Promise<GeneratedTypes>;
+export interface Generate_Types_For_File {
+	(id: string): Promise<Generated_Types>;
 }
 
-export interface GeneratedTypes {
+export interface Generated_Types {
 	types: string;
 	typemap?: string;
 }
@@ -71,18 +71,21 @@ export interface GeneratedTypes {
 // when it compiles type declarations for individual files compared to an entire project at once.
 // (there may be dramatic improvements to the individual file building strategy,
 // but I couldn't find them in a reasonable amount of time)
-export const toGenerateTypesForFile = async (fs: Filesystem): Promise<GenerateTypesForFile> => {
-	const results: Map<string, GeneratedTypes> = new Map();
+export const to_generate_types_for_file = async (
+	fs: Filesystem,
+): Promise<Generate_Types_For_File> => {
+	const results: Map<string, Generated_Types> = new Map();
 	return async (id) => {
 		if (results.has(id)) return results.get(id)!;
-		const rootPath = `${to_types_build_dir()}/${source_id_to_base_path(id)}`; // TODO pass through `paths`, maybe from the `Build_Context`
-		const typesId = replace_extension(rootPath, TS_TYPE_EXTENSION);
-		const typemapId = replace_extension(rootPath, TS_TYPEMAP_EXTENSION);
+		const root_path = `${to_types_build_dir()}/${source_id_to_base_path(id)}`; // TODO pass through `paths`, maybe from the `Build_Context`
+		const types_id = replace_extension(root_path, TS_TYPE_EXTENSION);
+		const typemap_id = replace_extension(root_path, TS_TYPEMAP_EXTENSION);
 		const [types, typemap] = await Promise.all([
-			fs.read_file(typesId, 'utf8'),
-			(async () => ((await fs.exists(typemapId)) ? fs.read_file(typemapId, 'utf8') : undefined))(),
+			fs.read_file(types_id, 'utf8'),
+			(async () =>
+				(await fs.exists(typemap_id)) ? fs.read_file(typemap_id, 'utf8') : undefined)(),
 		]);
-		const result: GeneratedTypes = {types, typemap};
+		const result: Generated_Types = {types, typemap};
 		results.set(id, result);
 		return result;
 	};

--- a/src/build/ts_build_helpers.ts
+++ b/src/build/ts_build_helpers.ts
@@ -34,7 +34,7 @@ export const generate_types = async (
 	src: string,
 	dest: string,
 	sourcemap: boolean,
-	typemap: boolean = sourcemap,
+	typemap: boolean,
 	tsc_args: string[] = EMPTY_ARRAY,
 ) => {
 	const tscResult = await spawn_process('npx', [

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -201,8 +201,8 @@ export const to_config = async (
 
 const to_bootstrap_config = (): Gro_Config => {
 	return {
-		sourcemap: false, // TODO or always true?
-		typemap: false, // TODO or always true?
+		sourcemap: false,
+		typemap: false,
 		host: DEFAULT_SERVER_HOST,
 		port: DEFAULT_SERVER_PORT,
 		log_level: DEFAULT_LOG_LEVEL,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -51,6 +51,7 @@ export interface Gro_Config {
 	readonly adapt: Adapt_Builds;
 	readonly target: Ecma_Script_Target;
 	readonly sourcemap: boolean;
+	readonly typemap: boolean;
 	readonly host: string;
 	readonly port: number;
 	readonly log_level: Log_Level;
@@ -65,6 +66,7 @@ export interface Gro_Config_Partial {
 	readonly adapt?: Adapt_Builds;
 	readonly target?: Ecma_Script_Target;
 	readonly sourcemap?: boolean;
+	readonly typemap?: boolean;
 	readonly host?: string;
 	readonly port?: number;
 	readonly log_level?: Log_Level;
@@ -200,6 +202,7 @@ export const to_config = async (
 const to_bootstrap_config = (): Gro_Config => {
 	return {
 		sourcemap: false, // TODO or always true?
+		typemap: false, // TODO or always true?
 		host: DEFAULT_SERVER_HOST,
 		port: DEFAULT_SERVER_PORT,
 		log_level: DEFAULT_LOG_LEVEL,
@@ -232,7 +235,8 @@ const validate_config = async (
 const normalize_config = (config: Gro_Config_Partial, dev: boolean): Gro_Config => {
 	const build_configs = normalize_build_configs(to_array(config.builds || null), dev);
 	return {
-		sourcemap: dev, // TODO maybe default to tsconfig?
+		sourcemap: dev,
+		typemap: !dev,
 		host: DEFAULT_SERVER_HOST,
 		port: DEFAULT_SERVER_PORT,
 		log_level: DEFAULT_LOG_LEVEL,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -52,6 +52,7 @@ export interface Gro_Config {
 	readonly target: Ecma_Script_Target;
 	readonly sourcemap: boolean;
 	readonly typemap: boolean;
+	readonly types: boolean;
 	readonly host: string;
 	readonly port: number;
 	readonly log_level: Log_Level;
@@ -67,6 +68,7 @@ export interface Gro_Config_Partial {
 	readonly target?: Ecma_Script_Target;
 	readonly sourcemap?: boolean;
 	readonly typemap?: boolean;
+	readonly types?: boolean;
 	readonly host?: string;
 	readonly port?: number;
 	readonly log_level?: Log_Level;
@@ -152,7 +154,7 @@ export const load_config = async (
 	let config: Gro_Config;
 	if (await fs.exists(config_source_id)) {
 		const {build_source} = await import('../build/build_source.js');
-		await build_source(fs, to_bootstrap_config(), dev, log, false);
+		await build_source(fs, to_bootstrap_config(), dev, log);
 
 		// The project has a `gro.config.ts`, so import it.
 		// If it's not already built, we need to bootstrap the config and use it to compile everything.
@@ -203,6 +205,7 @@ const to_bootstrap_config = (): Gro_Config => {
 	return {
 		sourcemap: false,
 		typemap: false,
+		types: false,
 		host: DEFAULT_SERVER_HOST,
 		port: DEFAULT_SERVER_PORT,
 		log_level: DEFAULT_LOG_LEVEL,
@@ -237,6 +240,7 @@ const normalize_config = (config: Gro_Config_Partial, dev: boolean): Gro_Config 
 	return {
 		sourcemap: dev,
 		typemap: !dev,
+		types: false,
 		host: DEFAULT_SERVER_HOST,
 		port: DEFAULT_SERVER_PORT,
 		log_level: DEFAULT_LOG_LEVEL,

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -79,6 +79,8 @@ export interface Gro_Config_Partial {
 	readonly adapt?: Adapt_Builds;
 	readonly target?: Ecma_Script_Target; // defaults to 'es2020'
 	readonly sourcemap?: boolean; // defaults to true in `dev`, false for prod
+	readonly typemap?: boolean; // defaults to false in `dev`, true for prod
+	readonly types?: boolean; // defaults to false
 	readonly host?: string; // env.GRO_HOST
 	readonly port?: number; // env.GRO_PORT
 	readonly log_level?: Log_Level; // env.GRO_LOG_LEVEL

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -40,6 +40,7 @@ export const config: Gro_Config_Creator = async ({dev}) => {
 		],
 		publish: '.',
 		sourcemap: dev,
+		typemap: !dev,
 		log_level: ENV_LOG_LEVEL ?? Log_Level.Trace,
 		serve: [
 			// first try to fulfill requests with files in `$PROJECT/src/client/` as if it were `/`

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -41,6 +41,7 @@ export const config: Gro_Config_Creator = async ({dev}) => {
 		publish: '.',
 		sourcemap: dev,
 		typemap: !dev,
+		types: !dev,
 		log_level: ENV_LOG_LEVEL ?? Log_Level.Trace,
 		serve: [
 			// first try to fulfill requests with files in `$PROJECT/src/client/` as if it were `/`

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -109,7 +109,7 @@ export const BUILD_DIRNAME_PROD = 'prod';
 export type Build_Out_Dirname = 'dev' | 'prod';
 
 export const TYPES_BUILD_DIRNAME = 'types';
-export const to_types_build_dir = (p = paths) => `${p.build}${TYPES_BUILD_DIRNAME}`;
+export const to_types_build_dir = (p = paths): string => `${p.build}${TYPES_BUILD_DIRNAME}`;
 
 export const to_build_out_path = (
 	dev: boolean,
@@ -119,13 +119,13 @@ export const to_build_out_path = (
 ): string => `${to_build_out_dir(dev, build_dir)}/${build_name}/${base_path}`;
 
 export const to_build_base_path = (build_id: string, build_dir = paths.build): string => {
-	const rootPath = strip_start(build_id, build_dir);
-	let separatorCount = 0;
-	for (let i = 0; i < rootPath.length; i++) {
-		if (rootPath[i] === '/') separatorCount++;
-		if (separatorCount === 2) {
+	const root_path = strip_start(build_id, build_dir);
+	let separator_count = 0;
+	for (let i = 0; i < root_path.length; i++) {
+		if (root_path[i] === '/') separator_count++;
+		if (separator_count === 2) {
 			// `2` to strip the dev/prod directory and the build name directory
-			return rootPath.substring(i + 1);
+			return root_path.substring(i + 1);
 		}
 	}
 	// TODO ? errors on inputs like `terser` - should that be allowed to be a `build_id`??


### PR DESCRIPTION
Adds the `typemap` option alongside `sourcemap` to the Gro config. This is the TypeScript `declarationMap` option renamed to fit Gro's conventions. (maybe not advisable, but I like it right now) Defaults to the opposite of sourcemaps: included in production but not development builds. We may want to change the `sourcemap` default to be always `true`, but for the current primary library usecase we're not shipping sourcemaps, but we *are* shipping typemaps for nice editor support. (e.g. `go to definition` jumps to the actual TypeScript source files)

Also adds the `types` option to the Gro config, defaulting to `false`. It's enabled project-wide, not per build config, because we build once with `tsc` and read from the cache. It's currently not designed for development usage -- watch mode won't pick up type changes.

This PR includes a gross hack to get `import type` dependencies working for the Node library adapter. We'll need to track these dependencies for the correct implementation,