### PR TITLE
safe deploy to exclude main branches

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.40.1
+
+- make `gro deploy` safer by excluding branches `'main'` and `'master'` unless `--force`
+  ([#268](https://github.com/feltcoop/gro/pull/268)
+
 ## 0.40.0
 
 - rename to `camelCase` from `snake_case`

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -42,13 +42,13 @@ export const task: Task<TaskArgs> = {
 	run: async ({fs, invokeTask, args, log}): Promise<void> => {
 		const {dirname, branch, dry, clean: cleanAndExit, force} = args;
 
-		const sourceBranch = branch || GIT_DEPLOY_BRANCH;
-
-		if (!force && EXCLUDED_BRANCHES.includes(sourceBranch)) {
+		if (!force && EXCLUDED_BRANCHES.includes(branch as string)) {
 			throw Error(
-				`For safety reasons, cannot deploy to branch '${sourceBranch}'. Pass --force to override.`,
+				`For safety reasons, cannot deploy to branch '${branch}'. Pass --force to override.`,
 			);
 		}
+
+		const sourceBranch = branch || GIT_DEPLOY_BRANCH;
 
 		// Exit early if the git working directory has any unstaged or staged changes.
 		// unstaged changes: `git diff --exit-code`

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -22,6 +22,7 @@ export interface TaskArgs extends Args {
 	branch?: string; // optional branch to deploy from; defaults to 'main'
 	dry?: boolean;
 	clean?: boolean; // instead of deploying, just clean the git worktree and Gro cache
+	force?: boolean; // allow deploying to excluded branches like main/master
 }
 
 // TODO customize
@@ -33,13 +34,21 @@ const INITIAL_FILE = 'package.json'; // this is a single file that's copied into
 const TEMP_PREFIX = '__TEMP__';
 const GIT_ARGS = {cwd: WORKTREE_DIR};
 
+const EXCLUDED_BRANCHES = ['main', 'master'];
+
 export const task: Task<TaskArgs> = {
 	summary: 'deploy to static hosting',
 	dev: false,
 	run: async ({fs, invokeTask, args, log}): Promise<void> => {
-		const {dirname, branch, dry, clean: cleanAndExit} = args;
+		const {dirname, branch, dry, clean: cleanAndExit, force} = args;
 
 		const sourceBranch = branch || GIT_DEPLOY_BRANCH;
+
+		if (!force && EXCLUDED_BRANCHES.includes(sourceBranch)) {
+			throw Error(
+				`For safety reasons, cannot deploy to branch '${sourceBranch}'. Pass --force to override.`,
+			);
+		}
 
 		// Exit early if the git working directory has any unstaged or staged changes.
 		// unstaged changes: `git diff --exit-code`


### PR DESCRIPTION
Makes `gro deploy` safer by disallowing branches `'main'` and `'master'` by default. As implemented, `gro deploy` force pushes to the target deployment branch because it treats it as disposable, but this could mean drastic badness if the developer gets confused and unintentionally chooses `--branch main` or something. The flag `--force` overrides this restriction.