### PR TITLE
fix import parsing to ignore non-literal dynamic imports

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.30.2
+
+- fix import parsing to ignore non-literal dynamic imports
+  ([#237](https://github.com/feltcoop/gro/pull/237))
+
 ## 0.30.1
 
 - fix conversion of absolute specifiers to include `./` if bare

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -111,9 +111,18 @@ export const postprocess = (
 			let index = 0;
 			// TODO what should we pass as the second arg to parse? the id? nothing? `lexer.parse(code, id);`
 			const [imports] = lexer.parse(content);
+			let start: number;
+			let end: number;
 			for (const {s, e, d} of imports) {
-				const start = d > -1 ? s + 1 : s;
-				const end = d > -1 ? e - 1 : e;
+				if (d > -1) {
+					const first_char = content[s];
+					if (first_char !== `'` && first_char !== '"') continue; // ignore non-literals
+					start = s + 1;
+					end = e - 1;
+				} else {
+					start = s;
+					end = e;
+				}
 				const specifier = content.substring(start, end);
 				if (specifier === 'import.meta') continue;
 				const mapped_specifier = handle_specifier(specifier);


### PR DESCRIPTION
Without this change Gro would try to parse `import(abc)`, where `abc` is a variable and not a string literal, as the module `b`. (because it blindly trimmed the first and last characters that were expected to be quotes) This makes it ignore non-literal dynamic imports.