### PR TITLE
rename id filters and add filter option to gro frontend adapter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
   ([#243](https://github.com/feltcoop/gro/pull/243))
 - **break**: rename builders and builder utils
   ([#244](https://github.com/feltcoop/gro/pull/244))
+- **break**: merge `fs/path_filter.ts` and `fs/file.ts` into `fs/filter.ts`,
+  rename `Id_Filter` from `File_Filter`, and add `Id_Stats_Filter`
+  ([#246](https://github.com/feltcoop/gro/pull/246))
 - ignore unwanted assets in frontend build
   ([#242](https://github.com/feltcoop/gro/pull/242))
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,8 @@
   rename `Id_Filter` from `File_Filter`, and add `Id_Stats_Filter`
   ([#246](https://github.com/feltcoop/gro/pull/246))
 - ignore unwanted assets in frontend build
-  ([#242](https://github.com/feltcoop/gro/pull/242))
+  ([#242](https://github.com/feltcoop/gro/pull/242),
+  [#246](https://github.com/feltcoop/gro/pull/246))
 
 ## 0.32.1
 

--- a/src/adapt/gro_adapter_gro_frontend.ts
+++ b/src/adapt/gro_adapter_gro_frontend.ts
@@ -12,7 +12,7 @@ import {print_build_config_label, to_input_files} from '../build/build_config.js
 import type {Build_Name} from 'src/build/build_config.js';
 import type {Host_Target} from 'src/adapt/utils.js';
 import {copy_dist, ensure_nojekyll} from './utils.js';
-import {BROWSER_BUILD_NAME, non_asset_extensions} from '../build/default_build_config.js';
+import {BROWSER_BUILD_NAME, default_non_asset_extensions} from '../build/default_build_config.js';
 import type {Id_Stats_Filter} from 'src/fs/filter.js';
 
 export interface Options {
@@ -22,8 +22,6 @@ export interface Options {
 	host_target: Host_Target;
 	filter: Id_Stats_Filter;
 }
-
-const default_filter: Id_Stats_Filter = (id) => !non_asset_extensions.has(extname(id));
 
 export const create_adapter = ({
 	build_name = BROWSER_BUILD_NAME,
@@ -99,3 +97,5 @@ export const create_adapter = ({
 		},
 	};
 };
+
+const default_filter: Id_Stats_Filter = (id) => !default_non_asset_extensions.has(extname(id));

--- a/src/adapt/utils.ts
+++ b/src/adapt/utils.ts
@@ -4,7 +4,7 @@ import {strip_end, strip_start} from '@feltcoop/felt/util/string.js';
 
 import type {Build_Config} from 'src/build/build_config.js';
 import type {Filesystem} from 'src/fs/filesystem.js';
-import type {Path_Stats} from 'src/fs/path_data.js';
+import type {Id_Stats_Filter} from 'src/fs/filter.js';
 import {
 	EXTERNALS_BUILD_DIRNAME,
 	to_build_base_path,
@@ -22,7 +22,7 @@ export const copy_dist = async (
 	dev: boolean,
 	dist_out_dir: string,
 	log: Logger,
-	filter?: (id: string, stats: Path_Stats) => boolean,
+	filter?: Id_Stats_Filter,
 	pack: boolean = true, // TODO reconsider this API, see `gro_adapter_node_library`
 	rebase_path: string = '',
 ): Promise<void> => {
@@ -31,7 +31,7 @@ export const copy_dist = async (
 	log.info(`copying ${print_path(build_out_dir)} to ${print_path(dist_out_dir)}`);
 	const typemap_files: string[] = [];
 	await fs.copy(build_out_dir, dist_out_dir, {
-		// overwrite: false, // TODO this is correct, right?
+		overwrite: false,
 		filter: async (id) => {
 			if (id === externals_dir) return false;
 			const stats = await fs.stat(id);

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -54,7 +54,7 @@ import {
 	clean_source_meta,
 	init_source_meta,
 } from './source_meta.js';
-import type {Path_Filter} from 'src/fs/path_filter.js';
+import type {Path_Filter} from 'src/fs/filter.js';
 
 /*
 

--- a/src/build/default_build_config.ts
+++ b/src/build/default_build_config.ts
@@ -82,7 +82,9 @@ export const to_default_browser_build = (
 
 // compute default asset extensions on demand to pick up any changes to the supported MIME types
 const to_default_asset_extensions = (): string[] =>
-	Array.from(get_extensions()).filter((extension) => !default_non_asset_extensions.has(extension));
+	Array.from(get_extensions()).filter(
+		(extension) => !default_non_asset_extensions.has(`.${extension}`),
+	);
 
 export const default_non_asset_extensions = new Set([
 	JS_EXTENSION,

--- a/src/build/default_build_config.ts
+++ b/src/build/default_build_config.ts
@@ -82,12 +82,11 @@ export const to_default_browser_build = (
 
 // compute default asset extensions on demand to pick up any changes to the supported MIME types
 const to_default_asset_extensions = (): string[] =>
-	Array.from(get_extensions()).filter((extension) => !non_asset_extensions.has(extension));
+	Array.from(get_extensions()).filter((extension) => !default_non_asset_extensions.has(extension));
 
-export const non_asset_extensions = new Set([
+export const default_non_asset_extensions = new Set([
 	JS_EXTENSION,
 	JSON_EXTENSION,
-	// these aren't currently included as MIME types, but that could change in the future
 	TS_EXTENSION,
 	SVELTE_EXTENSION,
 ]);

--- a/src/build/filer_dir.ts
+++ b/src/build/filer_dir.ts
@@ -3,7 +3,7 @@ import {noop} from '@feltcoop/felt/util/function.js';
 import {watch_node_fs} from '../fs/watch_node_fs.js';
 import type {Watch_Node_Fs} from 'src/fs/watch_node_fs.js';
 import type {Path_Stats} from 'src/fs/path_data.js';
-import type {Path_Filter} from 'src/fs/path_filter.js';
+import type {Path_Filter} from 'src/fs/filter.js';
 import type {Filesystem} from 'src/fs/filesystem.js';
 
 // Buildable filer dirs are watched, built, and written to disk.

--- a/src/fs/file.ts
+++ b/src/fs/file.ts
@@ -1,5 +1,0 @@
-// TODO
-
-export interface File_Filter {
-	(id: string): boolean;
-}

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -3,7 +3,7 @@ import type {Flavored} from '@feltcoop/felt/util/types.js';
 
 import type {Encoding} from 'src/fs/encoding.js';
 import type {Path_Stats} from 'src/fs/path_data.js';
-import type {Path_Filter} from 'src/fs/path_filter.js';
+import type {Path_Filter} from 'src/fs/filter.js';
 
 // API is modeled after `fs-extra`: https://github.com/jprichardson/node-fs-extra/
 export interface Filesystem {

--- a/src/fs/filter.ts
+++ b/src/fs/filter.ts
@@ -1,7 +1,6 @@
 import {join} from 'path';
 
 import {paths} from '../paths.js';
-import type {File_Filter} from 'src/fs/file.js';
 import type {Path_Stats} from 'src/fs/path_data.js';
 
 // This is a subset of the `cheap-watch` types designed for browser compatibility.
@@ -10,6 +9,14 @@ export interface Path_Filter {
 }
 
 export const to_path_filter =
-	(exclude: File_Filter, root = paths.root): Path_Filter =>
-	({path}) =>
-		!exclude(join(root, path));
+	(exclude: Id_Stats_Filter, root = paths.root): Path_Filter =>
+	({path, stats}) =>
+		!exclude(join(root, path), stats);
+
+export interface Id_Stats_Filter {
+	(id: string, stats: Path_Stats): boolean;
+}
+
+export interface Id_Filter {
+	(id: string): boolean;
+}

--- a/src/fs/memory.ts
+++ b/src/fs/memory.ts
@@ -7,7 +7,7 @@ import {to_fs_id, Fs_Stats} from './filesystem.js';
 import type {Filesystem, Fs_Read_File} from 'src/fs/filesystem.js';
 import type {Fs_Copy_Options, Fs_Id, Fs_Move_Options, Fs_Node} from 'src/fs/filesystem';
 import type {Path_Stats} from 'src/fs/path_data.js';
-import type {Path_Filter} from 'src/fs/path_filter.js';
+import type {Path_Filter} from 'src/fs/filter.js';
 import type {Encoding} from 'src/fs/encoding.js';
 
 // TODO should this module have a more specific name? or a more specific directory, with all other implementations?

--- a/src/fs/mime.ts
+++ b/src/fs/mime.ts
@@ -1,5 +1,7 @@
 import type {Flavored} from '@feltcoop/felt/util/types';
 
+// TODO the `extensions` here do not have a leading dot, but elsewhere in Gro they do!
+
 /*
 
 This is a minimal set of MIME types

--- a/src/fs/node.ts
+++ b/src/fs/node.ts
@@ -4,7 +4,7 @@ import {sort_map, compare_simple_map_entries} from '@feltcoop/felt/util/map.js';
 
 import type {Filesystem, Fs_Write_File} from 'src/fs/filesystem.js';
 import type {Path_Stats} from 'src/fs/path_data.js';
-import type {Path_Filter} from 'src/fs/path_filter.js';
+import type {Path_Filter} from 'src/fs/filter.js';
 
 // This uses `Cheap_Watch` which probably isn't the fastest, but it works fine for now.
 // TODO should this API be changed to only include files and not directories?

--- a/src/fs/watch_node_fs.ts
+++ b/src/fs/watch_node_fs.ts
@@ -3,8 +3,8 @@ import {omit_undefined} from '@feltcoop/felt/util/object.js';
 import type {Partial_Except} from '@feltcoop/felt/util/types.js';
 
 import type {Path_Stats} from 'src/fs/path_data.js';
-import {to_path_filter} from './path_filter.js';
-import type {Path_Filter} from 'src/fs/path_filter.js';
+import {to_path_filter} from './filter.js';
+import type {Path_Filter} from 'src/fs/filter.js';
 import {load_gitignore_filter} from '../utils/gitignore.js';
 
 /*

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -8,7 +8,7 @@ import {
 	NODE_MODULES_DIRNAME,
 	SVELTEKIT_DEV_DIRNAME,
 } from '../paths.js';
-import type {File_Filter} from 'src/fs/file.js';
+import type {Id_Filter} from 'src/fs/filter.js';
 
 /*
 
@@ -18,7 +18,7 @@ If we need support for Gro simultaneously, see ./package_json.ts as an example.
 
 */
 
-let filter: File_Filter | null = null;
+let filter: Id_Filter | null = null;
 
 const DEFAULT_IGNORED_PATHS = [
 	GIT_DIRNAME,
@@ -28,7 +28,7 @@ const DEFAULT_IGNORED_PATHS = [
 ];
 
 // TODO need some mapping to match gitignore behavior correctly with nested directories
-export const load_gitignore_filter = (force_refresh = false): File_Filter => {
+export const load_gitignore_filter = (force_refresh = false): Id_Filter => {
 	if (force_refresh) filter = null;
 	if (filter) return filter;
 	let lines: string[];


### PR DESCRIPTION
Consolidates and renames some filesystem filters and adds an optional filter to `gro_adapter_gro_frontend`. We can't know which Rollup plugins a user project may add, so we just expose the filter in the adapter to override the defaults.