### PR TITLE
support uncompiled svelte in production builds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 - **break**: change `gro_adapter_node_library` option `type` to boolean `bundle`
   ([#239](https://github.com/feltcoop/gro/pull/239))
-- output Svelte source files in production builds instead of compiling
+- support outputting Svelte source files in production builds
   ([#239](https://github.com/feltcoop/gro/pull/239))
 
 ## 0.30.3

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 - **break**: change `gro_adapter_node_library` option `type` to boolean `bundle`
   ([#239](https://github.com/feltcoop/gro/pull/239))
-- output Svelte source files in production library builds instead of compiling
+- output Svelte source files in production builds instead of compiling
   ([#239](https://github.com/feltcoop/gro/pull/239))
 
 ## 0.30.3

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # changelog
 
+## 0.31.0
+
+- **break**: change `gro_adapter_node_library` option `type` to boolean `bundle`
+  ([#239](https://github.com/feltcoop/gro/pull/239))
+- output Svelte source files in production library builds instead of compiling
+  ([#239](https://github.com/feltcoop/gro/pull/239))
+
 ## 0.30.3
 
 - fix dynamic import parsing to allow non-interpolated template string literals

--- a/src/build/build_dependency.test.ts
+++ b/src/build/build_dependency.test.ts
@@ -13,7 +13,8 @@ test_serialize_build_dependency(
 		const dependency: Build_Dependency = {
 			specifier: 'a',
 			mapped_specifier: 'b',
-			build_id: 'c',
+			original_specifier: 'c',
+			build_id: 'd',
 			external: true,
 		};
 		t.equal(serialize_build_dependency(dependency), dependency);
@@ -25,6 +26,7 @@ test_serialize_build_dependency('optimizes when serializing', () => {
 	const dependency: Build_Dependency = {
 		specifier: 'a',
 		mapped_specifier: 'a',
+		original_specifier: 'a',
 		build_id: 'a',
 		external: false,
 	};

--- a/src/build/build_dependency.ts
+++ b/src/build/build_dependency.ts
@@ -1,6 +1,7 @@
 export interface Build_Dependency {
 	readonly specifier: string;
 	readonly mapped_specifier: string;
+	readonly original_specifier: string;
 	readonly build_id: string;
 	readonly external: boolean;
 }
@@ -10,6 +11,7 @@ export interface Build_Dependency {
 export interface Serialized_Build_Dependency {
 	readonly specifier: string;
 	mapped_specifier?: string; // `undefined` implies same as `specifier`
+	original_specifier?: string; // `undefined` implies same as `specifier`
 	build_id?: string; // `undefined` implies same as `specifier`
 	external?: boolean; // `undefined` implies `false`
 }
@@ -17,11 +19,13 @@ export interface Serialized_Build_Dependency {
 export const deserialize_build_dependency = ({
 	specifier,
 	mapped_specifier,
+	original_specifier,
 	build_id,
 	external,
 }: Serialized_Build_Dependency): Build_Dependency => ({
 	specifier,
 	mapped_specifier: mapped_specifier !== undefined ? mapped_specifier : specifier,
+	original_specifier: original_specifier !== undefined ? original_specifier : specifier,
 	build_id: build_id !== undefined ? build_id : specifier,
 	external: external !== undefined ? external : false,
 });
@@ -29,12 +33,16 @@ export const deserialize_build_dependency = ({
 export const serialize_build_dependency = ({
 	specifier,
 	mapped_specifier,
+	original_specifier,
 	build_id,
 	external,
 }: Build_Dependency): Serialized_Build_Dependency => {
 	const serialized: Serialized_Build_Dependency = {specifier};
 	if (mapped_specifier !== specifier) {
 		serialized.mapped_specifier = mapped_specifier;
+	}
+	if (original_specifier !== specifier) {
+		serialized.original_specifier = original_specifier;
 	}
 	if (build_id !== specifier) {
 		serialized.build_id = build_id;

--- a/src/build/build_file.ts
+++ b/src/build/build_file.ts
@@ -32,14 +32,14 @@ export interface Base_Build_File extends Base_Filer_File {
 	readonly dependencies_by_build_id: Map<string, Build_Dependency> | null;
 }
 
-export const create_build_file = (
+export const create_build_file = async (
 	build: Build,
 	ctx: Build_Context,
 	result: Build_Result<Build>,
 	source_file: Buildable_Source_File,
 	build_config: Build_Config,
-): Build_File => {
-	const {content, dependencies_by_build_id} = postprocess(build, ctx, result, source_file);
+): Promise<Build_File> => {
+	const {content, dependencies_by_build_id} = await postprocess(build, ctx, result, source_file);
 	switch (build.encoding) {
 		case 'utf8':
 			return {

--- a/src/build/default_build_config.ts
+++ b/src/build/default_build_config.ts
@@ -39,7 +39,7 @@ export const NODE_LIBRARY_BUILD_CONFIG: Build_Config = {
 };
 
 export const API_SERVER_SOURCE_BASE_PATH = 'lib/server/server.ts';
-export const API_SERVER_BUILD_BASE_PATH = to_build_extension(API_SERVER_SOURCE_BASE_PATH); // 'lib/server/server.js'
+export const API_SERVER_BUILD_BASE_PATH = to_build_extension(API_SERVER_SOURCE_BASE_PATH, false); // 'lib/server/server.js'
 export const API_SERVER_SOURCE_ID = base_path_to_source_id(API_SERVER_SOURCE_BASE_PATH); // '/home/to/your/src/lib/server/server.ts'
 export const has_api_server = (fs: Filesystem): Promise<boolean> => fs.exists(API_SERVER_SOURCE_ID);
 export const API_SERVER_BUILD_NAME: Build_Name = 'server';

--- a/src/build/esbuild_build_helpers.ts
+++ b/src/build/esbuild_build_helpers.ts
@@ -10,7 +10,7 @@ export interface Esbuild_Transform_Options extends esbuild.TransformOptions {
 	sourcemap: boolean;
 }
 
-export const get_default_esbuild_options = (
+export const to_default_esbuild_options = (
 	dev: boolean,
 	target: Ecma_Script_Target = DEFAULT_ECMA_SCRIPT_TARGET,
 	sourcemap = dev,
@@ -29,7 +29,7 @@ export const get_default_esbuild_options = (
 			: {'process.env.NODE_ENV': dev ? '"development"' : '"production"'},
 });
 
-export const get_default_esbuild_preprocess_options = (
+export const to_default_esbuild_preprocess_options = (
 	dev: boolean,
 	target: Ecma_Script_Target = DEFAULT_ECMA_SCRIPT_TARGET,
 	sourcemap = dev,

--- a/src/build/esbuild_builder.ts
+++ b/src/build/esbuild_builder.ts
@@ -6,7 +6,7 @@ import {replace_extension} from '@feltcoop/felt/util/path.js';
 import {cyan} from '@feltcoop/felt/util/terminal.js';
 
 import type {Ecma_Script_Target, Generate_Types_For_File} from './ts_build_helpers.js';
-import {get_default_esbuild_options} from './esbuild_build_helpers.js';
+import {to_default_esbuild_options} from './esbuild_build_helpers.js';
 import {
 	JS_EXTENSION,
 	SOURCEMAP_EXTENSION,
@@ -141,4 +141,4 @@ type Create_Esbuild_Options = (
 ) => esbuild.TransformOptions;
 
 const create_default_esbuild_options: Create_Esbuild_Options = (dev, target, sourcemap) =>
-	get_default_esbuild_options(dev, target, sourcemap);
+	to_default_esbuild_options(dev, target, sourcemap);

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -50,7 +50,7 @@ export const postprocess = (
 			const is_external = is_external_import || is_external_imported_by_external;
 			let mapped_specifier: string;
 			if (is_external) {
-				mapped_specifier = to_build_extension(specifier);
+				mapped_specifier = to_build_extension(specifier, dev);
 				if (is_external_import) {
 					// handle regular externals
 					if (browser) {
@@ -89,8 +89,10 @@ export const postprocess = (
 			} else {
 				// internal import
 				final_specifier = to_relative_specifier(final_specifier, source.dir, paths.source);
-				mapped_specifier =
-					hack_to_build_extension_with_possibly_extensionless_specifier(final_specifier);
+				mapped_specifier = hack_to_build_extension_with_possibly_extensionless_specifier(
+					final_specifier,
+					dev,
+				);
 				build_id = join(build.dir, mapped_specifier);
 			}
 			if (dependencies_by_build_id === null) dependencies_by_build_id = new Map();
@@ -241,11 +243,12 @@ const should_modify_dot_js = (source_id: string): boolean => {
 // but we'd much prefer to remove it completely, and force internal import paths to conform to spec.
 const hack_to_build_extension_with_possibly_extensionless_specifier = (
 	specifier: string,
+	dev: boolean,
 ): string => {
 	const extension = extname(specifier);
 	return !extension || !HACK_EXTENSIONLESS_EXTENSIONS.has(extension)
 		? specifier + JS_EXTENSION
-		: to_build_extension(specifier);
+		: to_build_extension(specifier, dev);
 };
 
 // This hack is needed so we treat imports like `foo.task` as `foo.task.js`, not a `.task` file.

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -101,6 +101,14 @@ export const postprocess = (
 			}
 		}
 
+		// Support Svelte in production, outputting the plain `.svelte` but mapping specifiers
+		// TODO this is hacky but seems the least-bad way to do it
+		// 1. compile to JS with the Svelte compiler
+		// 2. use the existing import lexing and path transformation process
+		// 3. hackily replace the import paths in the original Svelte using a regexp
+		// if (source.extension === SVELTE_EXTENSION && build.extension === SVELTE_EXTENSION) {
+		// }
+
 		// Support Svelte CSS for development in the browser.
 		if (source.extension === SVELTE_EXTENSION && build.extension === JS_EXTENSION && browser) {
 			const css_compilation = result.builds.find((c) => c.extension === CSS_EXTENSION);
@@ -112,6 +120,7 @@ export const postprocess = (
 				content = inject_svelte_css_import(content, import_path);
 			}
 		}
+
 		return {content, dependencies_by_build_id};
 	} else {
 		// Handle other encodings like binary.
@@ -210,7 +219,7 @@ const to_relative_specifier_trimmed_by = (
 	return specifier;
 };
 
-const TYPE_IMPORT_MATCHER = /^import type [\s\S]*? from '(.+)';$/gm;
+const TYPE_IMPORT_MATCHER = /^import\s+type\s+[\s\S]*?from\s+'(.+)';$/gm;
 
 const parse_type_imports = (content: string): string[] =>
 	Array.from(content.matchAll(TYPE_IMPORT_MATCHER)).map((v) => v[1]);

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -21,25 +21,26 @@ import {
 } from '../utils/module.js';
 import {EXTERNALS_SOURCE_ID} from './externals_build_helpers.js';
 import type {Build_Dependency} from './build_dependency.js';
+import {extract_js_from_svelte_for_dependencies} from './svelte_build_helpers.js';
 
 // TODO this is all hacky and should be refactored, probably following Rollup's lead
 
-export const postprocess = (
+export const postprocess = async (
 	build: Build,
 	ctx: Build_Context,
 	result: Build_Result<Build>,
 	source: Build_Source,
-): {
+): Promise<{
 	content: Build['content'];
 	dependencies_by_build_id: Map<string, Build_Dependency> | null;
-} => {
+}> => {
 	if (build.encoding === 'utf8') {
 		const {content: original_content, build_config} = build;
 		let content = original_content;
 		const browser = build_config.platform === 'browser';
 		let dependencies_by_build_id: Map<string, Build_Dependency> | null = null;
 
-		const handle_specifier = (specifier: string): Build_Dependency => {
+		const handle_specifier: Handle_Specifier = (specifier) => {
 			const build_dependency = to_build_dependency(specifier, build, source, ctx);
 			if (dependencies_by_build_id === null) dependencies_by_build_id = new Map();
 			if (!dependencies_by_build_id.has(build_dependency.build_id)) {
@@ -50,67 +51,47 @@ export const postprocess = (
 
 		// Map import paths to the built versions.
 		if (build.extension === JS_EXTENSION) {
-			let transformed_content = '';
-			let index = 0;
-			// TODO what should we pass as the second arg to parse? the id? nothing? `lexer.parse(code, id);`
-			const [imports] = lexer.parse(content);
-			let start: number;
-			let end: number;
-			let backticked = false;
-			for (const {s, e, d} of imports) {
-				if (d > -1) {
-					const first_char = content[s];
-					if (first_char === '`') {
-						// allow template strings, but not interpolations -- see code ahead
-						backticked = true;
-					} else if (first_char !== `'` && first_char !== '"') {
-						// ignore non-literals
-						continue;
-					}
-					start = s + 1;
-					end = e - 1;
-				} else {
-					start = s;
-					end = e;
+			content = parse_dependencies(content, handle_specifier, true);
+		} else if (build.extension === SVELTE_EXTENSION) {
+			// Support Svelte in production, outputting the plain `.svelte`
+			// but extracting and mapping dependencies.
+			// TODO this is hacky but seems the least-bad way to do it
+			// 1. compile to JS with the Svelte preprocessor
+			const extracted_js = await extract_js_from_svelte_for_dependencies(build.content);
+			// 2. use the existing dependency parsing and path transformation process
+			parse_dependencies(extracted_js, handle_specifier, false);
+			// 3. hackily replace the import paths in the original Svelte using a regexp
+			if (dependencies_by_build_id !== null) {
+				// `dependencies_by_build_id` has been set by `handle_specifier`
+				for (const dependency of (
+					dependencies_by_build_id as Map<string, Build_Dependency>
+				).values()) {
+					content = content.replace(
+						new RegExp(`['|"|\`]${dependency.original_specifier}['|"|\`]`, 'g'),
+						`'${dependency.mapped_specifier}'`,
+					);
 				}
-				const specifier = content.substring(start, end);
-				if (backticked) {
-					backticked = false;
-					if (specifier.includes('${')) continue;
-				}
-				if (specifier === 'import.meta') continue;
-				const build_dependency = handle_specifier(specifier);
-				if (build_dependency.mapped_specifier !== specifier) {
-					transformed_content +=
-						content.substring(index, start) + build_dependency.mapped_specifier;
-					index = end;
-				}
-			}
-			if (index > 0) {
-				content = transformed_content + content.substring(index);
 			}
 		}
 
 		// For TS files, we need to separately parse type imports and add them to the dependencies,
 		// because by the time we parse the JS files above with `es-module-lexer`,
 		// we've already lost the `import type` information from the TypeScript source.
-		if (ctx.types && source.extension === TS_EXTENSION && build.extension === JS_EXTENSION) {
+		// TODO probably refactor into Rollup-like plugins
+		if (
+			ctx.types &&
+			((source.extension === TS_EXTENSION && build.extension === JS_EXTENSION) ||
+				(source.extension === SVELTE_EXTENSION &&
+					(build.extension === JS_EXTENSION || build.extension === SVELTE_EXTENSION)))
+		) {
 			const specifiers = parse_type_imports(source.content as string);
 			for (const specifier of specifiers) {
 				handle_specifier(specifier);
 			}
 		}
 
-		// Support Svelte in production, outputting the plain `.svelte` but mapping specifiers
-		// TODO this is hacky but seems the least-bad way to do it
-		// 1. compile to JS with the Svelte compiler
-		// 2. use the existing import lexing and path transformation process
-		// 3. hackily replace the import paths in the original Svelte using a regexp
-		// if (source.extension === SVELTE_EXTENSION && build.extension === SVELTE_EXTENSION) {
-		// }
-
 		// Support Svelte CSS for development in the browser.
-		if (source.extension === SVELTE_EXTENSION && build.extension === JS_EXTENSION && browser) {
+		if (browser && source.extension === SVELTE_EXTENSION && build.extension === JS_EXTENSION) {
 			const css_compilation = result.builds.find((c) => c.extension === CSS_EXTENSION);
 			if (css_compilation !== undefined) {
 				// TODO this is hardcoded to a sibling module, but that may be overly restrictive --
@@ -128,8 +109,56 @@ export const postprocess = (
 	}
 };
 
-// returns `mapped_specifier`, not because it makes a ton of sense,
-// but it's the only value needed, because this function populates `dependencies_by_build_id`
+interface Handle_Specifier {
+	(specifier: string): Build_Dependency;
+}
+
+const parse_dependencies = (
+	content: string,
+	handle_specifier: Handle_Specifier,
+	map_dependencies: boolean,
+): string => {
+	let transformed_content = '';
+	let index = 0;
+	// TODO what should we pass as the second arg to parse? the id? nothing? `lexer.parse(code, id);`
+	const [imports] = lexer.parse(content);
+	let start: number;
+	let end: number;
+	let backticked = false;
+	for (const {s, e, d} of imports) {
+		if (d > -1) {
+			const first_char = content[s];
+			if (first_char === '`') {
+				// allow template strings, but not interpolations -- see code ahead
+				backticked = true;
+			} else if (first_char !== `'` && first_char !== '"') {
+				// ignore non-literals
+				continue;
+			}
+			start = s + 1;
+			end = e - 1;
+		} else {
+			start = s;
+			end = e;
+		}
+		const specifier = content.substring(start, end);
+		if (backticked) {
+			backticked = false;
+			if (specifier.includes('${')) continue;
+		}
+		if (specifier === 'import.meta') continue;
+		const build_dependency = handle_specifier(specifier);
+		if (map_dependencies && build_dependency.mapped_specifier !== specifier) {
+			transformed_content += content.substring(index, start) + build_dependency.mapped_specifier;
+			index = end;
+		}
+	}
+	if (map_dependencies && index > 0) {
+		content = transformed_content + content.substring(index);
+	}
+	return map_dependencies ? content : '';
+};
+
 const to_build_dependency = (
 	specifier: string,
 	build: Build,
@@ -193,6 +222,7 @@ const to_build_dependency = (
 	return {
 		specifier: final_specifier,
 		mapped_specifier,
+		original_specifier: specifier,
 		build_id,
 		external: browser && is_external,
 	};
@@ -219,10 +249,10 @@ const to_relative_specifier_trimmed_by = (
 	return specifier;
 };
 
-const TYPE_IMPORT_MATCHER = /^import\s+type\s+[\s\S]*?from\s+'(.+)';$/gm;
-
 const parse_type_imports = (content: string): string[] =>
-	Array.from(content.matchAll(TYPE_IMPORT_MATCHER)).map((v) => v[1]);
+	Array.from(content.matchAll(/import\s+type[\s\S]*?from\s*['|"|\`](.+)['|"|\`]/gm)).map(
+		(v) => v[1],
+	);
 
 const inject_svelte_css_import = (content: string, import_path: string): string => {
 	let newline_index = content.length;

--- a/src/build/source_meta.test.ts
+++ b/src/build/source_meta.test.ts
@@ -19,7 +19,8 @@ test_serialize_source_meta('serializes and deserializes source meta without chan
 					{
 						specifier: 'a',
 						mapped_specifier: 'b',
-						build_id: 'c',
+						original_specifier: 'c',
+						build_id: 'd',
 						external: true,
 					},
 				],
@@ -49,6 +50,7 @@ test_serialize_source_meta('optimizes when serializing', () => {
 					{
 						specifier: 'a',
 						mapped_specifier: 'a',
+						original_specifier: 'a',
 						build_id: 'a',
 						external: false,
 					},

--- a/src/build/svelte_builder.ts
+++ b/src/build/svelte_builder.ts
@@ -86,6 +86,27 @@ export const create_svelte_builder = (opts: Initial_Options = {}): SvelteBuilder
 		}
 		const {id, encoding, content} = source;
 		const out_dir = to_build_out_path(dev, build_config.name, source.dir_base_path, build_dir);
+
+		// for production builds, output uncompiled Svelte
+		// TODO what about non-TypeScript preprocessors?
+		if (!dev) {
+			const svelte_id = `${out_dir}${source.filename}`;
+			const result: Build_Result<Text_Build> = {
+				builds: [
+					{
+						id: svelte_id,
+						filename: source.filename,
+						dir: out_dir,
+						extension: SVELTE_EXTENSION,
+						encoding,
+						content: source.content,
+						build_config,
+					},
+				],
+			};
+			return result;
+		}
+
 		let preprocessed_code: string;
 
 		// TODO see rollup-plugin-svelte for how to track deps

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -127,10 +127,11 @@ test_to_import_id.run();
 const test_to_build_extension = suite('to_build_extension');
 
 test_to_build_extension('basic behavior', () => {
-	t.is(to_build_extension('foo/bar.ts'), 'foo/bar.js');
-	t.is(to_build_extension('foo/bar.svelte'), 'foo/bar.svelte.js');
-	t.is(to_build_extension('foo/bar.css'), 'foo/bar.css');
-	t.is(to_build_extension('foo/bar.png'), 'foo/bar.png');
+	t.is(to_build_extension('foo/bar.ts', true), 'foo/bar.js');
+	t.is(to_build_extension('foo/bar.svelte', true), 'foo/bar.svelte.js');
+	t.is(to_build_extension('foo/bar.svelte', false), 'foo/bar.svelte');
+	t.is(to_build_extension('foo/bar.css', true), 'foo/bar.css');
+	t.is(to_build_extension('foo/bar.png', true), 'foo/bar.png');
 });
 
 test_to_build_extension.run();

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -145,7 +145,7 @@ export const replace_root_dir = (id: string, root_dir: string, p = paths): strin
 	join(root_dir, to_root_path(id, p));
 
 // Converts a source id into an id that can be imported.
-// When importing from inside Gro's dist/ directory,
+// When importing from inside Gro's own internal dist/ directory,
 // it returns a relative path and ignores `dev` and `build_name`.
 export const to_import_id = (
 	source_id: string,
@@ -153,20 +153,24 @@ export const to_import_id = (
 	build_name: Build_Name,
 	p = paths_from_id(source_id),
 ): string => {
-	const dir_base_path = strip_start(to_build_extension(source_id), p.source);
+	const dir_base_path = strip_start(to_build_extension(source_id, dev), p.source);
 	return !is_this_project_gro && gro_import_dir === p.dist
 		? join(gro_import_dir, dir_base_path)
 		: to_build_out_path(dev, build_name, dir_base_path, p.build);
 };
 
-// TODO This function loses information. It's also hardcodedd to Gro's default file types.
+// TODO This function loses information,
+// and it's also hardcoded to Gro's default file types and output conventions.
 // Maybe this points to a configurable system? Users can define their own extensions in Gro.
-// Maybe `extensionConfigs: FilerExtensionConfig[]`.
-export const to_build_extension = (source_id: string): string =>
+// Maybe `extension_configs: Filer_Extension_Config[]`.
+// Or maybe just follow the lead of Rollup/esbuild?
+export const to_build_extension = (source_id: string, dev: boolean): string =>
 	source_id.endsWith(TS_EXTENSION)
 		? replace_extension(source_id, JS_EXTENSION)
 		: source_id.endsWith(SVELTE_EXTENSION)
-		? source_id + JS_EXTENSION
+		? dev
+			? source_id + JS_EXTENSION
+			: source_id
 		: source_id;
 
 // This implementation is complicated but it's fast.


### PR DESCRIPTION
This makes Gro properly build Svelte for production. Following Svelte conventions, the library adapter now publishes Svelte source, deferring compilation to users.

There are two main limitations:

- Custom preprocessors are not supported.
- This does not handle outputting compiled Svelte in production. We'll address that in #231.

We may want to rework things to move the `postprocess` step to the builders themselves, and provide helpers to avoid verbosity. That would allow builders to determine for themselves how to resolve dependencies, and modularize the currently-hardcoded JS and Svelte postprocessing.