### PR TITLE
extract plugins class

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -250,7 +250,7 @@
 - **break**: extract the `Filesystem` interface and
   thread it everywhere from `src/cli/invoke.ts` and tests
   ([#171](https://github.com/feltcoop/gro/pull/171))
-- **break**: replace `src/utils/gitignore.ts` helper `isGitignored`
+- **break**: replace `src/utils/gitignore.ts` helper `is_gitignored`
   with `src/fs/path_filter.ts` helper `to_path_filter`
   ([#172](https://github.com/feltcoop/gro/pull/172))
 
@@ -287,7 +287,7 @@
   ([#164](https://github.com/feltcoop/gro/pull/164))
 - make serve task work for production SvelteKit builds
   ([#163](https://github.com/feltcoop/gro/pull/163))
-- add `src/utils/gitignore.ts` with `isGitignored` and `load_gitignore_filter`
+- add `src/utils/gitignore.ts` with `is_gitignored` and `load_gitignore_filter`
   ([#165](https://github.com/feltcoop/gro/pull/165))
 - add helper `to_sveltekit_base_path` to `src/build/sveltekit_helpers.ts`
   ([#163](https://github.com/feltcoop/gro/pull/163))

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -49,24 +49,26 @@ export class Plugins {
 	}
 
 	async setup(): Promise<void> {
-		const {timings} = this.ctx;
+		const {ctx} = this;
+		const {timings} = ctx;
 		const timing_to_setup = timings.start('plugins.setup');
 		for (const plugin of this.instances) {
 			if (!plugin.setup) continue;
 			const timing = timings.start(`setup:${plugin.name}`);
-			await plugin.setup(this.ctx);
+			await plugin.setup(ctx);
 			timing();
 		}
 		timing_to_setup();
 	}
 
 	async teardown(): Promise<void> {
-		const {timings} = this.ctx;
+		const {ctx} = this;
+		const {timings} = ctx;
 		const timing_to_teardown = timings.start('plugins.teardown');
 		for (const plugin of this.instances) {
 			if (!plugin.teardown) continue;
 			const timing = timings.start(`teardown:${plugin.name}`);
-			await plugin.teardown(this.ctx);
+			await plugin.teardown(ctx);
 			timing();
 		}
 		timing_to_teardown();

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -32,7 +32,10 @@ export interface Plugin_Context<T_Args = any, T_Events = any>
 }
 
 export class Plugins {
-	constructor(public readonly ctx: Plugin_Context, public readonly instances: readonly Plugin[]) {}
+	constructor(
+		private readonly ctx: Plugin_Context,
+		private readonly instances: readonly Plugin[],
+	) {}
 
 	static async create(ctx: Plugin_Context): Promise<Plugins> {
 		const {timings} = ctx;

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -36,36 +36,36 @@ export class Plugins {
 
 	static async create(ctx: Plugin_Context): Promise<Plugins> {
 		const {timings} = ctx;
-		const timing_to_create_plugins = timings.start('plugins.create');
+		const timing_to_create = timings.start('plugins.create');
 		const instances: Plugin<any, any>[] = to_array(await ctx.config.plugin(ctx)).filter(
 			Boolean,
 		) as Plugin<any, any>[];
 		const plugins = new Plugins(ctx, instances);
-		timing_to_create_plugins();
+		timing_to_create();
 		return plugins;
 	}
 
 	async setup(): Promise<void> {
 		const {timings} = this.ctx;
-		const timing_to_call_plugin_setup = timings.start('plugins.setup');
+		const timing_to_setup = timings.start('plugins.setup');
 		for (const plugin of this.instances) {
 			if (!plugin.setup) continue;
 			const timing = timings.start(`setup:${plugin.name}`);
 			await plugin.setup(this.ctx);
 			timing();
 		}
-		timing_to_call_plugin_setup();
+		timing_to_setup();
 	}
 
 	async teardown(): Promise<void> {
 		const {timings} = this.ctx;
-		const timing_to_call_plugin_teardown = timings.start('plugins.teardown');
+		const timing_to_teardown = timings.start('plugins.teardown');
 		for (const plugin of this.instances) {
 			if (!plugin.teardown) continue;
 			const timing = timings.start(`teardown:${plugin.name}`);
 			await plugin.teardown(this.ctx);
 			timing();
 		}
-		timing_to_call_plugin_teardown();
+		timing_to_teardown();
 	}
 }

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1,3 +1,6 @@
+import {to_array} from '@feltcoop/felt/util/array.js';
+import type {Timings} from '@feltcoop/felt/util/time.js';
+
 import type {Task_Context} from '../task/task.js';
 import type {Gro_Config} from '../config/config.js';
 import type {Filer} from 'src/build/Filer.js';
@@ -25,4 +28,44 @@ export interface Plugin_Context<T_Args = any, T_Events = any>
 	extends Task_Context<T_Args, T_Events> {
 	config: Gro_Config;
 	filer: Filer | null;
+	timings: Timings;
+}
+
+export class Plugins {
+	constructor(public readonly ctx: Plugin_Context, public readonly instances: Plugin[]) {}
+
+	static async create(ctx: Plugin_Context): Promise<Plugins> {
+		const {timings} = ctx;
+		const timing_to_create_plugins = timings.start('plugins.create');
+		const instances: Plugin<any, any>[] = to_array(await ctx.config.plugin(ctx)).filter(
+			Boolean,
+		) as Plugin<any, any>[];
+		const plugins = new Plugins(ctx, instances);
+		timing_to_create_plugins();
+		return plugins;
+	}
+
+	async setup(): Promise<void> {
+		const {timings} = this.ctx;
+		const timing_to_call_plugin_setup = timings.start('plugins.setup');
+		for (const plugin of this.instances) {
+			if (!plugin.setup) continue;
+			const timing = timings.start(`setup:${plugin.name}`);
+			await plugin.setup(this.ctx);
+			timing();
+		}
+		timing_to_call_plugin_setup();
+	}
+
+	async teardown(): Promise<void> {
+		const {timings} = this.ctx;
+		const timing_to_call_plugin_teardown = timings.start('plugins.teardown');
+		for (const plugin of this.instances) {
+			if (!plugin.teardown) continue;
+			const timing = timings.start(`teardown:${plugin.name}`);
+			await plugin.teardown(this.ctx);
+			timing();
+		}
+		timing_to_call_plugin_teardown();
+	}
 }

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -32,7 +32,7 @@ export interface Plugin_Context<T_Args = any, T_Events = any>
 }
 
 export class Plugins {
-	constructor(public readonly ctx: Plugin_Context, public readonly instances: Plugin[]) {}
+	constructor(public readonly ctx: Plugin_Context, public readonly instances: readonly Plugin[]) {}
 
 	static async create(ctx: Plugin_Context): Promise<Plugins> {
 		const {timings} = ctx;

--- a/src/utils/gitignore.test.ts
+++ b/src/utils/gitignore.test.ts
@@ -21,7 +21,7 @@ test_load_gitignore_filter('basic behavior', () => {
 	t.ok(!filter(resolve('a/node_module/b')));
 });
 
-test_load_gitignore_filter('caching and forceRefresh', () => {
+test_load_gitignore_filter('caching and force_refresh', () => {
 	const filter1 = load_gitignore_filter();
 	const filter2 = load_gitignore_filter();
 	t.is(filter1, filter2);

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -28,8 +28,8 @@ const DEFAULT_IGNORED_PATHS = [
 ];
 
 // TODO need some mapping to match gitignore behavior correctly with nested directories
-export const load_gitignore_filter = (forceRefresh = false): File_Filter => {
-	if (forceRefresh) filter = null;
+export const load_gitignore_filter = (force_refresh = false): File_Filter => {
+	if (force_refresh) filter = null;
 	if (filter) return filter;
 	let lines: string[];
 	try {
@@ -42,28 +42,28 @@ export const load_gitignore_filter = (forceRefresh = false): File_Filter => {
 	} catch (err) {
 		lines = DEFAULT_IGNORED_PATHS;
 	}
-	filter = createFilter(lines.map((line) => toPattern(line)));
+	filter = createFilter(lines.map((line) => to_pattern(line)));
 	return filter;
 };
 
-export const isGitignored = (path: string, root = process.cwd(), forceRefresh?: boolean) =>
-	load_gitignore_filter(forceRefresh)(join(root, path));
+export const is_gitignored = (path: string, root = process.cwd(), force_refresh?: boolean) =>
+	load_gitignore_filter(force_refresh)(join(root, path));
 
 // TODO What's the better way to do this?
 // This is a quick hacky mapping for one use case between
 // `.gitignore` and picomatch: https://github.com/micromatch/picomatch
 // This code definitely fails for valid patterns!
-const toPattern = (line: string): string => {
-	const firstChar = line[0];
-	if (firstChar === '/') {
+const to_pattern = (line: string): string => {
+	const first_char = line[0];
+	if (first_char === '/') {
 		line = line.substring(1);
-	} else if (firstChar !== '*') {
+	} else if (first_char !== '*') {
 		line = `**/${line}`;
 	}
-	const lastChar = line[line.length - 1];
-	if (lastChar === '/') {
+	const last_char = line[line.length - 1];
+	if (last_char === '/') {
 		line = `${line}**`;
-	} else if (lastChar !== '*') {
+	} else if (last_char !== '*') {
 		line = `${line}/**`;
 	}
 	return line;


### PR DESCRIPTION
Refactors the usage of `Plugin` to a common manager class with structured methods for creation/setup/teardown, removing the copypasta between `gro dev` and `gro build`.