### PR TITLE
fix library adapter types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,9 +5,12 @@
 - **break**: remove `gro start` task
   ([#223](https://github.com/feltcoop/gro/pull/223))
 - add `Plugin`s and `config.plugin` to support SvelteKit and API servers
-  ([#223](https://github.com/feltcoop/gro/pull/223))
+  ([#223](https://github.com/feltcoop/gro/pull/223),
+  [#224](https://github.com/feltcoop/gro/pull/224))
 - implement API server config and adapter
   ([#223](https://github.com/feltcoop/gro/pull/223))
+- implement library adapter
+  ([#226](https://github.com/feltcoop/gro/pull/226))
 
 ## 0.27.3
 

--- a/src/adapt/utils.ts
+++ b/src/adapt/utils.ts
@@ -1,6 +1,6 @@
 import {relative, dirname} from 'path';
 import type {Logger} from '@feltcoop/felt/util/log.js';
-import {strip_end, strip_start} from '@feltcoop/felt/util/string.js';
+import {strip_end} from '@feltcoop/felt/util/string.js';
 
 import type {Build_Config} from '../build/build_config.js';
 import type {Filesystem} from '../fs/filesystem.js';
@@ -14,12 +14,7 @@ import {
 	print_path,
 	SOURCE_DIRNAME,
 	paths,
-	TS_TYPE_EXTENSION,
-	to_types_build_dir,
 } from '../paths.js';
-
-// TODO this has a huge hack to copy all types over to the dist because
-// we're not including `import type` imports as dependencies yet
 
 export const copy_dist = async (
 	fs: Filesystem,
@@ -33,7 +28,6 @@ export const copy_dist = async (
 	const build_out_dir = to_build_out_path(dev, build_config.name);
 	const externals_dir = to_build_out_path(dev, build_config.name, EXTERNALS_BUILD_DIRNAME);
 	log.info(`copying ${print_path(build_out_dir)} to ${print_path(dist_out_dir)}`);
-	const copied_type_files: Set<string> = new Set(); // TODO HACK -- see above, delete this
 	const typemap_files: string[] = [];
 	await fs.copy(build_out_dir, dist_out_dir, {
 		filter: async (id) => {
@@ -41,10 +35,6 @@ export const copy_dist = async (
 			const stats = await fs.stat(id);
 			if (filter && !filter(id, stats)) return false;
 			if (stats.isDirectory()) return true;
-			// TODO HACK -- see above, delete this
-			if (id.endsWith(TS_TYPE_EXTENSION) || id.endsWith(TS_TYPEMAP_EXTENSION)) {
-				copied_type_files.add(id);
-			}
 			// typemaps are edited before copying, see below
 			if (id.endsWith(TS_TYPEMAP_EXTENSION)) {
 				typemap_files.push(id);
@@ -54,45 +44,11 @@ export const copy_dist = async (
 		},
 	});
 
-	// TODO HACK -- see above, delete this
-	const hack_typemap_files: string[] = [];
-	if (copied_type_files.size) {
-		await fs.copy(to_types_build_dir(), dist_out_dir, {
-			filter: async (id) => {
-				const stats = await fs.stat(id);
-				if (filter && !filter(id, stats)) return false;
-				if (stats.isDirectory()) return true;
-				const should_copy = !copied_type_files.has(id);
-				if (should_copy && id.endsWith(TS_TYPEMAP_EXTENSION)) {
-					hack_typemap_files.push(id);
-					return false;
-				}
-				return should_copy;
-			},
-		});
-	}
-
 	// typemap files (.d.ts.map) need their `sources` property mapped back to the source directory
 	// based on the relative change from the build to the dist
 	await Promise.all(
 		typemap_files.map(async (id) => {
 			const base_path = to_build_base_path(id);
-			const source_base_path = `${strip_end(base_path, TS_TYPEMAP_EXTENSION)}${TS_EXTENSION}`;
-			const dist_source_id = pack
-				? `${dist_out_dir}/${SOURCE_DIRNAME}/${source_base_path}`
-				: `${paths.source}${source_base_path}`;
-			const dist_out_path = `${dist_out_dir}/${base_path}`;
-			const typemap_source_path = relative(dirname(dist_out_path), dist_source_id);
-			const typemap = JSON.parse(await fs.read_file(id, 'utf8'));
-			typemap.sources[0] = typemap_source_path; // haven't seen any exceptions that would break this
-			return fs.write_file(dist_out_path, JSON.stringify(typemap));
-		}),
-	);
-
-	// TODO HACK -- see above, delete this
-	await Promise.all(
-		hack_typemap_files.map(async (id) => {
-			const base_path = strip_start(id, to_types_build_dir()).substring(1);
 			const source_base_path = `${strip_end(base_path, TS_TYPEMAP_EXTENSION)}${TS_EXTENSION}`;
 			const dist_source_id = pack
 				? `${dist_out_dir}/${SOURCE_DIRNAME}/${source_base_path}`

--- a/src/build/default_build_config.ts
+++ b/src/build/default_build_config.ts
@@ -29,8 +29,8 @@ export const SYSTEM_BUILD_CONFIG: Build_Config = {
 
 const NODE_LIBRARY_PATH = 'lib/index.ts';
 const NODE_LIBRARY_SOURCE_ID = base_path_to_source_id(NODE_LIBRARY_PATH);
-export const has_node_library = async (fs: Filesystem): Promise<boolean> =>
-	await fs.exists(NODE_LIBRARY_SOURCE_ID);
+export const has_node_library = (fs: Filesystem): Promise<boolean> =>
+	fs.exists(NODE_LIBRARY_SOURCE_ID);
 export const NODE_LIBRARY_BUILD_NAME: Build_Name = 'library';
 export const NODE_LIBRARY_BUILD_CONFIG: Build_Config = {
 	name: NODE_LIBRARY_BUILD_NAME,

--- a/src/build/default_build_config.ts
+++ b/src/build/default_build_config.ts
@@ -27,11 +27,10 @@ export const SYSTEM_BUILD_CONFIG: Build_Config = {
 	input: [createFilter(['**/*.{task,test,gen,gen.*}.ts', '**/fixtures/**'])],
 };
 
-const NODE_LIBRARY_PATH = 'index.ts';
-const NODE_LIBRARY_SOURCE_ID = base_path_to_source_id('index.ts');
-const NODE_LIBRARY_EXCLUDE_SOURCE_ID = base_path_to_source_id('index.html');
+const NODE_LIBRARY_PATH = 'lib/index.ts';
+const NODE_LIBRARY_SOURCE_ID = base_path_to_source_id(NODE_LIBRARY_PATH);
 export const has_node_library = async (fs: Filesystem): Promise<boolean> =>
-	(await fs.exists(NODE_LIBRARY_SOURCE_ID)) && !(await fs.exists(NODE_LIBRARY_EXCLUDE_SOURCE_ID));
+	await fs.exists(NODE_LIBRARY_SOURCE_ID);
 export const NODE_LIBRARY_BUILD_NAME: Build_Name = 'library';
 export const NODE_LIBRARY_BUILD_CONFIG: Build_Config = {
 	name: NODE_LIBRARY_BUILD_NAME,

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -21,7 +21,7 @@ import {
 	MODULE_PATH_LIB_PREFIX,
 	MODULE_PATH_SRC_PREFIX,
 } from '../utils/module.js';
-import {EXTERNALS_SOURCE_ID, is_external_build_id} from './externals_build_helpers.js';
+import {EXTERNALS_SOURCE_ID} from './externals_build_helpers.js';
 import type {Build_Dependency} from './build_dependency.js';
 
 // TODO this is all hacky and should be refactored, probably following Rollup's lead
@@ -44,7 +44,7 @@ export const postprocess = (
 
 		// returns `mapped_specifier`, not because it makes a ton of sense,
 		// but it's the only value needed, because this function populates `dependencies_by_build_id`
-		const handle_specifier = (specifier: string, is_type_import: boolean): string => {
+		const handle_specifier = (specifier: string, _is_type_import: boolean): string => {
 			let build_id: string;
 			let final_specifier = specifier; // this is the raw specifier, but pre-mapped for common externals
 			const is_external_import = is_external_module(specifier);
@@ -100,9 +100,11 @@ export const postprocess = (
 					final_specifier = relative(source.dir, paths.source + final_specifier.substring(3));
 				}
 				build_id = join(build.dir, mapped_specifier);
-				// TODO hmm shouldn't this be the correct thing? there must be a hack for types elsewhere?
 				// if (is_type_import) {
 				// 	build_id = replace_extension(build_id, TS_TYPE_EXTENSION);
+				// 	// TODO i think this needs to do TYPEMAP as well,
+				// 	// AND we need to remove the hack that includes them automatically (see `types` usage)
+				// 	// so we probably add to the `dependencies_by_build_id` 3x below
 				// }
 			}
 			if (dependencies_by_build_id === null) dependencies_by_build_id = new Map();
@@ -111,12 +113,14 @@ export const postprocess = (
 					specifier: final_specifier,
 					mapped_specifier,
 					build_id,
-					external: is_external_build_id(build_id, build_config, ctx),
+					// TODO can't we use the `is_external` check above instead of calling this?
+					external: browser && is_external,
+					// external: is_external_build_id(build_id, build_config, ctx),
 					// TODO what if this had `original_specifier` and `is_external_import` too?
 				});
-				if (is_type_import) {
-					console.log('specifier to build_id', source.id, specifier, build_id);
-				}
+				// if (is_type_import) {
+				// 	console.log('specifier to build_id', source.id, specifier, build_id);
+				// }
 			}
 			return mapped_specifier;
 		};

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -19,10 +19,10 @@ It looks at the project and tries to do the right thing:
 	assumes a SvelteKit frontend
 - if `src/lib/index.ts`,
 	assumes a Node library
-- if `src/index.html` and `src/index.ts`,
-	assumes Gro's deprecated SPA mode - https://github.com/feltcoop/gro/issues/106
 - if `src/server/server.ts`,
 	assumes a Node API server
+- if `src/index.html` and `src/index.ts`,
+	assumes Gro's deprecated SPA mode - https://github.com/feltcoop/gro/issues/106
 
 */
 

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -17,10 +17,10 @@ It looks at the project and tries to do the right thing:
 
 - if `src/routes` and `src/app.html`,
 	assumes a SvelteKit frontend
+- if `src/lib/index.ts`,
+	assumes a Node library
 - if `src/index.html` and `src/index.ts`,
 	assumes Gro's deprecated SPA mode - https://github.com/feltcoop/gro/issues/106
-- if `src/index.ts` and not `src/index.html`,
-	assumes a Node library
 - if `src/server/server.ts`,
 	assumes a Node API server
 

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -142,6 +142,8 @@ const test_to_source_extension = suite('to_source_extension');
 test_to_source_extension('basic behavior', () => {
 	t.is(to_source_extension('foo/bar.js'), 'foo/bar.ts');
 	t.is(to_source_extension('foo/bar.js.map'), 'foo/bar.ts');
+	t.is(to_source_extension('foo/bar.d.ts'), 'foo/bar.ts');
+	t.is(to_source_extension('foo/bar.d.ts.map'), 'foo/bar.ts');
 	t.is(to_source_extension('foo/bar.svelte.js'), 'foo/bar.svelte');
 	t.is(to_source_extension('foo/bar.svelte.js.map'), 'foo/bar.svelte');
 	t.is(to_source_extension('foo/bar.svelte.css'), 'foo/bar.svelte');

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -206,6 +206,9 @@ export const to_source_extension = (build_id: string): string => {
 		case SVELTE_CSS_SOURCEMAP_EXTENSION: {
 			return build_id.substring(0, len - extension2!.length);
 		}
+		case TS_TYPEMAP_EXTENSION: {
+			return build_id.substring(0, len - extension3.length) + TS_EXTENSION;
+		}
 		// case undefined:
 		// default:
 		// 	return build_id;
@@ -216,7 +219,8 @@ export const to_source_extension = (build_id: string): string => {
 		case SVELTE_CSS_BUILD_EXTENSION: {
 			return build_id.substring(0, len - extension1!.length);
 		}
-		case JS_SOURCEMAP_EXTENSION: {
+		case JS_SOURCEMAP_EXTENSION:
+		case TS_TYPE_EXTENSION: {
 			return build_id.substring(0, len - extension2.length) + TS_EXTENSION;
 		}
 		// case undefined:

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -49,10 +49,11 @@ export class Plugins {
 	}
 
 	async setup(): Promise<void> {
-		const {ctx} = this;
+		const {ctx, instances} = this;
+		if (!this.instances.length) return;
 		const {timings} = ctx;
 		const timing_to_setup = timings.start('plugins.setup');
-		for (const plugin of this.instances) {
+		for (const plugin of instances) {
 			if (!plugin.setup) continue;
 			const timing = timings.start(`setup:${plugin.name}`);
 			await plugin.setup(ctx);
@@ -62,10 +63,11 @@ export class Plugins {
 	}
 
 	async teardown(): Promise<void> {
-		const {ctx} = this;
+		const {ctx, instances} = this;
+		if (!this.instances.length) return;
 		const {timings} = ctx;
 		const timing_to_teardown = timings.start('plugins.teardown');
-		for (const plugin of this.instances) {
+		for (const plugin of instances) {
 			if (!plugin.teardown) continue;
 			const timing = timings.start(`teardown:${plugin.name}`);
 			await plugin.teardown(ctx);


### PR DESCRIPTION
Fixes types in the library adapter by parsing `import type` dependencies. It's not bulletproof because it just uses a regexp, but any issues it causes could be worked around easily. (e.g. changing multiline comments to single line will break the matcher on commented-out imports)

Due to the way the internals currently work, this include imported types as dependencies, *and*, incorrectly, their accompanying `.js` files. They shouldn't cause any harm, but it's a wart I want to fix. The proper fix will require changing the efficient-but-less-powerful handling of type dependencies.