### PR TITLE
add relative path prefix to bare internal specifiers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.30.1
 
 - fix conversion of absolute specifiers to include `./` if bare
-  ([#235](https://github.com/feltcoop/gro/pull/235))
+  ([#236](https://github.com/feltcoop/gro/pull/236))
 - upgrade to esbuild@0.12.15
   ([#235](https://github.com/feltcoop/gro/pull/235))
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.30.1
 
-- fix computed relative import paths to include `./` if bare
+- fix conversion of absolute specifiers to include `./` if bare
   ([#235](https://github.com/feltcoop/gro/pull/235))
 - upgrade to esbuild@0.12.15
   ([#235](https://github.com/feltcoop/gro/pull/235))

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.30.1
 
+- fix computed relative import paths to include `./` if bare
+  ([#235](https://github.com/feltcoop/gro/pull/235))
 - upgrade to esbuild@0.12.15
   ([#235](https://github.com/feltcoop/gro/pull/235))
 

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -97,6 +97,8 @@ export const postprocess = (
 					mapped_specifier = relative(source.dir, paths.source + mapped_specifier.substring(3));
 					final_specifier = relative(source.dir, paths.source + final_specifier.substring(3));
 				}
+				if (mapped_specifier[0] !== '.') mapped_specifier = './' + mapped_specifier;
+				if (final_specifier[0] !== '.') final_specifier = './' + final_specifier;
 				build_id = join(build.dir, mapped_specifier);
 			}
 			if (dependencies_by_build_id === null) dependencies_by_build_id = new Map();


### PR DESCRIPTION
Fixes imports from absolute paths pointing to modules inside the current directory, adding the `./` prefix as required by ESM.