### PR TITLE
add path rebasing to library adapter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,8 @@
 - implement API server config and adapter
   ([#223](https://github.com/feltcoop/gro/pull/223))
 - implement library adapter
-  ([#226](https://github.com/feltcoop/gro/pull/226))
+  ([#226](https://github.com/feltcoop/gro/pull/226),
+  [#227](https://github.com/feltcoop/gro/pull/227))
 
 ## 0.27.3
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "changelog.md",
+    "contributing.md"
   ],
   "engines": {
     "node": ">=14.16.0"

--- a/src/adapt/gro-adapter-node-library.ts
+++ b/src/adapt/gro-adapter-node-library.ts
@@ -59,8 +59,8 @@ export const create_adapter = ({
 
 			const files = to_input_files(build_config.input);
 
-			const timing_to_bundle_with_rollup = timings.start('bundle with rollup');
 			if (type === 'bundled') {
+				const timing_to_bundle_with_rollup = timings.start('bundle with rollup');
 				if (type !== 'bundled') throw Error();
 				// TODO use `filters` to select the others..right?
 				if (!files.length) {
@@ -99,8 +99,8 @@ export const create_adapter = ({
 						map_watch_options,
 					});
 				}
+				timing_to_bundle_with_rollup();
 			}
-			timing_to_bundle_with_rollup();
 
 			const timing_to_copy_dist = timings.start('copy build to dist');
 			const filter = type === 'bundled' ? bundled_dist_filter : undefined;

--- a/src/adapt/gro-adapter-node-library.ts
+++ b/src/adapt/gro-adapter-node-library.ts
@@ -36,8 +36,15 @@ const name = '@feltcoop/gro-adapter-node-library';
 // This means all library modules must be under `src/lib` to work without additional transformation.
 const LIBRARY_DIR = 'lib/';
 // This function converts the build config's source file ids to the flattened base paths:
-const source_id_to_library_base_path = (source_id: string, library_rebase_path: string): string =>
-	strip_start(to_build_extension(source_id_to_base_path(source_id)), library_rebase_path);
+const source_id_to_library_base_path = (source_id: string, library_rebase_path: string): string => {
+	const base_path = source_id_to_base_path(source_id);
+	if (!base_path.startsWith(library_rebase_path)) {
+		throw Error(
+			`Source file does not start with library_rebase_path ${library_rebase_path}: ${base_path}`,
+		);
+	}
+	return strip_start(to_build_extension(base_path), library_rebase_path);
+};
 
 // TODO maybe add a `files` option to explicitly include source files,
 // and fall back to inferring from the build config

--- a/src/adapt/gro-adapter-node-library.ts
+++ b/src/adapt/gro-adapter-node-library.ts
@@ -218,21 +218,13 @@ const bundled_dist_filter = (id: string, stats: Path_Stats): boolean =>
 const to_possible_filenames = (paths: string[]): string[] =>
 	paths.flatMap((path) => {
 		const lower = path.toLowerCase();
-		return [lower, `${lower}.md`];
+		const upper = path.toUpperCase();
+		return [lower, `${lower}.md`, upper, `${upper}.md`];
 	});
 
-// these are the files npm includes by default; unlike npm, the only extension we support is `.md`
+// these are a subset of the files npm includes by default --
+// unlike npm, the only extension we support is `.md`
 const PACKAGE_FILES = new Set(
-	['package.json'].concat(
-		to_possible_filenames([
-			'README',
-			'CHANGES',
-			'CHANGELOG',
-			'HISTORY',
-			'LICENSE',
-			'LICENCE',
-			'NOTICE',
-		]),
-	),
+	['package.json'].concat(to_possible_filenames(['README', 'LICENSE'])),
 );
-const OTHER_PACKAGE_FILES = new Set(to_possible_filenames(['GOVERNANCE']));
+const OTHER_PACKAGE_FILES = new Set(to_possible_filenames(['CHANGELOG', 'GOVERNANCE']));

--- a/src/adapt/utils.ts
+++ b/src/adapt/utils.ts
@@ -1,6 +1,6 @@
 import {relative, dirname} from 'path';
 import type {Logger} from '@feltcoop/felt/util/log.js';
-import {strip_end} from '@feltcoop/felt/util/string.js';
+import {strip_end, strip_start} from '@feltcoop/felt/util/string.js';
 
 import type {Build_Config} from '../build/build_config.js';
 import type {Filesystem} from '../fs/filesystem.js';
@@ -24,9 +24,10 @@ export const copy_dist = async (
 	log: Logger,
 	filter?: (id: string, stats: Path_Stats) => boolean,
 	pack: boolean = true, // TODO reconsider this API, see `gro-adapter-node-library`
+	rebase_path: string = '',
 ): Promise<void> => {
-	const build_out_dir = to_build_out_path(dev, build_config.name);
-	const externals_dir = to_build_out_path(dev, build_config.name, EXTERNALS_BUILD_DIRNAME);
+	const build_out_dir = to_build_out_path(dev, build_config.name, rebase_path);
+	const externals_dir = build_out_dir + EXTERNALS_BUILD_DIRNAME;
 	log.info(`copying ${print_path(build_out_dir)} to ${print_path(dist_out_dir)}`);
 	const typemap_files: string[] = [];
 	await fs.copy(build_out_dir, dist_out_dir, {
@@ -53,7 +54,7 @@ export const copy_dist = async (
 			const dist_source_id = pack
 				? `${dist_out_dir}/${SOURCE_DIRNAME}/${source_base_path}`
 				: `${paths.source}${source_base_path}`;
-			const dist_out_path = `${dist_out_dir}/${base_path}`;
+			const dist_out_path = `${dist_out_dir}/${strip_start(base_path, rebase_path)}`;
 			const typemap_source_path = relative(dirname(dist_out_path), dist_source_id);
 			const typemap = JSON.parse(await fs.read_file(id, 'utf8'));
 			typemap.sources[0] = typemap_source_path; // haven't seen any exceptions that would break this

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -58,6 +58,7 @@ export const config: Gro_Config_Creator = async ({dev}) => {
 					// TODO temp hack - unlike most libraries, Gro ships its dist/ as a sibling to src/,
 					// and this flag opts out of the default library behavior
 					pack: false,
+					library_rebase_path: '',
 				}),
 			]),
 	};


### PR DESCRIPTION
Adds path rebasing to the library adapter, so the default SvelteKit convention prefixed with `lib/` gets flattened into the root directory. This keeps things simple, so the `exports` field of `package.json` map 1:1 to actual files, and so you can import modules in packages without any `lib/` namespacing.