### PR TITLE
forward sveltekit args

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.34.2
+
+- forward args to `svelte-kit dev` and `svelte-kit build`
+  ([#254](https://github.com/feltcoop/gro/pull/254))
+
 ## 0.34.1
 
 - fix type publishing

--- a/src/plugin/gro_plugin_sveltekit_frontend.ts
+++ b/src/plugin/gro_plugin_sveltekit_frontend.ts
@@ -9,6 +9,13 @@ export interface Options {}
 
 export interface Task_Args extends Args {
 	watch?: boolean;
+	// `svelte-kit dev` and `svelte-kit preview` args
+	port?: number;
+	open?: boolean;
+	host?: string;
+	https?: boolean;
+	// `svelte-kit build` args
+	verbose?: boolean;
 }
 
 const name = '@feltcoop/gro_adapter_sveltekit_frontend';
@@ -20,7 +27,7 @@ export const create_plugin = ({}: Partial<Options> = EMPTY_OBJECT): Plugin<Task_
 		setup: async ({dev, args, log}) => {
 			if (dev) {
 				if (args.watch) {
-					sveltekit_process = spawn_process('npx', ['svelte-kit', 'dev']);
+					sveltekit_process = spawn_process('npx', to_sveltekit_args('dev', args));
 				} else {
 					log.warn(
 						`${name} is loaded but will not output anything` +
@@ -28,7 +35,7 @@ export const create_plugin = ({}: Partial<Options> = EMPTY_OBJECT): Plugin<Task_
 					);
 				}
 			} else {
-				await spawn('npx', ['svelte-kit', 'build']);
+				await spawn('npx', to_sveltekit_args('build', args));
 			}
 		},
 		teardown: async () => {
@@ -38,4 +45,28 @@ export const create_plugin = ({}: Partial<Options> = EMPTY_OBJECT): Plugin<Task_
 			}
 		},
 	};
+};
+
+const to_sveltekit_args = (command: 'dev' | 'build', args: Task_Args): string[] => {
+	const sveltekit_args = ['svelte-kit', command];
+	if (command === 'dev') {
+		if (args.port) {
+			console.log('ARGS', args.port, typeof args.port);
+			sveltekit_args.push('--port', args.port.toString());
+		}
+		if (args.open) {
+			sveltekit_args.push('--open');
+		}
+		if (args.host) {
+			sveltekit_args.push('--host', args.host);
+		}
+		if (args.https) {
+			sveltekit_args.push('--https');
+		}
+	} else if (command === 'build') {
+		if (args.verbose) {
+			sveltekit_args.push('--verbose');
+		}
+	}
+	return sveltekit_args;
 };

--- a/src/plugin/gro_plugin_sveltekit_frontend.ts
+++ b/src/plugin/gro_plugin_sveltekit_frontend.ts
@@ -47,9 +47,9 @@ export const create_plugin = ({}: Partial<Options> = EMPTY_OBJECT): Plugin<Task_
 	};
 };
 
-const to_sveltekit_args = (command: 'dev' | 'build', args: Task_Args): string[] => {
+const to_sveltekit_args = (command: 'dev' | 'build' | 'preview', args: Task_Args): string[] => {
 	const sveltekit_args = ['svelte-kit', command];
-	if (command === 'dev') {
+	if (command === 'dev' || command === 'preview') {
 		if (args.port) {
 			sveltekit_args.push('--port', args.port.toString());
 		}

--- a/src/plugin/gro_plugin_sveltekit_frontend.ts
+++ b/src/plugin/gro_plugin_sveltekit_frontend.ts
@@ -51,7 +51,6 @@ const to_sveltekit_args = (command: 'dev' | 'build', args: Task_Args): string[] 
 	const sveltekit_args = ['svelte-kit', command];
 	if (command === 'dev') {
 		if (args.port) {
-			console.log('ARGS', args.port, typeof args.port);
 			sveltekit_args.push('--port', args.port.toString());
 		}
 		if (args.open) {


### PR DESCRIPTION
Makes `gro dev` and `gro build` forward SvelteKit args to the `svelte-kit` CLI command in the plugin.