### PR TITLE
fix build config validation and normalization

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
   ([#153](https://github.com/feltcoop/gro/pull/153))
 - infer `npm link` in Node library adapter
   ([#218](https://github.com/feltcoop/gro/pull/218))
+- fix build config validation and normalization
+  ([#220](https://github.com/feltcoop/gro/pull/220))
 
 ## 0.27.0
 

--- a/src/build/build_config.test.ts
+++ b/src/build/build_config.test.ts
@@ -174,13 +174,12 @@ test_normalize_build_configs.run();
 const test_validate_build_configs = suite('validate_build_configs');
 
 test_validate_build_configs('basic behavior', async () => {
-	t.ok((await validate_build_configs(fs, normalize_build_configs([], true), true)).ok);
+	t.ok((await validate_build_configs(fs, normalize_build_configs([], true))).ok);
 	t.ok(
 		(
 			await validate_build_configs(
 				fs,
 				normalize_build_configs([{name: 'node', platform: 'node', input}], true),
-				true,
 			)
 		).ok,
 	);
@@ -197,7 +196,6 @@ test_validate_build_configs('basic behavior', async () => {
 					],
 					true,
 				),
-				true,
 			)
 		).ok,
 	);
@@ -215,7 +213,6 @@ test_validate_build_configs('basic behavior', async () => {
 					],
 					true,
 				),
-				true,
 			)
 		).ok,
 	);
@@ -227,17 +224,14 @@ test_validate_build_configs('fails with input path that does not exist', async (
 			await validate_build_configs(
 				fs,
 				normalize_build_configs([{name: 'node', platform: 'node', input: 'no_such_file.ts'}], true),
-				true,
 			)
 		).ok,
 	);
 });
 
 test_validate_build_configs('fails with undefined', async () => {
-	t.not.ok((await validate_build_configs(fs, undefined as any, true)).ok);
-	t.not.ok(
-		(await validate_build_configs(fs, {name: 'node', platform: 'node', input} as any, true)).ok,
-	);
+	t.not.ok((await validate_build_configs(fs, undefined as any)).ok);
+	t.not.ok((await validate_build_configs(fs, {name: 'node', platform: 'node', input} as any)).ok);
 });
 
 test_validate_build_configs('fails with an invalid name', async () => {
@@ -246,7 +240,6 @@ test_validate_build_configs('fails with an invalid name', async () => {
 			await validate_build_configs(
 				fs,
 				normalize_build_configs([{platform: 'node', input} as any], true),
-				true,
 			)
 		).ok,
 	);
@@ -255,7 +248,6 @@ test_validate_build_configs('fails with an invalid name', async () => {
 			await validate_build_configs(
 				fs,
 				normalize_build_configs([{name: '', platform: 'node', input}], true),
-				true,
 			)
 		).ok,
 	);
@@ -273,7 +265,6 @@ test_validate_build_configs('fails with duplicate names', async () => {
 					],
 					true,
 				),
-				true,
 			)
 		).ok,
 	);
@@ -288,7 +279,6 @@ test_validate_build_configs('fails with duplicate names', async () => {
 					],
 					true,
 				),
-				true,
 			)
 		).ok,
 	);
@@ -300,7 +290,6 @@ test_validate_build_configs('fails with a system build in production mode', asyn
 			await validate_build_configs(
 				fs,
 				normalize_build_configs([{name: 'system', platform: 'node', input}], false),
-				true,
 			)
 		).ok,
 	);
@@ -312,7 +301,6 @@ test_validate_build_configs('fails with an invalid platform', async () => {
 			await validate_build_configs(
 				fs,
 				normalize_build_configs([{name: 'node', input} as any], true),
-				true,
 			)
 		).ok,
 	);
@@ -321,7 +309,6 @@ test_validate_build_configs('fails with an invalid platform', async () => {
 			await validate_build_configs(
 				fs,
 				normalize_build_configs([{name: 'node', platform: 'deno', input} as any], true),
-				true,
 			)
 		).ok,
 	);

