### PR TITLE
make dev server a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ It includes:
 - [task runner](/src/task) that uses the filesystem convention `*.task.ts`
   (docs at [`src/task`](/src/task))
   - lots of [common default tasks](/src/docs/tasks.md) that projects can easily override and compose
-- codegen by convention (docs at [`src/gen`](/src/gen))
+- [testing](/src/docs/test.md) with [`uvu`](https://github.com/lukeed/uvu)
 - [dev server](/src/server/README.md) with efficient caching and http2/https support
+- codegen by convention (docs at [`src/gen`](/src/gen))
 - integrated platform-independent [`fs`](/src/fs/filesystem.ts)
   (code is parameterized with an `fs` argument)
   - modeled & implemented with [`fs-extra`](https://github.com/jprichardson/node-fs-extra),
     a drop-in replacement for Node's `fs` with better semantics
   - [memory](/src/fs/memory.ts) implementation works everywhere JS runs
   - TODO more, like: `localStorage`, GitHub repo, generic keyvalue stores, a composition/proxy API
-- [testing](/src/docs/test.md) with [`uvu`](https://github.com/lukeed/uvu)
 - formatting with [Prettier](https://github.com/prettier/prettier):
   it's not always pretty, but it's always formatted
 - more to come, exploring what deeply integrated tools enable

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,9 @@
 # changelog
 
-## 0.34.3
+## 0.34.4
 
 - make the dev server a plugin
-  ([#257](https://github.com/feltcoop/gro/pull/257))
+  ([#258](https://github.com/feltcoop/gro/pull/258))
 
 ## 0.34.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## 0.34.3
 
+- make the dev server a plugin
+  ([#257](https://github.com/feltcoop/gro/pull/257))
+
+## 0.34.3
+
 - clean during `gro build` except when invoked by `gro publish` and `gro deploy`
   ([#255](https://github.com/feltcoop/gro/pull/255))
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,9 @@
 # changelog
 
-## 0.34.4
+## 0.35.0
 
+- **break**: remove dev task event `dev.create_server` and add `dev.create_context`
+  ([#258](https://github.com/feltcoop/gro/pull/258))
 - make the dev server a plugin
   ([#258](https://github.com/feltcoop/gro/pull/258))
 

--- a/contributing.md
+++ b/contributing.md
@@ -45,7 +45,7 @@ It's trying to say "look out for the opinions: it's normal to disagree; MIT".
 But Gro _is_ more general-purpose than the phrase may suggest.
 But SvelteKit and Vite are _actually designed to be_ general-purpose tools.
 Please set your expectations accordingly 🐢
-I expect we'll see more and more app frameworks/kits tailored
+I expect we'll see more and more kits tailored
 to needs beyond Gro's already-opinionated scope.
 
 > **fun fact**: not every design detail in Gro is an opinion! sometimes it's just an implementation 🐌

--- a/contributing.md
+++ b/contributing.md
@@ -45,7 +45,8 @@ It's trying to say "look out for the opinions: it's normal to disagree; MIT".
 But Gro _is_ more general-purpose than the phrase may suggest.
 But SvelteKit and Vite are _actually designed to be_ general-purpose tools.
 Please set your expectations accordingly 🐢
-I expect we'll see more kits/metaframeworks tailored to needs beyond Gro's scope.
+I expect we'll see more and more app frameworks/kits tailored
+to needs beyond Gro's already-opinionated scope.
 
 > **fun fact**: not every design detail in Gro is an opinion! sometimes it's just an implementation 🐌
 

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -36,7 +36,7 @@ export const config: Gro_Config_Creator = async ({fs}) => {
 			has_sveltekit_frontend(fs),
 			has_gro_frontend(fs),
 		]);
-	const enable_dev_server = enable_node_library || enable_api_server || enable_gro_frontend;
+	const enable_dev_server = enable_gro_frontend;
 	const partial: Gro_Config_Partial = {
 		builds: [
 			enable_node_library ? NODE_LIBRARY_BUILD_CONFIG : null,

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -36,6 +36,7 @@ export const config: Gro_Config_Creator = async ({fs}) => {
 			has_sveltekit_frontend(fs),
 			has_gro_frontend(fs),
 		]);
+	const enable_dev_server = enable_gro_frontend;
 	const partial: Gro_Config_Partial = {
 		builds: [
 			enable_node_library ? NODE_LIBRARY_BUILD_CONFIG : null,
@@ -46,6 +47,9 @@ export const config: Gro_Config_Creator = async ({fs}) => {
 		log_level: ENV_LOG_LEVEL ?? Log_Level.Trace,
 		types: enable_node_library,
 		plugin: async () => [
+			enable_dev_server
+				? (await import('../plugin/gro_plugin_dev_server.js')).create_plugin()
+				: null,
 			enable_api_server
 				? (await import('../plugin/gro_plugin_api_server.js')).create_plugin()
 				: null,

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -36,7 +36,7 @@ export const config: Gro_Config_Creator = async ({fs}) => {
 			has_sveltekit_frontend(fs),
 			has_gro_frontend(fs),
 		]);
-	const enable_dev_server = enable_gro_frontend;
+	const enable_dev_server = enable_node_library || enable_api_server || enable_gro_frontend;
 	const partial: Gro_Config_Partial = {
 		builds: [
 			enable_node_library ? NODE_LIBRARY_BUILD_CONFIG : null,

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -5,27 +5,25 @@ import type {Task} from 'src/task/task.js';
 import {Filer} from './build/Filer.js';
 import {gro_builder_default} from './build/gro_builder_default.js';
 import {paths, to_build_out_path} from './paths.js';
-import {create_gro_server} from './server/server.js';
 import type {Gro_Server} from 'src/server/server.js';
 import type {Gro_Config} from 'src/config/config.js';
 import {load_config} from './config/config.js';
 import type {Served_Dir_Partial} from 'src/build/served_dir.js';
-import {load_https_credentials} from './server/https.js';
+import type {Plugin_Context} from './plugin/plugin.js';
 import {Plugins} from './plugin/plugin.js';
+import type {Dev_Server_Plugin_Context} from 'src/plugin/gro_plugin_dev_server.js';
 
 export interface Task_Args {
 	watch?: boolean; // defaults to `true`
-	'no-watch'?: boolean;
+	'no-watch'?: boolean; // CLI arg to set `watch: false` -- internally, refer to `watch` not this
 	insecure?: boolean;
 	cert?: string;
 	certkey?: string;
 }
 
-export interface Dev_Task_Context {
-	config: Gro_Config;
-	filer: Filer;
-	server: Gro_Server;
-}
+export interface Dev_Task_Context
+	extends Dev_Server_Plugin_Context,
+		Plugin_Context<Task_Args, Task_Events> {}
 
 export interface Task_Events {
 	'dev.create_config': (config: Gro_Config) => void;
@@ -73,29 +71,25 @@ export const task: Task<Task_Args, Task_Events> = {
 			timing_to_init_filer();
 		};
 
-		const plugins = await Plugins.create({...ctx, config, filer, timings});
+		// TODO should this be a Svelte store?
+		const dev_task_context: Dev_Task_Context = {...ctx, config, filer, timings};
+		// events.emit('dev.init_dev_task_context', dev_task_context);
 
-		const timing_to_create_gro_server = timings.start('create dev server');
-		const https = args.insecure
-			? null
-			: await load_https_credentials(fs, log, args.cert, args.certkey);
-		const server = create_gro_server({filer, host: config.host, port: config.port, https});
-		timing_to_create_gro_server();
-		events.emit('dev.create_server', server);
+		const plugins = await Plugins.create(dev_task_context);
+
+		if (dev_task_context.server) {
+			events.emit('dev.create_server', dev_task_context.server);
+		}
 
 		await init_filer();
 
 		await plugins.setup();
 
-		if (watch) {
-			const timing_to_start_gro_server = timings.start('start dev server');
-			await server.start();
-			timing_to_start_gro_server();
-		} else {
+		if (!watch) {
 			await plugins.teardown();
 		}
 
-		const dev_task_context: Dev_Task_Context = {config, server, filer};
+		// const dev_task_context: Dev_Task_Context = {config, server, filer};
 		events.emit('dev.ready', dev_task_context);
 
 		print_timings(timings, log);

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -5,7 +5,6 @@ import type {Task} from 'src/task/task.js';
 import {Filer} from './build/Filer.js';
 import {gro_builder_default} from './build/gro_builder_default.js';
 import {paths, to_build_out_path} from './paths.js';
-import type {Gro_Server} from 'src/server/server.js';
 import type {Gro_Config} from 'src/config/config.js';
 import {load_config} from './config/config.js';
 import type {Served_Dir_Partial} from 'src/build/served_dir.js';
@@ -28,6 +27,7 @@ export interface Dev_Task_Context
 export interface Task_Events {
 	'dev.create_config': (config: Gro_Config) => void;
 	'dev.create_filer': (filer: Filer) => void;
+	'dev.create_context': (ctx: Dev_Task_Context) => void;
 	'dev.ready': (ctx: Dev_Task_Context) => void;
 }
 
@@ -71,14 +71,15 @@ export const task: Task<Task_Args, Task_Events> = {
 		};
 
 		const dev_task_context: Dev_Task_Context = {...ctx, config, filer, timings};
+		events.emit('dev.create_context', dev_task_context);
 
 		const plugins = await Plugins.create(dev_task_context);
-
-		events.emit('dev.ready', dev_task_context);
 
 		await init_filer();
 
 		await plugins.setup();
+
+		events.emit('dev.ready', dev_task_context);
 
 		if (!watch) {
 			await plugins.teardown();

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -28,7 +28,6 @@ export interface Dev_Task_Context
 export interface Task_Events {
 	'dev.create_config': (config: Gro_Config) => void;
 	'dev.create_filer': (filer: Filer) => void;
-	'dev.create_server': (server: Gro_Server) => void;
 	'dev.ready': (ctx: Dev_Task_Context) => void;
 }
 
@@ -71,15 +70,11 @@ export const task: Task<Task_Args, Task_Events> = {
 			timing_to_init_filer();
 		};
 
-		// TODO should this be a Svelte store?
 		const dev_task_context: Dev_Task_Context = {...ctx, config, filer, timings};
-		// events.emit('dev.init_dev_task_context', dev_task_context);
 
 		const plugins = await Plugins.create(dev_task_context);
 
-		if (dev_task_context.server) {
-			events.emit('dev.create_server', dev_task_context.server);
-		}
+		events.emit('dev.ready', dev_task_context);
 
 		await init_filer();
 
@@ -88,9 +83,6 @@ export const task: Task<Task_Args, Task_Events> = {
 		if (!watch) {
 			await plugins.teardown();
 		}
-
-		// const dev_task_context: Dev_Task_Context = {config, server, filer};
-		events.emit('dev.ready', dev_task_context);
 
 		print_timings(timings, log);
 	},

--- a/src/docs/test.md
+++ b/src/docs/test.md
@@ -46,6 +46,7 @@ and possibly pay off in more ways down the line:
 
 - double underscore `test__` prefix
 - opening and closing tags `/* test__imported_thing */` around each suite
+- name each suite according to what it's testing, as much as makes sense
 
 We recommend copy/pasting test files to avoid tedium.
 

--- a/src/docs/test.md
+++ b/src/docs/test.md
@@ -1,6 +1,7 @@
 # test
 
-Gro uses [`uvu`](https://github.com/lukeed/uvu) for tests and forwards args to it from `gro test`.
+Gro uses [`uvu`](https://github.com/lukeed/uvu) for tests --
+when you run `gro test [...args]`, you're running `uvu [...args]` within Gro's normal task context.
 Internally, Gro has its own build system for your `src/` files,
 and it points `uvu` at Gro's compiled JS outputs.
 

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -11,6 +11,7 @@ import {BROWSER_BUILD_NAME, NODE_LIBRARY_BUILD_CONFIG} from './build/build_confi
 export const config: Gro_Config_Creator = async ({dev}) => {
 	// TODO not this
 	const ASSET_PATHS = ['html', 'css', 'json', 'ico', 'png', 'jpg', 'webp', 'webm', 'mp3'];
+	const enable_browser_build = dev;
 	const partial: Gro_Config_Partial = {
 		builds: [
 			{
@@ -28,7 +29,7 @@ export const config: Gro_Config_Creator = async ({dev}) => {
 				],
 			},
 			// the Gro browser build is currently an internal experiment
-			dev
+			enable_browser_build
 				? {
 						name: BROWSER_BUILD_NAME,
 						platform: 'browser',
@@ -47,6 +48,11 @@ export const config: Gro_Config_Creator = async ({dev}) => {
 			// then look for files in `$PROJECT/src/`
 			to_build_out_path(true, BROWSER_BUILD_NAME, ''),
 			// then.. no file found
+		],
+		plugin: async () => [
+			enable_browser_build
+				? (await import('./plugin/gro_plugin_dev_server.js')).create_plugin()
+				: null,
 		],
 		// TODO maybe adapters should have flags for whether they run in dev or not? and allow overriding or something?
 		adapt: async () =>

--- a/src/plugin/gro_plugin_api_server.ts
+++ b/src/plugin/gro_plugin_api_server.ts
@@ -2,7 +2,7 @@ import {EMPTY_OBJECT} from '@feltcoop/felt/util/object.js';
 import type {Restartable_Process} from '@feltcoop/felt/util/process.js';
 import {spawn_restartable_process} from '@feltcoop/felt/util/process.js';
 
-import type {Plugin} from 'src/plugin/plugin.js';
+import type {Plugin, Plugin_Context} from 'src/plugin/plugin.js';
 import type {Args} from 'src/task/task.js';
 import {API_SERVER_BUILD_BASE_PATH, API_SERVER_BUILD_NAME} from '../build/build_config_defaults.js';
 import {to_build_out_dir} from '../paths.js';
@@ -22,7 +22,7 @@ export interface Task_Args extends Args {
 export const create_plugin = ({
 	build_name = API_SERVER_BUILD_NAME,
 	base_build_path = API_SERVER_BUILD_BASE_PATH,
-}: Partial<Options> = EMPTY_OBJECT): Plugin<Task_Args, {}> => {
+}: Partial<Options> = EMPTY_OBJECT): Plugin<Plugin_Context<Task_Args, {}>> => {
 	let server_process: Restartable_Process | null = null;
 
 	// TODO type

--- a/src/plugin/gro_plugin_api_server.ts
+++ b/src/plugin/gro_plugin_api_server.ts
@@ -35,7 +35,7 @@ export const create_plugin = ({
 	};
 
 	return {
-		name: '@feltcoop/gro_plugin_sveltekit_frontend',
+		name: '@feltcoop/gro_plugin_api_server',
 		setup: async ({dev, fs, filer}) => {
 			// When `src/lib/server/server.ts` or any of its dependencies change, restart the API server.
 			const server_build_path = `${to_build_out_dir(dev)}/${build_name}/${base_build_path}`;

--- a/src/plugin/gro_plugin_dev_server.ts
+++ b/src/plugin/gro_plugin_dev_server.ts
@@ -1,0 +1,50 @@
+import type {Plugin, Plugin_Context} from 'src/plugin/plugin.js';
+import type {Args} from 'src/task/task.js';
+import type {Gro_Server} from 'src/server/server.js';
+import {load_https_credentials} from '../server/https.js';
+import {create_gro_server} from '../server/server.js';
+
+const name = '@feltcoop/gro_plugin_dev_server';
+
+export interface Task_Args extends Args {
+	insecure?: boolean;
+	cert?: string;
+	certkey?: string;
+	watch?: boolean;
+}
+
+export interface Dev_Server_Plugin_Context {
+	server?: Gro_Server; // TODO how to make this work with a plugin?
+}
+
+export const create_plugin = (): Plugin<
+	Plugin_Context<Task_Args, {}> & Dev_Server_Plugin_Context
+> => {
+	return {
+		name,
+		setup: async (ctx) => {
+			const {config, fs, filer, timings, args, log} = ctx;
+			if (!filer) throw Error(`${name} expects a filer arg`);
+
+			const timing_to_create_gro_server = timings.start('create dev server');
+			const https = args.insecure
+				? null
+				: await load_https_credentials(fs, log, args.cert, args.certkey);
+			ctx.server = create_gro_server({filer, host: config.host, port: config.port, https});
+			// TODO set on context and return context, right?
+			timing_to_create_gro_server();
+
+			if (args.watch) {
+				const timing_to_start_gro_server = timings.start('start dev server');
+				await ctx.server.start();
+				timing_to_start_gro_server();
+			}
+		},
+		teardown: async (ctx) => {
+			if (ctx.server) {
+				await ctx.server.close();
+				ctx.server = undefined;
+			}
+		},
+	};
+};

--- a/src/plugin/gro_plugin_dev_server.ts
+++ b/src/plugin/gro_plugin_dev_server.ts
@@ -20,6 +20,7 @@ export interface Dev_Server_Plugin_Context {
 export const create_plugin = (): Plugin<
 	Plugin_Context<Task_Args, {}> & Dev_Server_Plugin_Context
 > => {
+	let started_server = false;
 	return {
 		name,
 		setup: async (ctx) => {
@@ -38,10 +39,11 @@ export const create_plugin = (): Plugin<
 				const timing_to_start_gro_server = timings.start('start dev server');
 				await ctx.server.start();
 				timing_to_start_gro_server();
+				started_server = true;
 			}
 		},
 		teardown: async (ctx) => {
-			if (ctx.server) {
+			if (started_server && ctx.server) {
 				await ctx.server.close();
 				ctx.server = undefined;
 			}

--- a/src/plugin/gro_plugin_sveltekit_frontend.ts
+++ b/src/plugin/gro_plugin_sveltekit_frontend.ts
@@ -2,7 +2,7 @@ import type {Spawned_Process} from '@feltcoop/felt/util/process.js';
 import {spawn, spawn_process} from '@feltcoop/felt/util/process.js';
 import {EMPTY_OBJECT} from '@feltcoop/felt/util/object.js';
 
-import type {Plugin} from 'src/plugin/plugin.js';
+import type {Plugin, Plugin_Context} from 'src/plugin/plugin.js';
 import type {Args} from 'src/task/task.js';
 
 export interface Options {}
@@ -20,7 +20,9 @@ export interface Task_Args extends Args {
 
 const name = '@feltcoop/gro_adapter_sveltekit_frontend';
 
-export const create_plugin = ({}: Partial<Options> = EMPTY_OBJECT): Plugin<Task_Args, {}> => {
+export const create_plugin = ({}: Partial<Options> = EMPTY_OBJECT): Plugin<
+	Plugin_Context<Task_Args, {}>
+> => {
 	let sveltekit_process: Spawned_Process | null = null;
 	return {
 		name,

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -12,16 +12,16 @@ In contrast, `Adapter`s use the results of `gro build` to produce final artifact
 
 */
 
-export interface Plugin<T_Args = any, T_Events = any> {
+export interface Plugin<T_Plugin_Context extends Plugin_Context = Plugin_Context> {
 	name: string;
-	setup?: (ctx: Plugin_Context<T_Args, T_Events>) => void | Promise<void>;
-	teardown?: (ctx: Plugin_Context<T_Args, T_Events>) => void | Promise<void>;
+	setup?: (ctx: T_Plugin_Context) => void | Promise<void>;
+	teardown?: (ctx: T_Plugin_Context) => void | Promise<void>;
 }
 
-export interface To_Config_Plugins<T_Args = any, T_Events = any> {
-	(ctx: Plugin_Context<T_Args, T_Events>):
-		| (Plugin<T_Args, T_Events> | null | (Plugin<T_Args, T_Events> | null)[])
-		| Promise<Plugin<T_Args, T_Events> | null | (Plugin<T_Args, T_Events> | null)[]>;
+export interface To_Config_Plugins<T_Plugin_Context extends Plugin_Context = Plugin_Context> {
+	(ctx: T_Plugin_Context):
+		| (Plugin<T_Plugin_Context> | null | (Plugin<T_Plugin_Context> | null)[])
+		| Promise<Plugin<T_Plugin_Context> | null | (Plugin<T_Plugin_Context> | null)[]>;
 }
 
 export interface Plugin_Context<T_Args = any, T_Events = any>
@@ -31,18 +31,18 @@ export interface Plugin_Context<T_Args = any, T_Events = any>
 	timings: Timings;
 }
 
-export class Plugins {
+export class Plugins<T_Plugin_Context extends Plugin_Context> {
 	constructor(
-		private readonly ctx: Plugin_Context,
+		private readonly ctx: T_Plugin_Context,
 		private readonly instances: readonly Plugin[],
 	) {}
 
-	static async create(ctx: Plugin_Context): Promise<Plugins> {
+	static async create<T_Plugin_Context extends Plugin_Context>(
+		ctx: T_Plugin_Context,
+	): Promise<Plugins<T_Plugin_Context>> {
 		const {timings} = ctx;
 		const timing_to_create = timings.start('plugins.create');
-		const instances: Plugin<any, any>[] = to_array(await ctx.config.plugin(ctx)).filter(
-			Boolean,
-		) as Plugin<any, any>[];
+		const instances: Plugin[] = to_array(await ctx.config.plugin(ctx)).filter(Boolean) as any;
 		const plugins = new Plugins(ctx, instances);
 		timing_to_create();
 		return plugins;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -14,6 +14,7 @@ import type {Logger} from '@feltcoop/felt/util/log.js';
 import {strip_after} from '@feltcoop/felt/util/string.js';
 import type {Assignable} from '@feltcoop/felt/util/types.js';
 import {to_env_number, to_env_string} from '@feltcoop/felt/util/env.js';
+import {promisify} from 'util';
 
 import type {Filer} from 'src/build/Filer.js';
 import {
@@ -37,6 +38,7 @@ type Http2StreamHandler = (
 export interface Gro_Server {
 	readonly server: Http1_Server | Http2Server;
 	start(): Promise<void>;
+	close(): Promise<void>;
 	readonly host: string;
 	readonly port: number;
 }
@@ -124,6 +126,10 @@ export const create_gro_server = (options: Options): Gro_Server => {
 					resolve();
 				});
 			});
+		},
+		close: async () => {
+			await promisify(server.close.bind(server))();
+			log.trace(rainbow('closed'));
 		},
 	};
 	return gro_server;


### PR DESCRIPTION
The dev server is starting up when we don't need it, so this makes it a plugin that's conditionally included, like for Gro frontend builds.

- [x] extract dev server into a plugin

followup TODOs:

- [ ] make a dashboard plugin that enables the dev server plugin for libraries and api servers
- [ ] look at dev server gitignore and default dirs
