### PR TITLE
infer npm link from package json

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.27.1
+
+- infer `npm link` in Node library adapter
+  ([#217](https://github.com/feltcoop/gro/pull/217))
+
 ## 0.27.0
 
 - **break**: convert to `snake_case` from `camelCase`

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.27.1
 
 - infer `npm link` in Node library adapter
-  ([#217](https://github.com/feltcoop/gro/pull/217))
+  ([#218](https://github.com/feltcoop/gro/pull/218))
 
 ## 0.27.0
 

--- a/src/adapt/gro-adapter-node-library.ts
+++ b/src/adapt/gro-adapter-node-library.ts
@@ -35,7 +35,7 @@ export interface Options {
 	// TODO currently these options are only available for 'bundled'
 	esm: boolean; // defaults to true
 	cjs: boolean; // defaults to true
-	pack: boolean; // treat the dist as a package to be published - defaults to true
+	pack: boolean; // TODO temp hack for Gro's build -- treat the dist as a package to be published - defaults to true
 }
 
 export interface Adapter_Args extends Build_Task_Args {}

--- a/src/adapt/gro-adapter-node-library.ts
+++ b/src/adapt/gro-adapter-node-library.ts
@@ -22,6 +22,7 @@ import {print_build_config_label, to_input_files} from '../build/build_config.js
 import {run_rollup} from '../build/rollup.js';
 import type {Path_Stats} from '../fs/path_data.js';
 import type {Task_Args as Build_Task_Args} from '../build.task.js';
+import {load_package_json} from '../utils/package_json.js';
 
 // TODO maybe add a `files` option to explicitly include source files,
 // and fall back to inferring from the build config
@@ -31,7 +32,6 @@ export interface Options {
 	build_name: Build_Name; // defaults to 'library'
 	dir: string; // defaults to `dist/${build_name}`
 	type: 'unbundled' | 'bundled'; // defaults to 'unbundled'
-	link: string | null; // path to `npm link`, defaults to null
 	// TODO currently these options are only available for 'bundled'
 	esm: boolean; // defaults to true
 	cjs: boolean; // defaults to true
@@ -44,7 +44,6 @@ export const create_adapter = ({
 	build_name = NODE_LIBRARY_BUILD_NAME,
 	dir = `${paths.dist}${build_name}`,
 	type = 'unbundled',
-	link = null,
 	esm = true,
 	cjs = true,
 	pack = true,
@@ -115,6 +114,8 @@ export const create_adapter = ({
 			await copy_dist(fs, build_config, dev, dir, log, filter, pack);
 			timing_to_copy_dist();
 
+			const pkg = await load_package_json(fs);
+
 			// If the output is treated as a package, it needs some special handling to get it ready.
 			if (pack) {
 				// copy files from the project root to the dist, but don't overwrite anything in the build
@@ -131,8 +132,6 @@ export const create_adapter = ({
 				await fs.copy(paths.source, `${dir}/${SOURCE_DIRNAME}`);
 
 				// update package.json with computed values
-				const pkg_path = `${dir}/package.json`;
-				const pkg = JSON.parse(await fs.read_file(pkg_path, 'utf8'));
 
 				// add the "files" key to package.json
 				const pkg_files = new Set(pkg.files || []);
@@ -150,7 +149,7 @@ export const create_adapter = ({
 
 				// add the "exports" key to package.json
 				const pkg_exports: Record<string, string> = {
-					'.': pkg.main,
+					'.': pkg.main!,
 					'./package.json': './package.json',
 				};
 				for (const source_id of files) {
@@ -160,14 +159,18 @@ export const create_adapter = ({
 				pkg.exports = pkg_exports;
 
 				// write the new package.json
-				await fs.write_file(pkg_path, JSON.stringify(pkg, null, 2), 'utf8');
+				await fs.write_file(`${dir}/package.json`, JSON.stringify(pkg, null, 2), 'utf8');
 			}
 
-			// `npm link` if configured
-			if (link) {
+			// `npm link`
+			if (pkg.bin) {
 				const timing_to_npm_link = timings.start('npm link');
-				const chmod_result = await spawn_process('chmod', ['+x', link]);
-				if (!chmod_result.ok) log.error(`CLI chmod failed with code ${chmod_result.code}`);
+				await Promise.all(
+					Object.values(pkg.bin).map(async (bin_path) => {
+						const chmod_result = await spawn_process('chmod', ['+x', bin_path]);
+						if (!chmod_result.ok) log.error(`CLI chmod failed with code ${chmod_result.code}`);
+					}),
+				);
 				log.info(`linking`);
 				const link_result = await spawn_process('npm', ['link']);
 				if (!link_result.ok) {

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -55,7 +55,6 @@ export const config: Gro_Config_Creator = async ({dev}) => {
 			Promise.all([
 				(await import('./adapt/gro-adapter-node-library.js')).create_adapter({
 					dir: 'dist',
-					link: 'dist/cli/gro.js',
 					// TODO temp hack - unlike most libraries, Gro ships its dist/ as a sibling to src/,
 					// and this flag opts out of the default library behavior
 					pack: false,

--- a/src/utils/package_json.ts
+++ b/src/utils/package_json.ts
@@ -4,19 +4,16 @@ import type {Json} from '@feltcoop/felt/util/json.js';
 import type {Filesystem} from '../fs/filesystem.js';
 import {paths, gro_paths, is_this_project_gro} from '../paths.js';
 
-/*
+// This is a single entrypoint for getting the `package.json` of both the current project and Gro.
+// It's cached but can be reloaded with `force_refresh` flag.
 
-This is a single entrypoint for getting the `package.json` of both the current project and Gro.
-It's helpful because Node's ES modules do not yet support json files without a flag,
-and in the future we should be able to easily auto-generate types for them.
-
-TODO we probably want to extract this to felt
-
-*/
-
+// TODO fill out this type
 export interface Package_Json {
-	[key: string]: Json;
+	[key: string]: Json | undefined;
 	name: string;
+	main?: string;
+	bin?: {[key: string]: string};
+	files?: string[];
 }
 export interface Gro_Package_Json extends Package_Json {}
 
@@ -25,19 +22,19 @@ let gro_package_json: Gro_Package_Json | undefined;
 
 export const load_package_json = async (
 	fs: Filesystem,
-	forceRefresh = false,
+	force_refresh = false,
 ): Promise<Package_Json> => {
-	if (is_this_project_gro) return load_gro_package_json(fs, forceRefresh);
-	if (!package_json || forceRefresh) {
+	if (is_this_project_gro) return load_gro_package_json(fs, force_refresh);
+	if (!package_json || force_refresh) {
 		package_json = JSON.parse(await fs.read_file(join(paths.root, 'package.json'), 'utf8'));
 	}
 	return package_json!;
 };
 export const load_gro_package_json = async (
 	fs: Filesystem,
-	forceRefresh = false,
+	force_refresh = false,
 ): Promise<Gro_Package_Json> => {
-	if (!gro_package_json || forceRefresh) {
+	if (!gro_package_json || force_refresh) {
 		gro_package_json = JSON.parse(await fs.read_file(join(gro_paths.root, 'package.json'), 'utf8'));
 	}
 	return gro_package_json!;


### PR DESCRIPTION
Updates the Node library adapter to infer `npm link` behavior from the `package.json`, rather than making it a configurable option.