### PR TITLE
remove main_test config and behavior

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.37.0
+
+- **break**: remove `main_test` config option and behavior
+  ([#261](https://github.com/feltcoop/gro/pull/261))
+
 ## 0.36.1
 
 - add some convenience peer dependencies like `@types/source-map-support` --

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -9,16 +9,8 @@ import type {Logger} from '@feltcoop/felt/util/log.js';
 import {omit_undefined} from '@feltcoop/felt/util/object.js';
 import type {Assignable, Result} from '@feltcoop/felt/util/types.js';
 import {to_array} from '@feltcoop/felt/util/array.js';
-import {resolve} from 'path';
 
-import {
-	paths,
-	to_build_out_path,
-	CONFIG_BUILD_PATH,
-	DIST_DIRNAME,
-	MAIN_TEST_PATH,
-	SOURCE_DIRNAME,
-} from '../paths.js';
+import {paths, to_build_out_path, CONFIG_BUILD_PATH, DIST_DIRNAME} from '../paths.js';
 import {normalize_build_configs, validate_build_configs} from '../build/build_config.js';
 import type {To_Config_Adapters} from 'src/adapt/adapt.js';
 import type {Build_Config, Build_Config_Partial} from 'src/build/build_config.js';
@@ -62,7 +54,6 @@ export interface Gro_Config {
 	readonly sourcemap: boolean;
 	readonly typemap: boolean;
 	readonly types: boolean;
-	readonly main_test: string | null;
 	readonly host: string;
 	readonly port: number;
 	readonly log_level: Log_Level;
@@ -79,7 +70,6 @@ export interface Gro_Config_Partial {
 	readonly sourcemap?: boolean;
 	readonly typemap?: boolean;
 	readonly types?: boolean;
-	readonly main_test?: string | null;
 	readonly host?: string;
 	readonly port?: number;
 	readonly log_level?: Log_Level;
@@ -219,7 +209,6 @@ const to_bootstrap_config = (): Gro_Config => {
 		types: false,
 		host: DEFAULT_SERVER_HOST,
 		port: DEFAULT_SERVER_PORT,
-		main_test: null,
 		log_level: DEFAULT_LOG_LEVEL,
 		plugin: () => null,
 		adapt: () => null,
@@ -261,9 +250,6 @@ const normalize_config = (config: Gro_Config_Partial, dev: boolean): Gro_Config 
 		adapt: () => null,
 		serve: null,
 		...omit_undefined(config),
-		main_test: to_main_test_path(
-			config.main_test === undefined ? MAIN_TEST_PATH : config.main_test,
-		), // TODO better path normalization
 		builds: build_configs,
 		publish:
 			config.publish || config.publish === null
@@ -280,7 +266,3 @@ const to_default_publish_dirs = (build_configs: Build_Config[]): string | null =
 	const build_config_to_publish = build_configs.find((b) => b.name === NODE_LIBRARY_BUILD_NAME);
 	return build_config_to_publish ? `${DIST_DIRNAME}/${build_config_to_publish.name}` : null;
 };
-
-// treats empty string as `null`, making Gro ignoring the `main_path`
-const to_main_test_path = (main_test: string | null): string | null =>
-	main_test ? resolve(SOURCE_DIRNAME, main_test) : null;

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -55,7 +55,6 @@ export interface Gro_Config_Partial {
 	readonly sourcemap?: boolean; // defaults to true in `dev`, false for prod
 	readonly typemap?: boolean; // defaults to false in `dev`, true for prod
 	readonly types?: boolean; // defaults to false
-	readonly main_test?: string | null; // defaults to 'lib/main.test.ts', set `null` to disable
 	readonly host?: string; // env.GRO_HOST
 	readonly port?: number; // env.GRO_PORT
 	readonly log_level?: Log_Level; // env.GRO_LOG_LEVEL
@@ -183,11 +182,3 @@ config = {
 	],
 };
 ```
-
-### `main_test`
-
-Defaults to copying [`'lib/main.test.ts'`](/src/lib/main.test.ts) into your project
-when `gro test` is invoked; set `null` to disable.
-It's a Gro convention that by default installs test sourcemaps
-by importing the dependency `source-map-support`,
-and also documents its possibly surprising presence.

--- a/src/lib/main.test.ts
+++ b/src/lib/main.test.ts
@@ -1,7 +1,4 @@
-// Gro creates this file to help you with sourcemaps and other global test setup and teardown.
-// To customize the file's location,
-// use the Gro config option `main_test: 'lib/main.test.ts'`,
-// or turn it off with `null`.
+// TODO how to properly set up sourcemaps? this file doesn't run when executing specific tests
 
 import sourcemap_support from 'source-map-support';
 

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -1,11 +1,11 @@
 import {print_timings} from '@feltcoop/felt/util/print.js';
 import {Timings} from '@feltcoop/felt/util/timings.js';
 import {spawn} from '@feltcoop/felt/util/process.js';
-import {rainbow, yellow} from '@feltcoop/felt/util/terminal.js';
+import {yellow} from '@feltcoop/felt/util/terminal.js';
 
 import type {Task} from 'src/task/task.js';
 import {Task_Error} from './task/task.js';
-import {gro_paths, MAIN_TEST_PATH, print_path, to_build_out_path, to_root_path} from './paths.js';
+import {to_build_out_path, to_root_path} from './paths.js';
 import {SYSTEM_BUILD_NAME} from './build/build_config_defaults.js';
 import {load_config} from './config/config.js';
 import {build_source} from './build/build_source.js';
@@ -27,15 +27,6 @@ export const task: Task = {
 		const timing_to_load_config = timings.start('load config');
 		const config = await load_config(fs, dev);
 		timing_to_load_config();
-
-		// init the main test file if it's truthy and doesn't exist yet
-		if (config.main_test && !(await fs.exists(config.main_test))) {
-			log.info(
-				rainbow('initializing main_test file'),
-				config.main_test && print_path(config.main_test),
-			);
-			await fs.copy(`${gro_paths.source}${MAIN_TEST_PATH}`, config.main_test);
-		}
 
 		const tests_build_dir = to_build_out_path(dev, SYSTEM_BUILD_NAME);
 


### PR DESCRIPTION
This removes the `main_test` config option added in #259. I dislike the design and it doesn't solve installing sourcemaps when running specific tests. There are several ways to approach this problem but I'm not sure which one is best. Adding this main test file to user projects seems like an ill-advised hack though.