### PR TITLE
improve type matcher regexp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - forward args to `svelte-kit dev` and `svelte-kit build`
   ([#254](https://github.com/feltcoop/gro/pull/254))
+- improve type matcher regexp
+  ([#253](https://github.com/feltcoop/gro/pull/253))
 
 ## 0.34.1
 

--- a/src/build/postprocess.ts
+++ b/src/build/postprocess.ts
@@ -242,9 +242,22 @@ const to_relative_specifier_trimmed_by = (
 	return specifier;
 };
 
+/*
+
+TODO this fails on some input:
+
+export declare type Async_Status = 'initial' | 'pending' | 'success' | 'failure';
+const a = "from './array'";
+
+Some possible improvements:
+
+- add some negating condition to `[\s\S]*?` -- maybe a semicolon should break it?
+- expect a semicolon
+
+*/
 const parse_type_dependencies = (content: string, handle_specifier: Handle_Specifier): void => {
 	for (const matches of content.matchAll(
-		/(import\s+type|export)\s[\s\S]*?from\s*['|"|\`](.+)['|"|\`]/gm,
+		/(import\s+type|export)[\s\S]*?from\s*['|"|\`](.+)['|"|\`]/gm,
 	)) {
 		handle_specifier(matches[2]);
 	}


### PR DESCRIPTION
Trying to improve the type import/export regexp to catch weird corner cases. We can't assume that e.g. Svelte files are formatted.

Merging this, but not too happy with the regexp as is -- I guess we'll revisit if something breaks!