### PR TITLE
fix dist assets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 - **break**: refactor `postprocess` into builders and delete `Build` and `Build_Result`
   ([#243](https://github.com/feltcoop/gro/pull/243))
-- correctly ignore unwanted assets in frontend build
+- ignore unwanted assets in frontend build
   ([#242](https://github.com/feltcoop/gro/pull/242))
 
 ## 0.32.1

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 - **break**: refactor `postprocess` into builders and delete `Build` and `Build_Result`
   ([#243](https://github.com/feltcoop/gro/pull/243))
 - correctly ignore unwanted assets in frontend build
-  ([#241](https://github.com/feltcoop/gro/pull/241))
+  ([#242](https://github.com/feltcoop/gro/pull/242))
 
 ## 0.32.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@
 
 ## 0.32.1
 
+- correctly ignore unwanted assets in frontend build
+  ([#241](https://github.com/feltcoop/gro/pull/241))
+
+## 0.32.1
+
 - change `gro deploy` to infer default `dirname`
   ([#241](https://github.com/feltcoop/gro/pull/241))
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,6 @@
 
 - **break**: refactor `postprocess` into builders and delete `Build` and `Build_Result`
   ([#243](https://github.com/feltcoop/gro/pull/243))
-
-## 0.32.1
-
 - correctly ignore unwanted assets in frontend build
   ([#241](https://github.com/feltcoop/gro/pull/241))
 

--- a/src/adapt/adapter.ts
+++ b/src/adapt/adapter.ts
@@ -1,8 +1,8 @@
 import {to_array} from '@feltcoop/felt/util/array.js';
 import type {Timings} from '@feltcoop/felt/util/timings.js';
 
-import type {Task_Context} from '../task/task.js';
-import type {Gro_Config} from '../config/config.js';
+import type {Task_Context} from 'src/task/task.js';
+import type {Gro_Config} from 'src/config/config.js';
 
 /*
 

--- a/src/adapt/gro_adapter_generic_build.ts
+++ b/src/adapt/gro_adapter_generic_build.ts
@@ -1,10 +1,10 @@
 import {strip_trailing_slash} from '@feltcoop/felt/util/path.js';
 
-import type {Adapter} from './adapter.js';
-import type {Host_Target} from './utils.js';
+import type {Adapter} from 'src/adapt/adapter.js';
+import type {Host_Target} from 'src/adapt/utils.js';
 import {copy_dist, ensure_nojekyll} from './utils.js';
 import {DIST_DIRNAME} from '../paths.js';
-import type {Build_Name} from '../build/build_config.js';
+import type {Build_Name} from 'src/build/build_config.js';
 
 export interface Options {
 	build_name: Build_Name;

--- a/src/adapt/gro_adapter_gro_frontend.ts
+++ b/src/adapt/gro_adapter_gro_frontend.ts
@@ -86,6 +86,7 @@ export const create_adapter = ({
 			}
 			timing_to_bundle();
 
+			// TODO this should actually filter based on the build config input, no?
 			await copy_dist(fs, build_config, dev, dir, log, (id) => asset_extensions.has(extname(id)));
 
 			if (host_target === 'github_pages') {

--- a/src/adapt/gro_adapter_gro_frontend.ts
+++ b/src/adapt/gro_adapter_gro_frontend.ts
@@ -4,13 +4,13 @@ import {EMPTY_OBJECT} from '@feltcoop/felt/util/object.js';
 import type {Plugin as Rollup_Plugin} from 'rollup';
 import {extname} from 'path';
 
-import type {Adapter} from './adapter.js';
-import type {Map_Input_Options} from '../build/rollup.js';
+import type {Adapter} from 'src/adapt/adapter.js';
+import type {Map_Input_Options} from 'src/build/rollup.js';
 import {run_rollup} from '../build/rollup.js';
 import {DIST_DIRNAME, source_id_to_base_path, to_import_id} from '../paths.js';
 import {print_build_config_label, to_input_files} from '../build/build_config.js';
-import type {Build_Name} from '../build/build_config.js';
-import type {Host_Target} from './utils.js';
+import type {Build_Name} from 'src/build/build_config.js';
+import type {Host_Target} from 'src/adapt/utils.js';
 import {copy_dist, ensure_nojekyll} from './utils.js';
 import {BROWSER_BUILD_NAME, non_asset_extensions} from '../build/default_build_config.js';
 

--- a/src/adapt/gro_adapter_gro_frontend.ts
+++ b/src/adapt/gro_adapter_gro_frontend.ts
@@ -12,7 +12,7 @@ import {print_build_config_label, to_input_files} from '../build/build_config.js
 import type {Build_Name} from '../build/build_config.js';
 import type {Host_Target} from './utils.js';
 import {copy_dist, ensure_nojekyll} from './utils.js';
-import {BROWSER_BUILD_NAME, ignored_asset_extensions} from '../build/default_build_config.js';
+import {BROWSER_BUILD_NAME, non_asset_extensions} from '../build/default_build_config.js';
 
 export interface Options {
 	build_name: Build_Name;
@@ -26,7 +26,6 @@ export const create_adapter = ({
 	dir = `${DIST_DIRNAME}/${build_name}`,
 	minify = true,
 	host_target = 'github_pages',
-	asset_extensions,
 }: Partial<Options> = EMPTY_OBJECT): Adapter => {
 	dir = strip_trailing_slash(dir);
 	return {
@@ -87,7 +86,26 @@ export const create_adapter = ({
 			timing_to_bundle();
 
 			// TODO this should actually filter based on the build config input, no?
-			await copy_dist(fs, build_config, dev, dir, log, (id) => asset_extensions.has(extname(id)));
+			await copy_dist(
+				fs,
+				build_config,
+				dev,
+				dir,
+				log,
+
+				// TODO fix this -- I don't think the answer is to make the ignored extensions configurable,
+				// shouldn't it be detectable from the inputs?
+				// should overwrite be false?
+
+				// TODO what if we had the `Filer` instance to look up the build id? could return from `build_source`
+				(id) => !non_asset_extensions.has(extname(id)),
+				// (id, stats) => {
+				// 	if (stats.isDirectory()) return true;
+				// 	const included = is_input_to_build_config(build_id_to_source_id(id), build_config.input);
+				// 	console.log('included id,', included, id);
+				// 	return included;
+				// },
+			);
 
 			if (host_target === 'github_pages') {
 				await ensure_nojekyll(fs, dir);

--- a/src/adapt/gro_adapter_node_library.ts
+++ b/src/adapt/gro_adapter_node_library.ts
@@ -3,7 +3,7 @@ import {EMPTY_OBJECT} from '@feltcoop/felt/util/object.js';
 import {strip_trailing_slash} from '@feltcoop/felt/util/path.js';
 import {strip_start} from '@feltcoop/felt/util/string.js';
 
-import type {Adapter} from './adapter.js';
+import type {Adapter} from 'src/adapt/adapter.js';
 import {Task_Error} from '../task/task.js';
 import {copy_dist} from './utils.js';
 import {
@@ -17,11 +17,11 @@ import {
 	DIST_DIRNAME,
 } from '../paths.js';
 import {NODE_LIBRARY_BUILD_NAME} from '../build/default_build_config.js';
-import type {Build_Name} from '../build/build_config.js';
+import type {Build_Name} from 'src/build/build_config.js';
 import {print_build_config_label, to_input_files} from '../build/build_config.js';
 import {run_rollup} from '../build/rollup.js';
-import type {Path_Stats} from '../fs/path_data.js';
-import type {Package_Json} from '../utils/package_json.js';
+import type {Path_Stats} from 'src/fs/path_data.js';
+import type {Package_Json} from 'src/utils/package_json.js';
 
 const name = '@feltcoop/gro_adapter_node_library';
 

--- a/src/adapt/gro_adapter_sveltekit_frontend.ts
+++ b/src/adapt/gro_adapter_sveltekit_frontend.ts
@@ -1,8 +1,8 @@
 import {EMPTY_OBJECT} from '@feltcoop/felt/util/object.js';
 import {strip_trailing_slash} from '@feltcoop/felt/util/path.js';
 
-import type {Adapter} from './adapter.js';
-import type {Host_Target} from './utils.js';
+import type {Adapter} from 'src/adapt/adapter.js';
+import type {Host_Target} from 'src/adapt/utils.js';
 import {ensure_nojekyll} from './utils.js';
 import {DIST_DIRNAME, SVELTEKIT_BUILD_DIRNAME, SVELTEKIT_DIST_DIRNAME} from '../paths.js';
 

--- a/src/adapt/utils.ts
+++ b/src/adapt/utils.ts
@@ -31,6 +31,7 @@ export const copy_dist = async (
 	log.info(`copying ${print_path(build_out_dir)} to ${print_path(dist_out_dir)}`);
 	const typemap_files: string[] = [];
 	await fs.copy(build_out_dir, dist_out_dir, {
+		// overwrite: false, // TODO this is correct, right?
 		filter: async (id) => {
 			if (id === externals_dir) return false;
 			const stats = await fs.stat(id);

--- a/src/adapt/utils.ts
+++ b/src/adapt/utils.ts
@@ -2,9 +2,9 @@ import {relative, dirname} from 'path';
 import type {Logger} from '@feltcoop/felt/util/log.js';
 import {strip_end, strip_start} from '@feltcoop/felt/util/string.js';
 
-import type {Build_Config} from '../build/build_config.js';
-import type {Filesystem} from '../fs/filesystem.js';
-import type {Path_Stats} from '../fs/path_data.js';
+import type {Build_Config} from 'src/build/build_config.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
+import type {Path_Stats} from 'src/fs/path_data.js';
 import {
 	EXTERNALS_BUILD_DIRNAME,
 	to_build_base_path,

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -1,10 +1,10 @@
 import {Timings} from '@feltcoop/felt/util/timings.js';
 import {print_timings} from '@feltcoop/felt/util/print.js';
 
-import type {Task, Args} from './task/task.js';
-import type {Map_Input_Options, Map_Output_Options, Map_Watch_Options} from './build/rollup.js';
+import type {Task, Args} from 'src/task/task.js';
+import type {Map_Input_Options, Map_Output_Options, Map_Watch_Options} from 'src/build/rollup.js';
 import {load_config} from './config/config.js';
-import type {Gro_Config} from './config/config.js';
+import type {Gro_Config} from 'src/config/config.js';
 import {adapt} from './adapt/adapter.js';
 import {build_source} from './build/build_source.js';
 import {Plugins} from './plugin/plugin.js';

--- a/src/build/Filer.test.ts
+++ b/src/build/Filer.test.ts
@@ -3,9 +3,9 @@ import * as t from 'uvu/assert';
 
 import {Filer} from './Filer.js';
 import {fs as memoryFs} from '../fs/memory.js';
-import type {Memory_Fs} from '../fs/memory.js';
-import type {Builder} from './builder.js';
-import type {Build_Config} from '../build/build_config.js';
+import type {Memory_Fs} from 'src/fs/memory.js';
+import type {Builder} from 'src/build/builder.js';
+import type {Build_Config} from 'src/build/build_config.js';
 
 interface Suite_Context {
 	fs: Memory_Fs;

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -11,31 +11,31 @@ import {print_error} from '@feltcoop/felt/util/print.js';
 import {wrap} from '@feltcoop/felt/util/async.js';
 import type {Omit_Strict, Assignable, Partial_Except} from '@feltcoop/felt/util/types.js';
 
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 import {create_filer_dir} from '../build/filer_dir.js';
-import type {Filer_Dir, Filer_Dir_Change_Callback} from '../build/filer_dir.js';
+import type {Filer_Dir, Filer_Dir_Change_Callback} from 'src/build/filer_dir.js';
 import {is_input_to_build_config, map_dependency_to_source_id} from './utils.js';
-import type {Map_Dependency_To_Source_Id} from './utils.js';
+import type {Map_Dependency_To_Source_Id} from 'src/build/utils.js';
 import {JS_EXTENSION, paths, to_build_out_path} from '../paths.js';
-import type {Build_Context, Builder, Builder_State} from './builder.js';
+import type {Build_Context, Builder, Builder_State} from 'src/build/builder.js';
 import {infer_encoding} from '../fs/encoding.js';
-import type {Encoding} from '../fs/encoding.js';
+import type {Encoding} from 'src/fs/encoding.js';
 import {print_build_config_label} from '../build/build_config.js';
-import type {Build_Name} from '../build/build_config.js';
-import type {Build_Config} from '../build/build_config.js';
+import type {Build_Name} from 'src/build/build_config.js';
+import type {Build_Config} from 'src/build/build_config.js';
 import {DEFAULT_ECMA_SCRIPT_TARGET} from '../build/default_build_config.js';
-import type {Ecma_Script_Target} from './ts_build_helpers.js';
+import type {Ecma_Script_Target} from 'src/build/ts_build_helpers.js';
 import {strip_base, to_served_dirs} from './served_dir.js';
-import type {Served_Dir, Served_Dir_Partial} from './served_dir.js';
+import type {Served_Dir, Served_Dir_Partial} from 'src/build/served_dir.js';
 import {
 	assert_buildable_source_file,
 	assert_source_file,
 	create_source_file,
 } from './source_file.js';
-import type {Buildable_Source_File, Source_File} from './source_file.js';
+import type {Buildable_Source_File, Source_File} from 'src/build/source_file.js';
 import {diff_dependencies} from './build_file.js';
-import type {Build_File} from './build_file.js';
-import type {Base_Filer_File} from './filer_file.js';
+import type {Build_File} from 'src/build/build_file.js';
+import type {Base_Filer_File} from 'src/build/filer_file.js';
 import {load_content} from './load.js';
 import {is_external_module} from '../utils/module.js';
 import {
@@ -44,17 +44,17 @@ import {
 	get_externals_builder_state,
 	get_externals_build_state,
 } from './externals_build_helpers.js';
-import type {Externals_Aliases} from './externals_build_helpers.js';
+import type {Externals_Aliases} from 'src/build/externals_build_helpers.js';
 import {queue_externals_build} from './externals_builder.js';
-import type {Source_Meta} from './source_meta.js';
-import type {Build_Dependency} from './build_dependency.js';
+import type {Source_Meta} from 'src/build/source_meta.js';
+import type {Build_Dependency} from 'src/build/build_dependency.js';
 import {
 	delete_source_meta,
 	update_source_meta,
 	clean_source_meta,
 	init_source_meta,
 } from './source_meta.js';
-import type {Path_Filter} from '../fs/path_filter.js';
+import type {Path_Filter} from 'src/fs/path_filter.js';
 
 /*
 

--- a/src/build/build_config.ts
+++ b/src/build/build_config.ts
@@ -6,7 +6,7 @@ import type {Result, Flavored} from '@feltcoop/felt/util/types.js';
 import {paths} from '../paths.js';
 import {CONFIG_BUILD_NAME, SYSTEM_BUILD_CONFIG, SYSTEM_BUILD_NAME} from './default_build_config.js';
 import {validate_input_files} from './utils.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 // See `../docs/config.md` for documentation.
 

--- a/src/build/build_dependency.test.ts
+++ b/src/build/build_dependency.test.ts
@@ -1,7 +1,7 @@
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
 
-import type {Build_Dependency, Serialized_Build_Dependency} from './build_dependency.js';
+import type {Build_Dependency, Serialized_Build_Dependency} from 'src/build/build_dependency.js';
 import {serialize_build_dependency, deserialize_build_dependency} from './build_dependency.js';
 
 /* test_serialize_build_dependency */

--- a/src/build/build_file.ts
+++ b/src/build/build_file.ts
@@ -1,12 +1,12 @@
 import {Unreachable_Error} from '@feltcoop/felt/util/error.js';
 
-import type {Base_Filer_File} from './filer_file.js';
-import type {Source_Meta} from './source_meta.js';
-import type {Build_Dependency} from './build_dependency.js';
+import type {Base_Filer_File} from 'src/build/filer_file.js';
+import type {Source_Meta} from 'src/build/source_meta.js';
+import type {Build_Dependency} from 'src/build/build_dependency.js';
 import {basename, dirname, extname} from 'path';
 import {load_content} from './load.js';
-import type {Build_Config} from '../build/build_config.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Build_Config} from 'src/build/build_config.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export type Build_File = Text_Build_File | Binary_Build_File;
 export interface Text_Build_File extends Base_Build_File {

--- a/src/build/build_source.ts
+++ b/src/build/build_source.ts
@@ -6,8 +6,8 @@ import {gray} from '@feltcoop/felt/util/terminal.js';
 import {paths, to_types_build_dir} from '../paths.js';
 import {Filer} from '../build/Filer.js';
 import {create_default_builder} from './default_builder.js';
-import type {Gro_Config} from '../config/config.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Gro_Config} from 'src/config/config.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 import {generate_types} from './ts_build_helpers.js';
 
 export const build_source = async (

--- a/src/build/builder.ts
+++ b/src/build/builder.ts
@@ -1,17 +1,17 @@
 import type {Logger} from '@feltcoop/felt/util/log.js';
 
-import type {Build_Config, Build_Name} from '../build/build_config.js';
+import type {Build_Config, Build_Name} from 'src/build/build_config.js';
 import type {
 	Externals_Aliases,
 	Externals_Builder_State,
 	EXTERNALS_BUILDER_STATE_KEY,
 } from './externals_build_helpers.js';
-import type {Ecma_Script_Target} from './ts_build_helpers.js';
-import type {Served_Dir} from './served_dir.js';
-import type {Source_Meta} from './source_meta.js';
-import type {Filesystem} from '../fs/filesystem.js';
-import type {Base_Filer_File} from './filer_file.js';
-import type {Build_File} from './build_file.js';
+import type {Ecma_Script_Target} from 'src/build/ts_build_helpers.js';
+import type {Served_Dir} from 'src/build/served_dir.js';
+import type {Source_Meta} from 'src/build/source_meta.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
+import type {Base_Filer_File} from 'src/build/filer_file.js';
+import type {Build_File} from 'src/build/build_file.js';
 
 export interface Builder<TSource extends Build_Source = Build_Source> {
 	name: string;

--- a/src/build/default_build_config.ts
+++ b/src/build/default_build_config.ts
@@ -82,9 +82,9 @@ export const to_default_browser_build = (
 
 // compute default asset extensions on demand to pick up any changes to the supported MIME types
 const to_default_asset_extensions = (): string[] =>
-	Array.from(get_extensions()).filter((extension) => !ignored_asset_extensions.has(extension));
+	Array.from(get_extensions()).filter((extension) => !non_asset_extensions.has(extension));
 
-export const ignored_asset_extensions = new Set([
+export const non_asset_extensions = new Set([
 	JS_EXTENSION,
 	JSON_EXTENSION,
 	// these aren't currently included as MIME types, but that could change in the future

--- a/src/build/default_build_config.ts
+++ b/src/build/default_build_config.ts
@@ -1,6 +1,6 @@
 import {createFilter} from '@rollup/pluginutils';
 
-import type {Build_Config, Build_Config_Partial, Build_Name} from './build_config.js';
+import type {Build_Config, Build_Config_Partial, Build_Name} from 'src/build/build_config.js';
 import {
 	to_build_extension,
 	base_path_to_source_id,
@@ -11,8 +11,8 @@ import {
 	SVELTE_EXTENSION,
 } from '../paths.js';
 import {get_extensions} from '../fs/mime.js';
-import type {Ecma_Script_Target} from '../build/ts_build_helpers.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Ecma_Script_Target} from 'src/build/ts_build_helpers.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export const DEFAULT_ECMA_SCRIPT_TARGET: Ecma_Script_Target = 'es2020';
 

--- a/src/build/default_build_config.ts
+++ b/src/build/default_build_config.ts
@@ -83,7 +83,8 @@ export const to_default_browser_build = (
 // compute default asset extensions on demand to pick up any changes to the supported MIME types
 const to_default_asset_extensions = (): string[] =>
 	Array.from(get_extensions()).filter((extension) => !ignored_asset_extensions.has(extension));
-const ignored_asset_extensions = new Set([
+
+export const ignored_asset_extensions = new Set([
 	JS_EXTENSION,
 	JSON_EXTENSION,
 	// these aren't currently included as MIME types, but that could change in the future

--- a/src/build/default_builder.ts
+++ b/src/build/default_builder.ts
@@ -1,14 +1,14 @@
-import type {Builder} from './builder.js';
+import type {Builder} from 'src/build/builder.js';
 import {EXTERNALS_SOURCE_ID} from './externals_build_helpers.js';
 import {SVELTE_EXTENSION, TS_EXTENSION} from '../paths.js';
 import {create_simple_builder} from './simple_builder.js';
-import type {Initial_Options as Simple_Builder_Initial_Options} from './simple_builder.js';
+import type {Initial_Options as Simple_Builder_Initial_Options} from 'src/build/simple_builder.js';
 import {create_esbuild_builder} from './esbuild_builder.js';
-import type {Initial_Options as Esbuild_Builder_Initial_Options} from './esbuild_builder.js';
+import type {Initial_Options as Esbuild_Builder_Initial_Options} from 'src/build/esbuild_builder.js';
 import {create_svelte_builder} from './svelte_builder.js';
-import type {Initial_Options as Svelte_Builder_Initial_Options} from './svelte_builder.js';
+import type {Initial_Options as Svelte_Builder_Initial_Options} from 'src/build/svelte_builder.js';
 import {create_externals_builder} from './externals_builder.js';
-import type {Initial_Options as Externals_Builder_Initial_Options} from './externals_builder.js';
+import type {Initial_Options as Externals_Builder_Initial_Options} from 'src/build/externals_builder.js';
 
 export const create_default_builder = (
 	esbuild_builder_options?: Esbuild_Builder_Initial_Options,

--- a/src/build/esbuild_build_helpers.ts
+++ b/src/build/esbuild_build_helpers.ts
@@ -3,7 +3,7 @@ import type * as svelte_preprocess_esbuild from 'svelte-preprocess-esbuild';
 
 import {DEFAULT_ECMA_SCRIPT_TARGET} from '../build/default_build_config.js';
 import {is_this_project_gro} from '../paths.js';
-import type {Ecma_Script_Target} from './ts_build_helpers.js';
+import type {Ecma_Script_Target} from 'src/build/ts_build_helpers.js';
 
 export interface Esbuild_Transform_Options extends esbuild.TransformOptions {
 	target: Ecma_Script_Target;

--- a/src/build/esbuild_builder.ts
+++ b/src/build/esbuild_builder.ts
@@ -5,7 +5,7 @@ import {omit_undefined} from '@feltcoop/felt/util/object.js';
 import {replace_extension} from '@feltcoop/felt/util/path.js';
 import {cyan} from '@feltcoop/felt/util/terminal.js';
 
-import type {Ecma_Script_Target, Generate_Types_For_File} from './ts_build_helpers.js';
+import type {Ecma_Script_Target, Generate_Types_For_File} from 'src/build/ts_build_helpers.js';
 import {to_default_esbuild_options} from './esbuild_build_helpers.js';
 import {
 	JS_EXTENSION,
@@ -15,11 +15,11 @@ import {
 	TS_EXTENSION,
 	TS_TYPEMAP_EXTENSION,
 } from '../paths.js';
-import type {Builder, Text_Build_Source} from './builder.js';
+import type {Builder, Text_Build_Source} from 'src/build/builder.js';
 import {add_js_sourcemap_footer} from './utils.js';
 import {to_generate_types_for_file} from './ts_build_helpers.js';
-import type {Filesystem} from '../fs/filesystem.js';
-import type {Build_File} from './build_file.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
+import type {Build_File} from 'src/build/build_file.js';
 import {postprocess} from './postprocess.js';
 
 export interface Options {

--- a/src/build/externals_build_helpers.ts
+++ b/src/build/externals_build_helpers.ts
@@ -1,9 +1,9 @@
 import type {ImportMap} from 'esinstall';
 
 import {EXTERNALS_BUILD_DIRNAME, to_build_out_path} from '../paths.js';
-import type {Builder_State, Build_Context} from './builder.js';
-import type {Build_Config} from '../build/build_config.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Builder_State, Build_Context} from 'src/build/builder.js';
+import type {Build_Config} from 'src/build/build_config.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export interface Externals_Builder_State {
 	readonly build_states: Map<Build_Config, Externals_Build_State>;

--- a/src/build/externals_builder.ts
+++ b/src/build/externals_builder.ts
@@ -10,13 +10,13 @@ import {EMPTY_ARRAY} from '@feltcoop/felt/util/array.js';
 import {to_env_number} from '@feltcoop/felt/util/env.js';
 
 import {EXTERNALS_BUILD_DIRNAME, JS_EXTENSION, to_build_out_path} from '../paths.js';
-import type {Builder, Build_Context, Text_Build_Source} from './builder.js';
+import type {Builder, Build_Context, Text_Build_Source} from 'src/build/builder.js';
 import {load_content} from './load.js';
 import {rollup_plugin_gro_svelte} from './rollup_plugin_gro_svelte.js';
 import {create_default_preprocessor} from './svelte_build_helpers.js';
 import {create_css_cache} from './css_cache.js';
 import {print_build_config} from '../build/build_config.js';
-import type {Build_Config} from '../build/build_config.js';
+import type {Build_Config} from 'src/build/build_config.js';
 import {
 	create_delayed_promise,
 	get_externals_builder_state,
@@ -27,9 +27,9 @@ import {
 	to_specifiers,
 	EXTERNALS_SOURCE_ID,
 } from './externals_build_helpers.js';
-import type {Externals_Build_State} from './externals_build_helpers.js';
-import type {Filesystem} from '../fs/filesystem.js';
-import type {Build_File} from './build_file.js';
+import type {Externals_Build_State} from 'src/build/externals_build_helpers.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
+import type {Build_File} from 'src/build/build_file.js';
 import {postprocess} from './postprocess.js';
 
 /*

--- a/src/build/filer_dir.ts
+++ b/src/build/filer_dir.ts
@@ -1,10 +1,10 @@
 import {noop} from '@feltcoop/felt/util/function.js';
 
 import {watch_node_fs} from '../fs/watch_node_fs.js';
-import type {Watch_Node_Fs} from '../fs/watch_node_fs.js';
-import type {Path_Stats} from '../fs/path_data.js';
-import type {Path_Filter} from '../fs/path_filter.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Watch_Node_Fs} from 'src/fs/watch_node_fs.js';
+import type {Path_Stats} from 'src/fs/path_data.js';
+import type {Path_Filter} from 'src/fs/path_filter.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 // Buildable filer dirs are watched, built, and written to disk.
 // For non-buildable dirs, the `dir` is only watched and nothing is written to the filesystem.

--- a/src/build/filer_file.ts
+++ b/src/build/filer_file.ts
@@ -1,6 +1,6 @@
-import type {Filesystem} from '../fs/filesystem.js';
-import type {Path_Stats} from '../fs/path_data.js';
-import type {Encoding} from '../fs/encoding.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
+import type {Path_Stats} from 'src/fs/path_data.js';
+import type {Encoding} from 'src/fs/encoding.js';
 import {get_mime_type_by_extension} from '../fs/mime.js';
 import {to_hash} from './utils.js';
 

--- a/src/build/format_file.ts
+++ b/src/build/format_file.ts
@@ -2,7 +2,7 @@ import prettier from 'prettier';
 import {extname} from 'path';
 
 import {load_package_json} from '../utils/package_json.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export const format_file = async (fs: Filesystem, id: string, content: string): Promise<string> => {
 	const parser = infer_parser(id);

--- a/src/build/gro_css_build.ts
+++ b/src/build/gro_css_build.ts
@@ -1,6 +1,6 @@
 import type {ExistingRawSourceMap} from 'rollup';
 
-import type {Css_Build, Css_Bundle} from './css_cache.js';
+import type {Css_Build, Css_Bundle} from 'src/build/css_cache.js';
 
 export interface Gro_Css_Build extends Css_Build {
 	source_id: string; // for Svelte files, the `.svelte` version instead of `.css`

--- a/src/build/load.ts
+++ b/src/build/load.ts
@@ -1,5 +1,5 @@
-import type {Encoding} from '../fs/encoding.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Encoding} from 'src/fs/encoding.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export const load_content = <T extends Encoding>(
 	fs: Filesystem,

--- a/src/build/noop_builder.ts
+++ b/src/build/noop_builder.ts
@@ -1,7 +1,7 @@
 import {Unreachable_Error} from '@feltcoop/felt/util/error.js';
 
 import {to_build_out_path} from '../paths.js';
-import type {Builder} from './builder.js';
+import type {Builder} from 'src/build/builder.js';
 
 export const noop_builder: Builder = {
 	name: '@feltcoop/gro_builder_noop',

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -12,17 +12,17 @@ import {
 	to_build_out_path,
 	TS_EXTENSION,
 } from '../paths.js';
-import type {Build_Context, Build_Source} from './builder.js';
+import type {Build_Context, Build_Source} from 'src/build/builder.js';
 import {
 	is_external_module,
 	MODULE_PATH_LIB_PREFIX,
 	MODULE_PATH_SRC_PREFIX,
 } from '../utils/module.js';
 import {EXTERNALS_SOURCE_ID} from './externals_build_helpers.js';
-import type {Build_Dependency} from './build_dependency.js';
+import type {Build_Dependency} from 'src/build/build_dependency.js';
 import {extract_js_from_svelte_for_dependencies} from './svelte_build_helpers.js';
-import type {Build_Config} from './build_config.js';
-import type {Build_File} from './build_file.js';
+import type {Build_Config} from 'src/build/build_config.js';
+import type {Build_File} from 'src/build/build_file.js';
 
 export interface Postprocess {
 	(

--- a/src/build/rollup.ts
+++ b/src/build/rollup.ts
@@ -24,12 +24,12 @@ import {paths} from '../paths.js';
 import {rollup_plugin_gro_output_css} from './rollup_plugin_gro_output_css.js';
 import type {Filesystem} from 'src/fs/filesystem.js';
 import {rollup_plugin_gro_plain_css} from './rollup_plugin_gro_plain_css.js';
-import type {Css_Cache} from './css_cache.js';
+import type {Css_Cache} from 'src/build/css_cache.js';
 import {create_css_cache} from './css_cache.js';
-import type {Gro_Css_Build} from './gro_css_build.js';
+import type {Gro_Css_Build} from 'src/build/gro_css_build.js';
 import {rollup_plugin_gro_svelte} from './rollup_plugin_gro_svelte.js';
 import {create_default_preprocessor} from './svelte_build_helpers.js';
-import type {Ecma_Script_Target} from './ts_build_helpers.js';
+import type {Ecma_Script_Target} from 'src/build/ts_build_helpers.js';
 import {DEFAULT_ECMA_SCRIPT_TARGET} from './default_build_config.js';
 
 export interface Options {

--- a/src/build/rollup_plugin_gro_output_css.ts
+++ b/src/build/rollup_plugin_gro_output_css.ts
@@ -5,8 +5,8 @@ import {blue, gray} from '@feltcoop/felt/util/terminal.js';
 import {System_Logger, print_log_label} from '@feltcoop/felt/util/log.js';
 import type {Logger} from '@feltcoop/felt/util/log.js';
 
-import type {Filesystem} from '../fs/filesystem.js';
-import type {Gro_Css_Build, Gro_Css_Bundle} from './gro_css_build.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
+import type {Gro_Css_Build, Gro_Css_Bundle} from 'src/build/gro_css_build.js';
 
 export interface Options {
 	fs: Filesystem;

--- a/src/build/rollup_plugin_gro_plain_css.ts
+++ b/src/build/rollup_plugin_gro_plain_css.ts
@@ -4,8 +4,8 @@ import {createFilter} from '@rollup/pluginutils';
 import {green} from '@feltcoop/felt/util/terminal.js';
 import {print_log_label, System_Logger} from '@feltcoop/felt/util/log.js';
 
-import type {Gro_Css_Build} from './gro_css_build.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Gro_Css_Build} from 'src/build/gro_css_build.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export interface Options {
 	fs: Filesystem;

--- a/src/build/rollup_plugin_gro_svelte.ts
+++ b/src/build/rollup_plugin_gro_svelte.ts
@@ -14,9 +14,9 @@ import {
 	handle_warn,
 	handle_stats,
 } from '../build/svelte_build_helpers.js';
-import type {Svelte_Compilation} from '../build/svelte_build_helpers.js';
+import type {Svelte_Compilation} from 'src/build/svelte_build_helpers.js';
 import {CSS_EXTENSION, print_path} from '../paths.js';
-import type {Gro_Css_Build} from './gro_css_build.js';
+import type {Gro_Css_Build} from 'src/build/gro_css_build.js';
 
 // TODO support `package.json` "svelte" field
 // see reference here https://github.com/rollup/rollup-plugin-svelte/blob/master/index.js#L190

--- a/src/build/simple_builder.ts
+++ b/src/build/simple_builder.ts
@@ -1,8 +1,8 @@
 import {omit_undefined} from '@feltcoop/felt/util/object.js';
 
 import {noop_builder} from './noop_builder.js';
-import type {Build_Context, Builder, Build_Source} from './builder.js';
-import type {Build_Config} from '../build/build_config.js';
+import type {Build_Context, Builder, Build_Source} from 'src/build/builder.js';
+import type {Build_Config} from 'src/build/build_config.js';
 
 export interface Get_Builder {
 	(source: Build_Source, build_config: Build_Config): Builder | null;

--- a/src/build/source_file.ts
+++ b/src/build/source_file.ts
@@ -2,19 +2,19 @@ import {basename, dirname, join} from 'path';
 import {Unreachable_Error} from '@feltcoop/felt/util/error.js';
 import {strip_start} from '@feltcoop/felt/util/string.js';
 
-import type {Non_Buildable_Filer_Dir, Buildable_Filer_Dir, Filer_Dir} from '../build/filer_dir.js';
+import type {Non_Buildable_Filer_Dir, Buildable_Filer_Dir, Filer_Dir} from 'src/build/filer_dir.js';
 import {reconstruct_build_files} from './build_file.js';
-import type {Build_File} from './build_file.js';
-import type {Base_Filer_File} from './filer_file.js';
+import type {Build_File} from 'src/build/build_file.js';
+import type {Base_Filer_File} from 'src/build/filer_file.js';
 import {to_hash} from './utils.js';
-import type {Build_Config} from '../build/build_config.js';
-import type {Encoding} from '../fs/encoding.js';
-import type {Filer_File} from './Filer.js';
-import type {Source_Meta} from './source_meta.js';
-import type {Build_Dependency} from './build_dependency.js';
+import type {Build_Config} from 'src/build/build_config.js';
+import type {Encoding} from 'src/fs/encoding.js';
+import type {Filer_File} from 'src/build/Filer.js';
+import type {Source_Meta} from 'src/build/source_meta.js';
+import type {Build_Dependency} from 'src/build/build_dependency.js';
 import {EXTERNALS_BUILD_DIRNAME} from '../paths.js';
 import {is_external_module} from '../utils/module.js';
-import type {Build_Context} from './builder.js';
+import type {Build_Context} from 'src/build/builder.js';
 
 export type Source_File = Buildable_Source_File | Non_Buildable_Source_File;
 export type Buildable_Source_File = Buildable_Text_Source_File | Buildable_Binary_Source_File;

--- a/src/build/source_meta.test.ts
+++ b/src/build/source_meta.test.ts
@@ -1,7 +1,7 @@
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
 
-import type {Serialized_Source_Meta_Data, Source_Meta_Data} from './source_meta.js';
+import type {Serialized_Source_Meta_Data, Source_Meta_Data} from 'src/build/source_meta.js';
 import {serialize_source_meta, deserialize_source_meta} from './source_meta.js';
 
 /* test_serialize_source_meta */

--- a/src/build/source_meta.ts
+++ b/src/build/source_meta.ts
@@ -1,13 +1,13 @@
 import {gray} from '@feltcoop/felt/util/terminal.js';
 
-import type {Encoding} from '../fs/encoding.js';
+import type {Encoding} from 'src/fs/encoding.js';
 import {JSON_EXTENSION, to_build_out_dirname} from '../paths.js';
 import {get_file_content_hash} from './filer_file.js';
-import type {Build_Context} from './builder.js';
-import type {Buildable_Source_File} from './source_file.js';
-import type {Build_Name} from '../build/build_config.js';
+import type {Build_Context} from 'src/build/builder.js';
+import type {Buildable_Source_File} from 'src/build/source_file.js';
+import type {Build_Name} from 'src/build/build_config.js';
 import {EXTERNALS_SOURCE_ID} from './externals_build_helpers.js';
-import type {Build_Dependency, Serialized_Build_Dependency} from './build_dependency.js';
+import type {Build_Dependency, Serialized_Build_Dependency} from 'src/build/build_dependency.js';
 import {serialize_build_dependency, deserialize_build_dependency} from './build_dependency.js';
 
 export interface Source_Meta {

--- a/src/build/svelte_build_helpers.ts
+++ b/src/build/svelte_build_helpers.ts
@@ -13,7 +13,7 @@ import {print_key_value, print_ms} from '@feltcoop/felt/util/print.js';
 import type {Omit_Strict} from '@feltcoop/felt/util/types.js';
 
 import {to_default_esbuild_preprocess_options} from './esbuild_build_helpers.js';
-import type {Ecma_Script_Target} from './ts_build_helpers.js';
+import type {Ecma_Script_Target} from 'src/build/ts_build_helpers.js';
 import {print_path} from '../paths.js';
 
 export type Create_Preprocessor = (

--- a/src/build/svelte_builder.ts
+++ b/src/build/svelte_builder.ts
@@ -7,14 +7,14 @@ import {omit_undefined} from '@feltcoop/felt/util/object.js';
 import {Unreachable_Error} from '@feltcoop/felt/util/error.js';
 import {cyan} from '@feltcoop/felt/util/terminal.js';
 
-import type {Ecma_Script_Target} from './ts_build_helpers.js';
+import type {Ecma_Script_Target} from 'src/build/ts_build_helpers.js';
 import {
 	base_svelte_compile_options,
 	create_default_preprocessor,
 	handle_stats,
 	handle_warn,
 } from './svelte_build_helpers.js';
-import type {Create_Preprocessor, Svelte_Compilation} from './svelte_build_helpers.js';
+import type {Create_Preprocessor, Svelte_Compilation} from 'src/build/svelte_build_helpers.js';
 import {
 	CSS_EXTENSION,
 	JS_EXTENSION,
@@ -22,10 +22,10 @@ import {
 	SVELTE_EXTENSION,
 	to_build_out_path,
 } from '../paths.js';
-import type {Builder, Text_Build_Source} from './builder.js';
-import type {Build_Config} from '../build/build_config.js';
+import type {Builder, Text_Build_Source} from 'src/build/builder.js';
+import type {Build_Config} from 'src/build/build_config.js';
 import {add_css_sourcemap_footer, add_js_sourcemap_footer} from './utils.js';
-import type {Build_File} from './build_file.js';
+import type {Build_File} from 'src/build/build_file.js';
 import {postprocess} from './postprocess.js';
 
 // TODO build types in production unless `declarations` is `false`,

--- a/src/build/sveltekit_helpers.ts
+++ b/src/build/sveltekit_helpers.ts
@@ -1,5 +1,5 @@
 import {to_package_repo_name} from '../utils/package_json.js';
-import type {Package_Json} from '../utils/package_json.js';
+import type {Package_Json} from 'src/utils/package_json.js';
 
 export const to_sveltekit_base_path = (pkg: Package_Json, dev: boolean): string =>
 	dev ? '' : `/${to_package_repo_name(pkg)}`;

--- a/src/build/ts_build_helpers.ts
+++ b/src/build/ts_build_helpers.ts
@@ -2,7 +2,7 @@ import {EMPTY_ARRAY} from '@feltcoop/felt/util/array.js';
 import {replace_extension} from '@feltcoop/felt/util/path.js';
 import {spawn} from '@feltcoop/felt/util/process.js';
 
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 import {
 	source_id_to_base_path,
 	to_types_build_dir,

--- a/src/build/utils.test.ts
+++ b/src/build/utils.test.ts
@@ -3,7 +3,7 @@ import * as t from 'uvu/assert';
 import {resolve, join} from 'path';
 
 import {paths} from '../paths.js';
-import {to_hash, createDirectoryFilter} from './utils.js';
+import {to_hash, create_directory_filter} from './utils.js';
 
 /* test_to_hash */
 const test_to_hash = suite('to_hash');
@@ -19,42 +19,42 @@ test_to_hash('returns the same value given the same input', () => {
 test_to_hash.run();
 /* /test_to_hash */
 
-/* test_createDirectoryFilter */
-const test_createDirectoryFilter = suite('createDirectoryFilter', {
+/* test_create_directory_filter */
+const test_create_directory_filter = suite('create_directory_filter', {
 	root_dir: resolve('bar'),
 });
 
-test_createDirectoryFilter('relative source path', () => {
-	const filter = createDirectoryFilter('foo');
+test_create_directory_filter('relative source path', () => {
+	const filter = create_directory_filter('foo');
 	t.ok(filter(join(paths.source, 'foo')));
 	t.ok(filter(join(paths.source, 'foo/')));
 	t.not.ok(filter(join(paths.source, 'fo')));
 	t.not.ok(filter(join(paths.source, 'fo/')));
 });
 
-test_createDirectoryFilter('absolute source path', () => {
-	const filter = createDirectoryFilter(join(paths.source, 'foo'));
+test_create_directory_filter('absolute source path', () => {
+	const filter = create_directory_filter(join(paths.source, 'foo'));
 	t.ok(filter(join(paths.source, 'foo')));
 	t.ok(filter(join(paths.source, 'foo/')));
 	t.not.ok(filter(join(paths.source, 'fo')));
 	t.not.ok(filter(join(paths.source, 'fo/')));
 });
 
-test_createDirectoryFilter('relative path with custom root', ({root_dir}) => {
-	const filter = createDirectoryFilter('foo', root_dir);
+test_create_directory_filter('relative path with custom root', ({root_dir}) => {
+	const filter = create_directory_filter('foo', root_dir);
 	t.ok(filter(join(root_dir, 'foo')));
 	t.ok(filter(join(root_dir, 'foo/')));
 	t.not.ok(filter(join(root_dir, 'fo')));
 	t.not.ok(filter(join(root_dir, 'fo/')));
 });
 
-test_createDirectoryFilter('absolute path with custom root', ({root_dir}) => {
-	const filter = createDirectoryFilter(join(root_dir, 'foo'), root_dir);
+test_create_directory_filter('absolute path with custom root', ({root_dir}) => {
+	const filter = create_directory_filter(join(root_dir, 'foo'), root_dir);
 	t.ok(filter(join(root_dir, 'foo')));
 	t.ok(filter(join(root_dir, 'foo/')));
 	t.not.ok(filter(join(root_dir, 'fo')));
 	t.not.ok(filter(join(root_dir, 'fo/')));
 });
 
-test_createDirectoryFilter.run();
-/* /test_createDirectoryFilter */
+test_create_directory_filter.run();
+/* /test_create_directory_filter */

--- a/src/cert.task.ts
+++ b/src/cert.task.ts
@@ -1,6 +1,6 @@
 import {spawn} from '@feltcoop/felt/util/process.js';
 
-import type {Task} from './task/task.js';
+import type {Task} from 'src/task/task.js';
 
 export interface Task_Args {
 	host?: string;

--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -1,4 +1,4 @@
-import type {Task} from './task/task.js';
+import type {Task} from 'src/task/task.js';
 import {Task_Error} from './task/task.js';
 import {find_gen_modules} from './gen/gen_module.js';
 

--- a/src/clean.task.ts
+++ b/src/clean.task.ts
@@ -1,6 +1,6 @@
 import {spawn} from '@feltcoop/felt/util/process.js';
 
-import type {Task} from './task/task.js';
+import type {Task} from 'src/task/task.js';
 import {clean} from './fs/clean.js';
 
 export interface Task_Args {

--- a/src/cli/invoke.ts
+++ b/src/cli/invoke.ts
@@ -4,7 +4,7 @@ attach_process_error_handlers();
 
 import mri from 'mri';
 
-import type {Args} from '../task/task.js';
+import type {Args} from 'src/task/task.js';
 import {invoke_task} from '../task/invoke_task.js';
 import {fs as node_fs} from '../fs/node.js';
 

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -18,9 +18,9 @@
 	import Source_Meta_Tree_Explorer from './Source_Meta_Tree_Explorer.svelte';
 	import Source_Meta_Tree_Explorers from './Source_Meta_Tree_Explorers.svelte';
 	import {create_source_tree} from './source_tree.js';
-	import type {Source_Tree} from './source_tree.js';
-	import type {Project_State} from '../server/project_state.js';
-	import type {View} from './view.js';
+	import type {Source_Tree} from 'src/client/source_tree.js';
+	import type {Project_State} from 'src/server/project_state.js';
+	import type {View} from 'src/client/view.js';
 	import {set_project_state} from './project_state.js';
 
 	console.log('enter App.svelte');

--- a/src/client/Build_Name.svelte
+++ b/src/client/Build_Name.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type {Build_Name} from '../build/build_config.js';
+	import type {Build_Name} from 'src/build/build_config.js';
 
 	export let build_name: Build_Name;
 </script>

--- a/src/client/File_Tree_Explorer_File.svelte
+++ b/src/client/File_Tree_Explorer_File.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type {File_Tree_File} from './file_tree.js';
+	import type {File_Tree_File} from 'src/client/file_tree.js';
 	import File_Tree_Explorer_Node from './File_Tree_Explorer_Node.svelte';
 
 	export let file: File_Tree_File;

--- a/src/client/File_Tree_Explorer_Folder.svelte
+++ b/src/client/File_Tree_Explorer_Folder.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import File_Tree_Explorer_File from './File_Tree_Explorer_File.svelte';
 	import File_Tree_Explorer_Node from './File_Tree_Explorer_Node.svelte';
-	import type {File_Tree_Folder} from './file_tree.js';
+	import type {File_Tree_Folder} from 'src/client/file_tree.js';
 
 	export let folder: File_Tree_Folder;
 </script>

--- a/src/client/File_Tree_Explorer_Node.svelte
+++ b/src/client/File_Tree_Explorer_Node.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type {File_Tree_Node} from './file_tree.js';
+	import type {File_Tree_Node} from 'src/client/file_tree.js';
 
 	export let node: File_Tree_Node;
 </script>

--- a/src/client/Source_Meta_Build_Tree.svelte
+++ b/src/client/Source_Meta_Build_Tree.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import {filter_selected_metas} from './source_tree.js';
-	import type {Source_Tree} from './source_tree.js';
+	import type {Source_Tree} from 'src/client/source_tree.js';
 	import Build_Id from './Build_Id.svelte';
 	import Source_Id from './Source_Id.svelte';
 	import {get_builds_by_build_name} from './source_tree.js';

--- a/src/client/Source_Meta_Build_Tree_Explorer.svelte
+++ b/src/client/Source_Meta_Build_Tree_Explorer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import {filter_selected_metas} from './source_tree.js';
-	import type {Source_Tree} from './source_tree.js';
+	import type {Source_Tree} from 'src/client/source_tree.js';
 	import {get_project_state} from './project_state.js';
 	import File_Tree_Explorer_Folder from './File_Tree_Explorer_Folder.svelte';
 	import {to_file_tree_folder} from './file_tree.js';

--- a/src/client/Source_Meta_Builds_Table.svelte
+++ b/src/client/Source_Meta_Builds_Table.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Build_Id from './Build_Id.svelte';
 	import Build_Name from './Build_Name.svelte';
-	import type {Source_Tree} from './source_tree.js';
+	import type {Source_Tree} from 'src/client/source_tree.js';
 
 	export let source_tree: Source_Tree;
 	export let selected_build_names: string[];

--- a/src/client/Source_Meta_Expander.svelte
+++ b/src/client/Source_Meta_Expander.svelte
@@ -3,8 +3,8 @@
 
 	import Source_Meta_Expander_Item from './Source_Meta_Expander_Item.svelte';
 	import {filter_selected_metas} from './source_tree.js';
-	import type {Source_Tree} from './source_tree.js';
-	import type {Source_Meta} from '../build/source_meta.js';
+	import type {Source_Tree} from 'src/client/source_tree.js';
+	import type {Source_Meta} from 'src/build/source_meta.js';
 
 	export let source_tree: Source_Tree;
 	export let selected_build_names: string[];

--- a/src/client/Source_Meta_Expander_Item.svelte
+++ b/src/client/Source_Meta_Expander_Item.svelte
@@ -2,7 +2,7 @@
 	import type {Writable} from 'svelte/store';
 
 	import Source_Id from './Source_Id.svelte';
-	import type {Source_Meta} from '../build/source_meta.js';
+	import type {Source_Meta} from 'src/build/source_meta.js';
 
 	export let source_meta: Source_Meta;
 	export let selected_source_meta: Writable<Source_Meta | null>;

--- a/src/client/Source_Meta_Raw.svelte
+++ b/src/client/Source_Meta_Raw.svelte
@@ -3,8 +3,8 @@
 
 	import Source_Meta_Raw_Item from './Source_Meta_Raw_Item.svelte';
 	import {filter_selected_metas} from './source_tree.js';
-	import type {Source_Tree} from './source_tree.js';
-	import type {Source_Meta} from '../build/source_meta.js';
+	import type {Source_Tree} from 'src/client/source_tree.js';
+	import type {Source_Meta} from 'src/build/source_meta.js';
 
 	export let source_tree: Source_Tree;
 	export let selected_build_names: string[];

--- a/src/client/Source_Meta_Raw_Item.svelte
+++ b/src/client/Source_Meta_Raw_Item.svelte
@@ -2,7 +2,7 @@
 	import type {Writable} from 'svelte/store';
 
 	import Source_Id from './Source_Id.svelte';
-	import type {Source_Meta} from '../build/source_meta.js';
+	import type {Source_Meta} from 'src/build/source_meta.js';
 
 	export let source_meta: Source_Meta;
 	export let hovered_source_meta: Writable<Source_Meta | null>;

--- a/src/client/Source_Meta_Table.svelte
+++ b/src/client/Source_Meta_Table.svelte
@@ -3,7 +3,7 @@
 	import Source_Id from './Source_Id.svelte';
 	import Build_Name from './Build_Name.svelte';
 	import {filter_selected_metas, get_builds_by_build_name} from './source_tree.js';
-	import type {Source_Tree} from './source_tree.js';
+	import type {Source_Tree} from 'src/client/source_tree.js';
 
 	export let source_tree: Source_Tree;
 	export let selected_build_names: string[];

--- a/src/client/Source_Meta_Tree_Explorer.svelte
+++ b/src/client/Source_Meta_Tree_Explorer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import {filter_selected_metas} from './source_tree.js';
-	import type {Source_Tree} from './source_tree.js';
+	import type {Source_Tree} from 'src/client/source_tree.js';
 	import {to_file_tree_folder} from './file_tree.js';
 	import File_Tree_Explorer_Folder from './File_Tree_Explorer_Folder.svelte';
 	import {get_project_state} from './project_state.js';

--- a/src/client/Source_Meta_Tree_Explorers.svelte
+++ b/src/client/Source_Meta_Tree_Explorers.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Source_Meta_Build_Tree_Explorer from './Source_Meta_Build_Tree_Explorer.svelte';
 	import Source_Meta_Tree_Explorer from './Source_Meta_Tree_Explorer.svelte';
-	import type {Source_Tree} from './source_tree.js';
+	import type {Source_Tree} from 'src/client/source_tree.js';
 
 	export let source_tree: Source_Tree;
 	export let selected_build_names: string[];

--- a/src/client/Source_Meta_View.svelte
+++ b/src/client/Source_Meta_View.svelte
@@ -4,9 +4,9 @@
 	import Build_Name from './Build_Name.svelte';
 	import Platform_Name from './Platform_Name.svelte';
 	import {get_metas_by_build_name} from './source_tree.js';
-	import type {Source_Tree} from './source_tree.js';
-	import type {View} from './view.js';
-	import type {Source_Meta} from '../build/source_meta.js';
+	import type {Source_Tree} from 'src/client/source_tree.js';
+	import type {View} from 'src/client/view.js';
+	import type {Source_Meta} from 'src/build/source_meta.js';
 
 	export let source_tree: Source_Tree;
 	export let selected_build_names: string[];

--- a/src/client/View_Name.svelte
+++ b/src/client/View_Name.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type {View} from './view.js';
+	import type {View} from 'src/client/view.js';
 
 	// TODO maybe change this data structure?
 	// just accept a string? class name in a registry? a file path? url?

--- a/src/client/file_tree.ts
+++ b/src/client/file_tree.ts
@@ -2,7 +2,7 @@ import {basename} from 'path';
 import {to_path_segments} from '@feltcoop/felt/util/path_parsing.js';
 import {strip_start} from '@feltcoop/felt/util/string.js';
 
-import type {Source_Tree_Meta} from './source_tree.js';
+import type {Source_Tree_Meta} from 'src/client/source_tree.js';
 
 export type File_Tree_Node = File_Tree_File | File_Tree_Folder;
 

--- a/src/client/project_state.ts
+++ b/src/client/project_state.ts
@@ -1,7 +1,7 @@
 import {setContext, getContext} from 'svelte';
 import type {Writable} from 'svelte/store';
 
-import type {Project_State} from '../server/project_state.js';
+import type {Project_State} from 'src/server/project_state.js';
 
 const context_key = Symbol();
 

--- a/src/client/source_tree.ts
+++ b/src/client/source_tree.ts
@@ -1,7 +1,7 @@
 import {deep_equal} from '@feltcoop/felt/util/equal.js';
 
-import type {Source_Meta, Source_Meta_Build} from '../build/source_meta.js';
-import type {Build_Config, Build_Name} from '../build/build_config.js';
+import type {Source_Meta, Source_Meta_Build} from 'src/build/source_meta.js';
+import type {Build_Config, Build_Name} from 'src/build/build_config.js';
 
 export interface Source_Tree {
 	// readonly children: Source_TreeNode[];

--- a/src/client/test_imports/test_imports.ts
+++ b/src/client/test_imports/test_imports.ts
@@ -1,5 +1,5 @@
 // test lib imports
-import {test_absolute_lib_import} from 'src/lib/test_absolute_lib_import.js';
+import {test_absolute_lib_import} from '$lib/test_absolute_lib_import.js';
 console.log('test_nested_imports test_absolute_lib_import', test_absolute_lib_import);
 
 // test absolute imports

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -12,17 +12,17 @@ import {to_array} from '@feltcoop/felt/util/array.js';
 
 import {paths, to_build_out_path, CONFIG_BUILD_PATH, DIST_DIRNAME} from '../paths.js';
 import {normalize_build_configs, validate_build_configs} from '../build/build_config.js';
-import type {To_Config_Adapters} from '../adapt/adapter.js';
-import type {Build_Config, Build_Config_Partial} from '../build/build_config.js';
+import type {To_Config_Adapters} from 'src/adapt/adapter.js';
+import type {Build_Config, Build_Config_Partial} from 'src/build/build_config.js';
 import {
 	DEFAULT_ECMA_SCRIPT_TARGET,
 	NODE_LIBRARY_BUILD_NAME,
 	CONFIG_BUILD_CONFIG,
 } from '../build/default_build_config.js';
-import type {Ecma_Script_Target} from '../build/ts_build_helpers.js';
-import type {Served_Dir_Partial} from '../build/served_dir.js';
+import type {Ecma_Script_Target} from 'src/build/ts_build_helpers.js';
+import type {Served_Dir_Partial} from 'src/build/served_dir.js';
 import {DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT} from '../server/server.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 import {config as create_default_config} from './gro.config.default.js';
 import type {To_Config_Plugins} from 'src/plugin/plugin.js';
 

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -1,6 +1,6 @@
 import {ENV_LOG_LEVEL, Log_Level} from '@feltcoop/felt/util/log.js';
 
-import type {Gro_Config_Creator, Gro_Config_Partial} from './config.js';
+import type {Gro_Config_Creator, Gro_Config_Partial} from 'src/config/config.js';
 import {
 	has_node_library,
 	NODE_LIBRARY_BUILD_CONFIG,

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -3,7 +3,7 @@ import {spawn} from '@feltcoop/felt/util/process.js';
 import {print_error} from '@feltcoop/felt/util/print.js';
 import {magenta, green, rainbow, red} from '@feltcoop/felt/util/terminal.js';
 
-import type {Task} from './task/task.js';
+import type {Task} from 'src/task/task.js';
 import {DIST_DIR, GIT_DIRNAME, paths, print_path, SVELTEKIT_DIST_DIRNAME} from './paths.js';
 import {BROWSER_BUILD_NAME, GIT_DEPLOY_BRANCH} from './build/default_build_config.js';
 import {clean} from './fs/clean.js';

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -1,15 +1,15 @@
 import {print_timings} from '@feltcoop/felt/util/print.js';
 import {Timings} from '@feltcoop/felt/util/timings.js';
 
-import type {Task} from './task/task.js';
+import type {Task} from 'src/task/task.js';
 import {Filer} from './build/Filer.js';
 import {create_default_builder} from './build/default_builder.js';
 import {paths, to_build_out_path} from './paths.js';
 import {create_gro_server} from './server/server.js';
-import type {Gro_Server} from './server/server.js';
-import type {Gro_Config} from './config/config.js';
+import type {Gro_Server} from 'src/server/server.js';
+import type {Gro_Config} from 'src/config/config.js';
 import {load_config} from './config/config.js';
-import type {Served_Dir_Partial} from './build/served_dir.js';
+import type {Served_Dir_Partial} from 'src/build/served_dir.js';
 import {load_https_credentials} from './server/https.js';
 import {Plugins} from './plugin/plugin.js';
 

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -99,7 +99,7 @@ or a filter function with the signature `(id: string) => boolean`.
 To define filters, it's convenient to use the
 [`createFilter` helper](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createFilter)
 from `@rollup/pluginutils` and
-Gro's own [`createDirectoryFilter` helper](../build/utils.ts).
+Gro's own [`create_directory_filter` helper](../build/utils.ts).
 
 ### `plugin`
 

--- a/src/format.task.ts
+++ b/src/format.task.ts
@@ -1,6 +1,6 @@
 import {print_spawn_result} from '@feltcoop/felt/util/process.js';
 
-import type {Task} from './task/task.js';
+import type {Task} from 'src/task/task.js';
 import {Task_Error} from './task/task.js';
 import {format_directory} from './build/format_directory.js';
 import {paths} from './paths.js';

--- a/src/fs/clean.ts
+++ b/src/fs/clean.ts
@@ -11,7 +11,7 @@ import {
 	SVELTEKIT_VITE_CACHE_PATH,
 	print_path,
 } from '../paths.js';
-import type {Filesystem} from './filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export const clean = async (
 	fs: Filesystem,

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -1,9 +1,9 @@
 import {resolve} from 'path';
 import type {Flavored} from '@feltcoop/felt/util/types.js';
 
-import type {Encoding} from './encoding.js';
-import type {Path_Stats} from './path_data.js';
-import type {Path_Filter} from './path_filter.js';
+import type {Encoding} from 'src/fs/encoding.js';
+import type {Path_Stats} from 'src/fs/path_data.js';
+import type {Path_Filter} from 'src/fs/path_filter.js';
 
 // API is modeled after `fs-extra`: https://github.com/jprichardson/node-fs-extra/
 export interface Filesystem {

--- a/src/fs/input_path.test.ts
+++ b/src/fs/input_path.test.ts
@@ -9,7 +9,7 @@ import {
 	load_source_ids_by_input_path,
 	get_possible_source_ids,
 } from './input_path.js';
-import type {Path_Stats} from './path_data.js';
+import type {Path_Stats} from 'src/fs/path_data.js';
 import {gro_paths, replace_root_dir, create_paths, paths} from '../paths.js';
 import {fs} from './node.js';
 

--- a/src/fs/input_path.ts
+++ b/src/fs/input_path.ts
@@ -9,10 +9,10 @@ import {
 	gro_dir_basename,
 	gro_paths,
 } from '../paths.js';
-import type {Paths} from '../paths.js';
+import type {Paths} from 'src/paths.js';
 import {to_path_data} from './path_data.js';
-import type {Path_Data, Path_Stats} from './path_data.js';
-import type {Filesystem} from './filesystem.js';
+import type {Path_Data, Path_Stats} from 'src/fs/path_data.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 /*
 

--- a/src/fs/memory.ts
+++ b/src/fs/memory.ts
@@ -4,11 +4,11 @@ import {to_path_parts} from '@feltcoop/felt/util/path_parsing.js';
 import {ensure_end, strip_start} from '@feltcoop/felt/util/string.js';
 
 import {to_fs_id, Fs_Stats} from './filesystem.js';
-import type {Filesystem, Fs_Read_File} from './filesystem.js';
-import type {Fs_Copy_Options, Fs_Id, Fs_Move_Options, Fs_Node} from './filesystem';
-import type {Path_Stats} from './path_data.js';
-import type {Path_Filter} from './path_filter.js';
-import type {Encoding} from './encoding.js';
+import type {Filesystem, Fs_Read_File} from 'src/fs/filesystem.js';
+import type {Fs_Copy_Options, Fs_Id, Fs_Move_Options, Fs_Node} from 'src/fs/filesystem';
+import type {Path_Stats} from 'src/fs/path_data.js';
+import type {Path_Filter} from 'src/fs/path_filter.js';
+import type {Encoding} from 'src/fs/encoding.js';
 
 // TODO should this module have a more specific name? or a more specific directory, with all other implementations?
 

--- a/src/fs/modules.ts
+++ b/src/fs/modules.ts
@@ -8,10 +8,10 @@ import {
 	load_source_path_data_by_input_path,
 	load_source_ids_by_input_path,
 } from '../fs/input_path.js';
-import type {Path_Stats, Path_Data} from './path_data.js';
+import type {Path_Stats, Path_Data} from 'src/fs/path_data.js';
 import {to_import_id, paths_from_id, print_path, print_path_or_gro_path} from '../paths.js';
 import {SYSTEM_BUILD_NAME} from '../build/default_build_config.js';
-import type {Filesystem} from './filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 /*
 

--- a/src/fs/node.ts
+++ b/src/fs/node.ts
@@ -2,9 +2,9 @@ import Cheap_Watch from 'cheap-watch';
 import fs_extra from 'fs-extra';
 import {sort_map, compare_simple_map_entries} from '@feltcoop/felt/util/map.js';
 
-import type {Filesystem, Fs_Write_File} from './filesystem.js';
-import type {Path_Stats} from './path_data.js';
-import type {Path_Filter} from './path_filter.js';
+import type {Filesystem, Fs_Write_File} from 'src/fs/filesystem.js';
+import type {Path_Stats} from 'src/fs/path_data.js';
+import type {Path_Filter} from 'src/fs/path_filter.js';
 
 // This uses `Cheap_Watch` which probably isn't the fastest, but it works fine for now.
 // TODO should this API be changed to only include files and not directories?

--- a/src/fs/path_filter.ts
+++ b/src/fs/path_filter.ts
@@ -1,8 +1,8 @@
 import {join} from 'path';
 
 import {paths} from '../paths.js';
-import type {File_Filter} from './file.js';
-import type {Path_Stats} from './path_data.js';
+import type {File_Filter} from 'src/fs/file.js';
+import type {Path_Stats} from 'src/fs/path_data.js';
 
 // This is a subset of the `cheap-watch` types designed for browser compatibility.
 export interface Path_Filter {

--- a/src/fs/watch_node_fs.ts
+++ b/src/fs/watch_node_fs.ts
@@ -2,9 +2,9 @@ import Cheap_Watch from 'cheap-watch';
 import {omit_undefined} from '@feltcoop/felt/util/object.js';
 import type {Partial_Except} from '@feltcoop/felt/util/types.js';
 
-import type {Path_Stats} from './path_data.js';
+import type {Path_Stats} from 'src/fs/path_data.js';
 import {to_path_filter} from './path_filter.js';
-import type {Path_Filter} from './path_filter.js';
+import type {Path_Filter} from 'src/fs/path_filter.js';
 import {load_gitignore_filter} from '../utils/gitignore.js';
 
 /*

--- a/src/gen.task.ts
+++ b/src/gen.task.ts
@@ -3,7 +3,7 @@ import {print_ms, print_error, print_timings} from '@feltcoop/felt/util/print.js
 import {plural} from '@feltcoop/felt/util/string.js';
 import {create_stopwatch, Timings} from '@feltcoop/felt/util/timings.js';
 
-import type {Task} from './task/task.js';
+import type {Task} from 'src/task/task.js';
 import {Task_Error} from './task/task.js';
 import {run_gen} from './gen/run_gen.js';
 import {load_gen_module, check_gen_modules, find_gen_modules} from './gen/gen_module.js';

--- a/src/gen/gen.ts
+++ b/src/gen/gen.ts
@@ -1,7 +1,7 @@
 import type {Logger} from '@feltcoop/felt/util/log';
 import {join, basename, dirname} from 'path';
 
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 import {is_source_id} from '../paths.js';
 
 // TODO consider splitting the primitive data/helpers/types

--- a/src/gen/gen_module.ts
+++ b/src/gen/gen_module.ts
@@ -2,7 +2,7 @@ import {Module_Meta, load_module, Load_Module_Result, find_modules} from '../fs/
 import {Gen, Gen_Results, Gen_File, is_gen_path, GEN_FILE_PATTERN} from './gen.js';
 import {get_possible_source_ids} from '../fs/input_path.js';
 import {paths} from '../paths.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export interface GenModule {
 	gen: Gen;

--- a/src/gen/run_gen.test.ts
+++ b/src/gen/run_gen.test.ts
@@ -3,7 +3,7 @@ import * as t from 'uvu/assert';
 import {resolve, join} from 'path';
 import {Logger} from '@feltcoop/felt/util/log.js';
 
-import type {Gen_Module_Meta} from './gen_module.js';
+import type {Gen_Module_Meta} from 'src/gen/gen_module.js';
 import {run_gen} from './run_gen.js';
 import {fs} from '../fs/node.js';
 

--- a/src/gen/run_gen.ts
+++ b/src/gen/run_gen.ts
@@ -3,7 +3,7 @@ import {print_error} from '@feltcoop/felt/util/print.js';
 import {Timings} from '@feltcoop/felt/util/timings.js';
 import type {Logger} from '@feltcoop/felt/util/log.js';
 
-import type {Gen_Module_Meta} from './gen_module.js';
+import type {Gen_Module_Meta} from 'src/gen/gen_module.js';
 import {
 	Gen_Results,
 	Gen_Module_Result,
@@ -12,7 +12,7 @@ import {
 	Gen_Module_Result_Success,
 	Gen_Module_Result_Failure,
 } from './gen.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 import {print_path} from '../paths.js';
 
 export const run_gen = async (

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -1,7 +1,7 @@
 import {createFilter} from '@rollup/pluginutils';
 import {ENV_LOG_LEVEL, Log_Level} from '@feltcoop/felt/util/log.js';
 
-import type {Gro_Config_Creator, Gro_Config_Partial} from './config/config.js';
+import type {Gro_Config_Creator, Gro_Config_Partial} from 'src/config/config.js';
 import {to_build_out_path} from './paths.js';
 import {BROWSER_BUILD_NAME, NODE_LIBRARY_BUILD_CONFIG} from './build/default_build_config.js';
 

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -1,7 +1,6 @@
 import {createFilter} from '@rollup/pluginutils';
 import {ENV_LOG_LEVEL, Log_Level} from '@feltcoop/felt/util/log.js';
 
-// import {createDirectoryFilter} from './build/utils.js';
 import type {Gro_Config_Creator, Gro_Config_Partial} from './config/config.js';
 import {to_build_out_path} from './paths.js';
 import {BROWSER_BUILD_NAME, NODE_LIBRARY_BUILD_CONFIG} from './build/default_build_config.js';
@@ -34,7 +33,6 @@ export const config: Gro_Config_Creator = async ({dev}) => {
 						name: BROWSER_BUILD_NAME,
 						platform: 'browser',
 						input: ['client/index.ts', createFilter(`**/*.{${ASSET_PATHS.join(',')}}`)],
-						// input: createDirectoryFilter('client'),
 				  }
 				: null,
 		],

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -16,6 +16,7 @@ import {
 	to_source_extension,
 	to_build_base_path,
 	EXTERNALS_BUILD_DIRNAME,
+	build_id_to_source_id,
 } from './paths.js';
 
 /* test_create_paths */
@@ -65,6 +66,16 @@ test_source_id_to_base_path('basic behavior', () => {
 
 test_source_id_to_base_path.run();
 /* /test_source_id_to_base_path */
+
+/* test_build_id_to_source_id */
+const test_build_id_to_source_id = suite('build_id_to_source_id');
+
+test_build_id_to_source_id('basic behavior', () => {
+	t.is(build_id_to_source_id(resolve('.gro/dev/somebuild/foo/bar.js')), resolve('src/foo/bar.ts'));
+});
+
+test_build_id_to_source_id.run();
+/* /test_build_id_to_source_id */
 
 /* test_base_path_to_source_id */
 const test_base_path_to_source_id = suite('base_path_to_source_id');

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -4,7 +4,7 @@ import {replace_extension, strip_trailing_slash} from '@feltcoop/felt/util/path.
 import {strip_start} from '@feltcoop/felt/util/string.js';
 import {gray} from '@feltcoop/felt/util/terminal.js';
 
-import type {Build_Name} from './build/build_config.js';
+import type {Build_Name} from 'src/build/build_config.js';
 
 /*
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -96,6 +96,12 @@ export const to_root_path = (id: string, p = paths): string => strip_start(id, p
 export const source_id_to_base_path = (source_id: string, p = paths): string =>
 	strip_start(source_id, p.source);
 
+// '/home/me/app/.gro/[prod|dev]/build_name/foo/bar/baz.js' → '/home/me/app/src/foo/bar/baz.ts'
+export const build_id_to_source_id = (build_id: string, build_dir = paths.build): string => {
+	const base_path = to_build_base_path(build_id, build_dir);
+	return base_path_to_source_id(to_source_extension(base_path));
+};
+
 // 'foo/bar/baz.ts' → '/home/me/app/src/foo/bar/baz.ts'
 export const base_path_to_source_id = (base_path: string, p = paths): string =>
 	`${p.source}${base_path}`;

--- a/src/plugin/gro_plugin_api_server.ts
+++ b/src/plugin/gro_plugin_api_server.ts
@@ -2,7 +2,7 @@ import {EMPTY_OBJECT} from '@feltcoop/felt/util/object.js';
 import type {Restartable_Process} from '@feltcoop/felt/util/process.js';
 import {spawn_restartable_process} from '@feltcoop/felt/util/process.js';
 
-import type {Plugin} from './plugin.js';
+import type {Plugin} from 'src/plugin/plugin.js';
 import type {Args} from 'src/task/task.js';
 import {API_SERVER_BUILD_BASE_PATH, API_SERVER_BUILD_NAME} from '../build/default_build_config.js';
 import {to_build_out_dir} from '../paths.js';

--- a/src/plugin/gro_plugin_sveltekit_frontend.ts
+++ b/src/plugin/gro_plugin_sveltekit_frontend.ts
@@ -2,8 +2,8 @@ import type {Spawned_Process} from '@feltcoop/felt/util/process.js';
 import {spawn, spawn_process} from '@feltcoop/felt/util/process.js';
 import {EMPTY_OBJECT} from '@feltcoop/felt/util/object.js';
 
-import type {Plugin} from './plugin.js';
-import type {Args} from '../task/task.js';
+import type {Plugin} from 'src/plugin/plugin.js';
+import type {Args} from 'src/task/task.js';
 
 export interface Options {}
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1,8 +1,8 @@
 import {to_array} from '@feltcoop/felt/util/array.js';
 import type {Timings} from '@feltcoop/felt/util/timings.js';
 
-import type {Task_Context} from '../task/task.js';
-import type {Gro_Config} from '../config/config.js';
+import type {Task_Context} from 'src/task/task.js';
+import type {Gro_Config} from 'src/config/config.js';
 import type {Filer} from 'src/build/Filer.js';
 
 /*

--- a/src/publish.task.ts
+++ b/src/publish.task.ts
@@ -5,10 +5,10 @@ import type {Logger} from '@feltcoop/felt/util/log.js';
 import {Unreachable_Error} from '@feltcoop/felt/util/error.js';
 import type {Flavored, Result} from '@feltcoop/felt/util/types.js';
 
-import type {Task} from './task/task.js';
+import type {Task} from 'src/task/task.js';
 import {load_package_json} from './utils/package_json.js';
 import {GIT_DEPLOY_BRANCH} from './build/default_build_config.js';
-import type {Filesystem} from './fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 import {load_config} from './config/config.js';
 import {build_source} from './build/build_source.js';
 import {clean} from './fs/clean.js';

--- a/src/serve.task.ts
+++ b/src/serve.task.ts
@@ -1,8 +1,8 @@
-import type {Task} from './task/task.js';
+import type {Task} from 'src/task/task.js';
 import {create_gro_server, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT} from './server/server.js';
 import {Filer} from './build/Filer.js';
 import {load_https_credentials} from './server/https.js';
-import type {Served_Dir_Partial} from './build/served_dir.js';
+import type {Served_Dir_Partial} from 'src/build/served_dir.js';
 
 export interface Task_Args {
 	_: string[];

--- a/src/server/https.ts
+++ b/src/server/https.ts
@@ -2,7 +2,7 @@ import {join} from 'path';
 import {to_env_string} from '@feltcoop/felt/util/env.js';
 import type {Logger} from '@feltcoop/felt/util/log.js';
 
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export interface HttpsCredentials {
 	cert: string;

--- a/src/server/project_state.ts
+++ b/src/server/project_state.ts
@@ -1,6 +1,6 @@
-import type {Source_Meta} from '../build/source_meta.js';
-import type {Build_Config} from '../build/build_config.js';
-import type {Package_Json} from '../utils/package_json.js';
+import type {Source_Meta} from 'src/build/source_meta.js';
+import type {Build_Config} from 'src/build/build_config.js';
+import type {Package_Json} from 'src/utils/package_json.js';
 
 // TODO rename?
 // Project_State (current)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -16,18 +16,18 @@ import {omit_undefined} from '@feltcoop/felt/util/object.js';
 import type {Assignable, Partial_Except} from '@feltcoop/felt/util/types.js';
 import {to_env_number, to_env_string} from '@feltcoop/felt/util/env.js';
 
-import type {Filer} from '../build/Filer.js';
+import type {Filer} from 'src/build/Filer.js';
 import {
 	get_file_mime_type,
 	get_file_content_buffer,
 	get_file_stats,
 	get_file_content_hash,
 } from '../build/filer_file.js';
-import type {Base_Filer_File} from '../build/filer_file.js';
+import type {Base_Filer_File} from 'src/build/filer_file.js';
 import {paths} from '../paths.js';
 import {load_package_json} from '../utils/package_json.js';
-import type {Project_State} from './project_state.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Project_State} from 'src/server/project_state.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 type Http2StreamHandler = (
 	stream: ServerHttp2Stream,

--- a/src/task/README.md
+++ b/src/task/README.md
@@ -241,7 +241,7 @@ Here's how a task can emit and listen to events:
 // src/some/mytask.task.ts
 import type {Task} from '@feltcoop/gro';
 
-import type {Task_Events as Other_Task_Events} from './othertask.task.ts';
+import type {Task_Events as Other_Task_Events} from 'src/task/othertask.task.ts';
 
 export interface Task_Args {}
 export interface Task_Events extends Other_Task_Events {

--- a/src/task/fixtures/test_task_module.task_fixture.ts
+++ b/src/task/fixtures/test_task_module.task_fixture.ts
@@ -1,4 +1,4 @@
-import type {Task} from '../task.js';
+import type {Task} from 'src/task/task.js';
 
 export const task: Task = {
 	summary: 'a test task for basic task behavior',

--- a/src/task/invoke_task.ts
+++ b/src/task/invoke_task.ts
@@ -5,7 +5,7 @@ import {create_stopwatch, Timings} from '@feltcoop/felt/util/timings.js';
 import {print_ms, print_timings} from '@feltcoop/felt/util/print.js';
 import {plural} from '@feltcoop/felt/util/string.js';
 
-import type {Args} from './task.js';
+import type {Args} from 'src/task/task.js';
 import {run_task} from './run_task.js';
 import {resolve_raw_input_path, get_possible_source_ids} from '../fs/input_path.js';
 import {TASK_FILE_SUFFIX, is_task_path, to_task_name} from './task.js';
@@ -25,7 +25,7 @@ import {find_modules, load_modules} from '../fs/modules.js';
 import {load_task_module} from './task_module.js';
 import {load_gro_package_json} from '../utils/package_json.js';
 import {SYSTEM_BUILD_NAME} from '../build/default_build_config.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 /*
 

--- a/src/task/run_task.ts
+++ b/src/task/run_task.ts
@@ -2,11 +2,11 @@ import type {EventEmitter} from 'events';
 import {cyan, red} from '@feltcoop/felt/util/terminal.js';
 import {print_log_label, System_Logger} from '@feltcoop/felt/util/log.js';
 
-import type {Task_Module_Meta} from './task_module.js';
-import type {Args} from './task.js';
+import type {Task_Module_Meta} from 'src/task/task_module.js';
+import type {Args} from 'src/task/task.js';
 import {Task_Error} from './task.js';
-import type {invoke_task as Invoke_Task_Function} from './invoke_task.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {invoke_task as Invoke_Task_Function} from 'src/task/invoke_task.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export type Run_Task_Result =
 	| {

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -2,7 +2,7 @@ import type StrictEventEmitter from 'strict-event-emitter-types';
 import type {EventEmitter} from 'events';
 import type {Logger} from '@feltcoop/felt/util/log.js';
 
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export interface Task<T_Args = Args, T_Events = {}> {
 	run: (ctx: Task_Context<T_Args, T_Events>) => Promise<unknown>; // TODO return value (make generic, forward it..how?)

--- a/src/task/task_module.ts
+++ b/src/task/task_module.ts
@@ -1,10 +1,10 @@
 import {source_id_to_base_path, paths, paths_from_id} from '../paths.js';
 import {load_module, load_modules, find_modules} from '../fs/modules.js';
-import type {Module_Meta, Load_Module_Result} from '../fs/modules.js';
+import type {Module_Meta, Load_Module_Result} from 'src/fs/modules.js';
 import {to_task_name, is_task_path, TASK_FILE_SUFFIX} from './task.js';
-import type {Task} from './task.js';
+import type {Task} from 'src/task/task.js';
 import {get_possible_source_ids} from '../fs/input_path.js';
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 
 export interface TaskModule {
 	task: Task;

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -2,7 +2,7 @@ import {print_timings} from '@feltcoop/felt/util/print.js';
 import {Timings} from '@feltcoop/felt/util/timings.js';
 import {spawn} from '@feltcoop/felt/util/process.js';
 
-import type {Task} from './task/task.js';
+import type {Task} from 'src/task/task.js';
 import {Task_Error} from './task/task.js';
 import {to_build_out_path, to_root_path} from './paths.js';
 import {SYSTEM_BUILD_NAME} from './build/default_build_config.js';

--- a/src/typecheck.task.ts
+++ b/src/typecheck.task.ts
@@ -1,6 +1,6 @@
 import {print_spawn_result, spawn} from '@feltcoop/felt/util/process.js';
 
-import type {Task} from './task/task.js';
+import type {Task} from 'src/task/task.js';
 import {Task_Error} from './task/task.js';
 
 export const task: Task = {

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -8,7 +8,7 @@ import {
 	NODE_MODULES_DIRNAME,
 	SVELTEKIT_DEV_DIRNAME,
 } from '../paths.js';
-import type {File_Filter} from '../fs/file.js';
+import type {File_Filter} from 'src/fs/file.js';
 
 /*
 

--- a/src/utils/package_json.ts
+++ b/src/utils/package_json.ts
@@ -1,7 +1,7 @@
 import {join} from 'path';
 import type {Json} from '@feltcoop/felt/util/json.js';
 
-import type {Filesystem} from '../fs/filesystem.js';
+import type {Filesystem} from 'src/fs/filesystem.js';
 import {paths, gro_paths, is_this_project_gro} from '../paths.js';
 
 // This is a single entrypoint for getting the `package.json` of both the current project and Gro.


### PR DESCRIPTION
Isn't a permanent fix, but cleans up the `dist/` directories of Gro frontend builds.

Also switches to absolute type path imports internally.