--- a/src/build/build_config.ts
+++ b/src/build/build_config.ts
@@ -84,7 +84,6 @@ const normalize_build_config_input = (
 export const validate_build_configs = async (
 	fs: Filesystem,
 	build_configs: Build_Config[],
-	dev: boolean,
 ): Promise<Result<{}, {reason: string}>> => {
 	if (!Array.isArray(build_configs)) {
 		return {
@@ -99,15 +98,6 @@ export const validate_build_configs = async (
 			reason:
 				`The field 'gro.builds' in package.json has` +
 				` a 'node' config with reserved name '${CONFIG_BUILD_NAME}'`,
-		};
-	}
-	const system_build_config = build_configs.find((c) => c.name === SYSTEM_BUILD_NAME);
-	if (dev && !system_build_config) {
-		return {
-			ok: false,
-			reason:
-				`The field 'gro.builds' in package.json must have` +
-				` a 'node' config named '${SYSTEM_BUILD_NAME}'`,
 		};
 	}
 	const names: Set<Build_Name> = new Set();

--- a/src/build/build_config.ts
+++ b/src/build/build_config.ts
@@ -53,12 +53,7 @@ export const normalize_build_configs = (
 	const build_configs: Build_Config[] = [];
 	let should_add_system_build_config = dev; // add system build only for dev, not prod
 	for (const partial of partials) {
-		if (
-			!partial ||
-			(!dev && (partial.name === SYSTEM_BUILD_NAME || partial.name === CONFIG_BUILD_NAME))
-		) {
-			continue;
-		}
+		if (!partial) continue;
 		const build_config: Build_Config = {
 			name: partial.name,
 			platform: partial.platform,
@@ -84,6 +79,7 @@ const normalize_build_config_input = (
 export const validate_build_configs = async (
 	fs: Filesystem,
 	build_configs: Build_Config[],
+	dev: boolean,
 ): Promise<Result<{}, {reason: string}>> => {
 	if (!Array.isArray(build_configs)) {
 		return {
@@ -98,6 +94,16 @@ export const validate_build_configs = async (
 			reason:
 				`The field 'gro.builds' in package.json has` +
 				` a 'node' config with reserved name '${CONFIG_BUILD_NAME}'`,
+		};
+	}
+	const system_build_config = build_configs.find((c) => c.name === SYSTEM_BUILD_NAME);
+	if (!dev && system_build_config) {
+		return {
+			ok: false,
+			reason:
+				`The field 'gro.builds' in package.json has` +
+				` a 'node' config named '${SYSTEM_BUILD_NAME}'` +
+				' for production but it is valid only in development',
 		};
 	}
 	const names: Set<Build_Name> = new Set();

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -191,7 +191,7 @@ export const to_config = async (
 
 	const config = normalize_config(extended_config, options.dev);
 
-	const validate_result = await validate_config(options.fs, config);
+	const validate_result = await validate_config(options.fs, config, options.dev);
 	if (!validate_result.ok) {
 		throw Error(`Invalid Gro config at '${path}': ${validate_result.reason}`);
 	}
@@ -226,8 +226,9 @@ const validate_config_module = (config_module: any): Result<{}, {reason: string}
 const validate_config = async (
 	fs: Filesystem,
 	config: Gro_Config,
+	dev: boolean,
 ): Promise<Result<{}, {reason: string}>> => {
-	const build_configs_result = await validate_build_configs(fs, config.builds);
+	const build_configs_result = await validate_build_configs(fs, config.builds, dev);
 	if (!build_configs_result.ok) return build_configs_result;
 	return {ok: true};
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -252,7 +252,7 @@ const normalize_config = (config: Gro_Config_Partial, dev: boolean): Gro_Config 
 				? config.publish
 				: to_default_publish_dirs(build_configs),
 		target: config.target || DEFAULT_ECMA_SCRIPT_TARGET,
-		system_build_config: build_configs.find((b) => b.name === SYSTEM_BUILD_NAME)!,
+		system_build_config: build_configs.find((b) => b.name === SYSTEM_BUILD_NAME),
 		// TODO instead of `primary` build configs, we want to be able to mount any number of them at once,
 		// so this is a temp hack that just chooses the first browser build
 		primary_browser_build_config: build_configs.find((b) => b.platform === 'browser') || null,

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -3,7 +3,6 @@ import {ENV_LOG_LEVEL, Log_Level} from '@feltcoop/felt/util/log.js';
 import type {Gro_Config_Creator, Gro_Config_Partial} from './config.js';
 import {
 	has_node_library,
-	SYSTEM_BUILD_CONFIG,
 	NODE_LIBRARY_BUILD_CONFIG,
 	has_sveltekit_frontend,
 } from '../build/default_build_config.js';
@@ -39,7 +38,6 @@ export const config: Gro_Config_Creator = async ({fs}) => {
 	]);
 	const partial: Gro_Config_Partial = {
 		builds: [
-			SYSTEM_BUILD_CONFIG,
 			enable_node_library ? NODE_LIBRARY_BUILD_CONFIG : null,
 			// enable_api_server ? API_SERVER_BUILD_CONFIG : null,
 			// enable_gro_frontend ? toDefaultBrowserBuild() : null, // TODO configure asset paths

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -68,7 +68,7 @@ export const task: Task<Task_Args, Task_Events> = {
 			dev,
 			builder: create_default_builder(),
 			source_dirs: [paths.source],
-			served_dirs: config.serve || get_default_served_dirs(config),
+			served_dirs: config.serve || to_default_served_dirs(config),
 			build_configs: config.builds,
 			target: config.target,
 			sourcemap: config.sourcemap,
@@ -143,8 +143,10 @@ export const task: Task<Task_Args, Task_Events> = {
 	},
 };
 
-const get_default_served_dirs = (config: Gro_Config): Served_Dir_Partial[] => {
-	const build_config_to_serve = config.primary_browser_build_config ?? config.system_build_config;
+// TODO rework this when we change the deprecated frontend build process
+const to_default_served_dirs = (config: Gro_Config): Served_Dir_Partial[] | undefined => {
+	const build_config_to_serve = config.primary_browser_build_config;
+	if (!build_config_to_serve) return undefined;
 	const build_out_dir_to_serve = to_build_out_path(true, build_config_to_serve.name, '');
 	return [build_out_dir_to_serve];
 };


### PR DESCRIPTION
Fixes a bug with build config inference. The system config is now a validation error for production builds instead of being silently filtered out. Like before, users do not need to manually include one, and it's discouraged to avoid mistakes.