### PR TITLE
fix dev server for prod

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.39.1
+
+- fix dev server plugin defaults to not load for prod builds
+  ([#265](https://github.com/feltcoop/gro/pull/265)
+
 ## 0.39.0
 
 - **break**: rename to `PascalCase` from `Proper_Snake_Case`

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -28,7 +28,7 @@ It looks at the project and tries to do the right thing:
 
 */
 
-export const config: GroConfigCreator = async ({fs}) => {
+export const config: GroConfigCreator = async ({fs, dev}) => {
 	const [enable_node_library, enable_api_server, enable_sveltekit_frontend, enable_gro_frontend] =
 		await Promise.all([
 			has_node_library(fs),
@@ -36,7 +36,7 @@ export const config: GroConfigCreator = async ({fs}) => {
 			has_sveltekit_frontend(fs),
 			has_gro_frontend(fs),
 		]);
-	const enable_dev_server = enable_gro_frontend;
+	const enable_dev_server = dev && enable_gro_frontend;
 	const partial: GroConfigPartial = {
 		builds: [
 			enable_node_library ? NODE_LIBRARY_BUILD_CONFIG : null,


### PR DESCRIPTION
Changes the defaults so the dev server plugin doesn't load during production builds.