### PR TITLE
fix dynamic import parsing to allow non-interpolated template string literals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.30.3
+
+- fix import parsing to allow non-interpolated template string literals
+  ([#238](https://github.com/feltcoop/gro/pull/238))
+
 ## 0.30.2
 
 - fix import parsing to ignore non-literal dynamic imports

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.30.3
 
-- fix import parsing to allow non-interpolated template string literals
+- fix dynamic import parsing to allow non-interpolated template string literals
   ([#238](https://github.com/feltcoop/gro/pull/238))
 
 ## 0.30.2


### PR DESCRIPTION
Without this, dynamic imports with valid string literals using backticks were ignored. Now it only ignores them if they include string interpolation with `${`.