### PR TITLE
infer deployment directory

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.32.1
 
 - change `gro deploy` to infer default `dirname`
-  ([#232](https://github.com/feltcoop/gro/pull/232))
+  ([#241](https://github.com/feltcoop/gro/pull/241))
 
 ## 0.32.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.32.1
+
+- change `gro deploy` to infer default `dirname`
+  ([#232](https://github.com/feltcoop/gro/pull/232))
+
 ## 0.32.0
 
 - **break**: add `gro_adapter_gro_frontend` adapter


### PR DESCRIPTION
Changes `gro deploy` to infer the default `dirname` if none is provided as an arg. First looks for `dist/svelte-kit`, then `dist/browser`, then throws an error. Probably want to extend this detection in the future.