### PR TITLE
clean during build

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.34.3
+
+- clean during `gro build` except when invoked by `gro publish` and `gro deploy`
+  ([#255](https://github.com/feltcoop/gro/pull/255))
+
 ## 0.34.2
 
 - forward args to `svelte-kit dev` and `svelte-kit build`

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -8,7 +8,7 @@ import type {Gro_Config} from 'src/config/config.js';
 import {adapt} from './adapt/adapt.js';
 import {build_source} from './build/build_source.js';
 import {Plugins} from './plugin/plugin.js';
-import {clean} from './fs/clean.js';
+import {clean_fs} from './fs/clean.js';
 
 export interface Task_Args {
 	clean?: boolean;
@@ -30,12 +30,12 @@ export const task: Task<Task_Args, Task_Events> = {
 
 		const timings = new Timings(); // TODO belongs in ctx
 
-		const {clean: should_clean = true} = args;
+		const {clean = true} = args;
 
 		// Clean in the default case, but *not* for `gro publish` and `gro deploy`,
 		// because they call clean themselves first.
-		if (should_clean) {
-			await clean(fs, {build_prod: true}, log);
+		if (clean) {
+			await clean_fs(fs, {build_prod: true}, log);
 		}
 
 		// TODO delete prod builds (what about config/system tho?)

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -1,15 +1,18 @@
 import {Timings} from '@feltcoop/felt/util/timings.js';
 import {print_timings} from '@feltcoop/felt/util/print.js';
 
-import type {Task, Args} from 'src/task/task.js';
+import type {Task} from 'src/task/task.js';
 import type {Map_Input_Options, Map_Output_Options, Map_Watch_Options} from 'src/build/rollup.js';
 import {load_config} from './config/config.js';
 import type {Gro_Config} from 'src/config/config.js';
 import {adapt} from './adapt/adapt.js';
 import {build_source} from './build/build_source.js';
 import {Plugins} from './plugin/plugin.js';
+import {clean} from './fs/clean.js';
 
-export interface Task_Args extends Args {
+export interface Task_Args {
+	clean?: boolean;
+	'no-clean'?: boolean;
 	map_input_options?: Map_Input_Options;
 	map_output_options?: Map_Output_Options;
 	map_watch_options?: Map_Watch_Options;
@@ -23,9 +26,17 @@ export const task: Task<Task_Args, Task_Events> = {
 	summary: 'build the project',
 	dev: false,
 	run: async (ctx): Promise<void> => {
-		const {fs, dev, log, events} = ctx;
+		const {fs, dev, log, events, args} = ctx;
 
 		const timings = new Timings(); // TODO belongs in ctx
+
+		const {clean: should_clean = true} = args;
+
+		// Clean in the default case, but *not* for `gro publish` and `gro deploy`,
+		// because they call clean themselves first.
+		if (should_clean) {
+			await clean(fs, {build_prod: true}, log);
+		}
 
 		// TODO delete prod builds (what about config/system tho?)
 

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -32,8 +32,8 @@ export const task: Task<Task_Args, Task_Events> = {
 
 		const {clean = true} = args;
 
-		// Clean in the default case, but *not* for `gro publish` and `gro deploy`,
-		// because they call clean themselves first.
+		// Clean in the default case, but not if the caller passes a `false` `clean` arg,
+		// This is used by `gro publish` and `gro deploy` because they call `clean_fs` themselves.
 		if (clean) {
 			await clean_fs(fs, {build_prod: true}, log);
 		}

--- a/src/clean.task.ts
+++ b/src/clean.task.ts
@@ -1,7 +1,7 @@
 import {spawn} from '@feltcoop/felt/util/process.js';
 
 import type {Task} from 'src/task/task.js';
-import {clean} from './fs/clean.js';
+import {clean_fs} from './fs/clean.js';
 
 export interface Task_Args {
 	build?: boolean; // !`/.gro`
@@ -20,7 +20,7 @@ export const task: Task<Task_Args> = {
 	summary: 'remove temporary dev and build files, and optionally prune git branches',
 	run: async ({fs, log, args}): Promise<void> => {
 		// TODO document with mdsvex
-		await clean(
+		await clean_fs(
 			fs,
 			{
 				build: !args.build,

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -3,7 +3,7 @@ import {spawn} from '@feltcoop/felt/util/process.js';
 import {print_error} from '@feltcoop/felt/util/print.js';
 import {magenta, green, rainbow, red} from '@feltcoop/felt/util/terminal.js';
 
-import type {Task} from 'src/task/task.js';
+import type {Args, Task} from 'src/task/task.js';
 import {DIST_DIR, GIT_DIRNAME, paths, print_path, SVELTEKIT_DIST_DIRNAME} from './paths.js';
 import {BROWSER_BUILD_NAME, GIT_DEPLOY_BRANCH} from './build/build_config_defaults.js';
 import {clean} from './fs/clean.js';
@@ -17,7 +17,7 @@ import {clean} from './fs/clean.js';
 // terminal command to clean up while live testing:
 // gro deploy --clean && gro clean -b && gb -D deploy && git push origin :deploy
 
-export interface Task_Args {
+export interface Task_Args extends Args {
 	dirname?: string; // defaults to detecting 'svelte-kit' | 'browser'
 	branch?: string; // optional branch to deploy from; defaults to 'main'
 	dry?: boolean;
@@ -100,7 +100,7 @@ export const task: Task<Task_Args> = {
 
 		try {
 			// Run the build.
-			await invoke_task('build');
+			await invoke_task('build', {...args, clean: false});
 
 			// After the build is ready, set the deployed directory, inferring as needed.
 			if (dirname !== undefined) {

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -6,7 +6,7 @@ import {magenta, green, rainbow, red} from '@feltcoop/felt/util/terminal.js';
 import type {Args, Task} from 'src/task/task.js';
 import {DIST_DIR, GIT_DIRNAME, paths, print_path, SVELTEKIT_DIST_DIRNAME} from './paths.js';
 import {BROWSER_BUILD_NAME, GIT_DEPLOY_BRANCH} from './build/build_config_defaults.js';
-import {clean} from './fs/clean.js';
+import {clean_fs} from './fs/clean.js';
 
 // docs at ./docs/deploy.md
 
@@ -89,7 +89,7 @@ export const task: Task<Task_Args> = {
 		log.info(magenta('↑↑↑↑↑↑↑'), green('ignore any errors in here'), magenta('↑↑↑↑↑↑↑'));
 
 		// Get ready to build from scratch.
-		await clean(fs, {build_prod: true}, log);
+		await clean_fs(fs, {build_prod: true}, log);
 
 		if (clean_and_exit) {
 			log.info(rainbow('all clean'));

--- a/src/fs/clean.ts
+++ b/src/fs/clean.ts
@@ -13,7 +13,7 @@ import {
 } from '../paths.js';
 import type {Filesystem} from 'src/fs/filesystem.js';
 
-export const clean = async (
+export const clean_fs = async (
 	fs: Filesystem,
 	{
 		build = false,

--- a/src/publish.task.ts
+++ b/src/publish.task.ts
@@ -68,7 +68,7 @@ export const task: Task<Task_Args> = {
 		}
 
 		// Build to create the final artifacts:
-		await invoke_task('build');
+		await invoke_task('build', {...args, clean: false});
 
 		if (dry) {
 			log.info({version_increment, publish: config.publish, branch});

--- a/src/publish.task.ts
+++ b/src/publish.task.ts
@@ -11,7 +11,7 @@ import {GIT_DEPLOY_BRANCH} from './build/build_config_defaults.js';
 import type {Filesystem} from 'src/fs/filesystem.js';
 import {load_config} from './config/config.js';
 import {build_source} from './build/build_source.js';
-import {clean} from './fs/clean.js';
+import {clean_fs} from './fs/clean.js';
 
 // publish.task.ts
 // - usage: `gro publish patch`
@@ -48,7 +48,7 @@ export const task: Task<Task_Args> = {
 		await spawn('git', ['checkout', branch]);
 
 		// Clean before loading the config:
-		await clean(fs, {build_prod: true}, log);
+		await clean_fs(fs, {build_prod: true}, log);
 
 		const config = await load_config(fs, dev);
 		if (config.publish === null) {

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -10,17 +10,13 @@ import {SYSTEM_BUILD_NAME} from './build/build_config_defaults.js';
 import {load_config} from './config/config.js';
 import {build_source} from './build/build_source.js';
 
-export interface Task_Args {
-	_: string[];
-}
-
 // Runs the project's tests: `gro test [...args]`
 // Args are passed through directly to `uvu`'s CLI:
 // https://github.com/lukeed/uvu/blob/master/docs/cli.md
 
 const DEFAULT_TEST_FILE_PATTERNS = ['.+\\.test\\.js$'];
 
-export const task: Task<Task_Args> = {
+export const task: Task = {
 	summary: 'run tests',
 	run: async ({fs, dev, log, args}): Promise<void> => {
 		const pattern_count = args._.length;

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -10,13 +10,17 @@ import {SYSTEM_BUILD_NAME} from './build/build_config_defaults.js';
 import {load_config} from './config/config.js';
 import {build_source} from './build/build_source.js';
 
+export interface Task_Args {
+	_: string[];
+}
+
 // Runs the project's tests: `gro test [...args]`
 // Args are passed through directly to `uvu`'s CLI:
 // https://github.com/lukeed/uvu/blob/master/docs/cli.md
 
 const DEFAULT_TEST_FILE_PATTERNS = ['.+\\.test\\.js$'];
 
-export const task: Task = {
+export const task: Task<Task_Args> = {
 	summary: 'run tests',
 	run: async ({fs, dev, log, args}): Promise<void> => {
 		const pattern_count = args._.length;


### PR DESCRIPTION
This fixes an issue with `gro build` where it doesn't clean when called by itself. It did clean when called as part of `gro deploy` and `gro publish`, but now it uses an arg to make sure it's always clean.

Also renames `clean` to `clean_fs` to be less ambiguous and avoid naming clashes with the `clean` arg.