### PR TITLE
fix css

### DIFF
--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -1,7 +1,6 @@
-import {join, extname, relative} from 'path';
+import {join, extname, relative, basename} from 'path';
 // `lexer.init` is expected to be awaited elsewhere before `postprocess` is called
 import lexer from 'es-module-lexer';
-import {strip_start} from '@feltcoop/felt/util/string.js';
 
 import {
 	paths,
@@ -131,16 +130,11 @@ export const postprocess = (
 		if (source.extension === SVELTE_EXTENSION && build.extension === JS_EXTENSION && browser) {
 			const css_compilation = result.builds.find((c) => c.extension === CSS_EXTENSION);
 			if (css_compilation !== undefined) {
-				let import_path: string | undefined;
-				for (const served_dir of ctx.served_dirs) {
-					if (css_compilation.id.startsWith(served_dir.path)) {
-						import_path = strip_start(css_compilation.id, served_dir.root);
-						break;
-					}
-				}
-				if (import_path !== undefined) {
-					content = inject_svelte_css_import(content, import_path);
-				}
+				// TODO this is hardcoded to a sibling module, but that may be overly restrictive --
+				// a previous version of this code used the `ctx.served_dirs` to handle any location,
+				// but this coupled the build outputs to the served dirs, which failed and is weird
+				const import_path = `./${basename(css_compilation.filename)}`;
+				content = inject_svelte_css_import(content, import_path);
 			}
 		}
 		return {content, dependencies_by_build_id};

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -21,7 +21,7 @@
 	import type {Source_Tree} from './source_tree.js';
 	import type {Project_State} from '../server/project_state.js';
 	import type {View} from './view.js';
-	import {provide_project_state} from './project_state.js';
+	import {set_project_state} from './project_state.js';
 
 	console.log('enter App.svelte');
 
@@ -30,7 +30,7 @@
 	let selected_build_names: string[] = [];
 
 	const ctx = writable<Project_State>(null!);
-	provide_project_state(ctx);
+	set_project_state(ctx);
 
 	const source_meta_views: View[] = [
 		Source_Meta_Raw,

--- a/src/client/Build_Id.svelte
+++ b/src/client/Build_Id.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import {use_project_state} from './project_state.js';
+	import {get_project_state} from './project_state.js';
 	import {to_root_path} from './path_helpers.js';
 
-	const project = use_project_state();
+	const project = get_project_state();
 
 	export let id: string;
 

--- a/src/client/Source_Id.svelte
+++ b/src/client/Source_Id.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import {use_project_state} from './project_state.js';
+	import {get_project_state} from './project_state.js';
 
-	const project = use_project_state();
+	const project = get_project_state();
 
 	export let id: string;
 

--- a/src/client/Source_Meta_Build_Tree_Explorer.svelte
+++ b/src/client/Source_Meta_Build_Tree_Explorer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import {filter_selected_metas} from './source_tree.js';
 	import type {Source_Tree} from './source_tree.js';
-	import {use_project_state} from './project_state.js';
+	import {get_project_state} from './project_state.js';
 	import File_Tree_Explorer_Folder from './File_Tree_Explorer_Folder.svelte';
 	import {to_file_tree_folder} from './file_tree.js';
 
@@ -10,7 +10,7 @@
 	export const selected_source_meta = undefined;
 	export const hovered_source_meta = undefined;
 
-	const project = use_project_state();
+	const project = get_project_state();
 
 	$: filtered_source_metas = filter_selected_metas(source_tree, selected_build_names);
 	$: file_tree_folder = to_file_tree_folder($project.source_dir, filtered_source_metas);

--- a/src/client/Source_Meta_Tree_Explorer.svelte
+++ b/src/client/Source_Meta_Tree_Explorer.svelte
@@ -3,14 +3,14 @@
 	import type {Source_Tree} from './source_tree.js';
 	import {to_file_tree_folder} from './file_tree.js';
 	import File_Tree_Explorer_Folder from './File_Tree_Explorer_Folder.svelte';
-	import {use_project_state} from './project_state.js';
+	import {get_project_state} from './project_state.js';
 
 	export let source_tree: Source_Tree;
 	export let selected_build_names: string[];
 	export const selected_source_meta = undefined;
 	export const hovered_source_meta = undefined;
 
-	const project = use_project_state();
+	const project = get_project_state();
 
 	$: filtered_source_metas = filter_selected_metas(source_tree, selected_build_names);
 	$: file_tree_folder = to_file_tree_folder($project.source_dir, filtered_source_metas);

--- a/src/client/project_state.ts
+++ b/src/client/project_state.ts
@@ -5,7 +5,7 @@ import type {Project_State} from '../server/project_state.js';
 
 const context_key = Symbol();
 
-export const provide_project_state = (ctx: Writable<Project_State>): void =>
+export const set_project_state = (ctx: Writable<Project_State>): void =>
 	setContext(context_key, ctx);
 
-export const use_project_state = (): Writable<Project_State> => getContext(context_key);
+export const get_project_state = (): Writable<Project_State> => getContext(context_key);

--- a/src/client/test_imports/test_imports.ts
+++ b/src/client/test_imports/test_imports.ts
@@ -1,7 +1,7 @@
 // test lib imports
-import {test_lib_import} from '$lib/test_lib_import.js';
-console.log('test_nested_imports test_lib_import', test_lib_import);
+import {test_absolute_lib_import} from 'src/lib/test_absolute_lib_import.js';
+console.log('test_nested_imports test_absolute_lib_import', test_absolute_lib_import);
 
 // test absolute imports
-import {test_absolute_import} from 'src/lib/test_absolute_import.js';
-console.log('test_nested_imports test_absolute_import', test_absolute_import);
+import {test_absolute_src_import} from 'src/lib/test_absolute_src_import.js';
+console.log('test_nested_imports test_absolute_src_import', test_absolute_src_import);

--- a/src/lib/test_absolute_import.ts
+++ b/src/lib/test_absolute_import.ts
@@ -1,1 +1,0 @@
-export const test_absolute_import = 'src/';

--- a/src/lib/test_absolute_lib_import.ts
+++ b/src/lib/test_absolute_lib_import.ts
@@ -1,0 +1,1 @@
+export const test_absolute_lib_import = '$lib/';

--- a/src/lib/test_absolute_src_import.ts
+++ b/src/lib/test_absolute_src_import.ts
@@ -1,0 +1,1 @@
+export const test_absolute_src_import = 'src/';

--- a/src/lib/test_lib_import.ts
+++ b/src/lib/test_lib_import.ts
@@ -1,1 +1,0 @@
-export const test_lib_import = '$lib/';


### PR DESCRIPTION
Fixes an issue with CSS in Gro's deprecated-ish frontend builds. It was relying on the Filer's `served_dirs` to include Svelte CSS, but that's weird and broken when we build without serving, so it's now hardcoded to look for Svelte CSS as a sibling to the JS. We may want more flexibility in the future but I see no issue with this for now, and a more complete fix will probably be generic.