### PR TITLE
clean dist for production builds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.45.2
+
+- clean dist for production builds
+  ([#285](https://github.com/feltcoop/gro/pull/285))
+
 ## 0.45.1
 
 - fix peer dependency versions

--- a/src/adapt/groAdapterGenericBuild.ts
+++ b/src/adapt/groAdapterGenericBuild.ts
@@ -21,8 +21,6 @@ export const createAdapter = ({
 	return {
 		name: '@feltcoop/groAdapterGenericBuild',
 		adapt: async ({config, fs, dev, log}) => {
-			await fs.remove(dir);
-
 			const buildConfig = config.builds.find((b) => b.name === buildName);
 			if (!buildConfig) {
 				throw Error(`Unknown build config: ${buildName}`);

--- a/src/adapt/groAdapterNodeLibrary.ts
+++ b/src/adapt/groAdapterNodeLibrary.ts
@@ -72,8 +72,6 @@ export const createAdapter = ({
 	return {
 		name,
 		adapt: async ({config, fs, dev, log, args, timings}) => {
-			await fs.remove(dir);
-
 			const {mapInputOptions, mapOutputOptions, mapWatchOptions} = args;
 
 			const buildConfig = config.builds.find((b) => b.name === buildName);

--- a/src/adapt/groAdapterSveltekitFrontend.ts
+++ b/src/adapt/groAdapterSveltekitFrontend.ts
@@ -24,8 +24,6 @@ export const createAdapter = ({
 	return {
 		name: '@feltcoop/groAdapterSveltekitFrontend',
 		adapt: async ({fs}) => {
-			await fs.remove(dir);
-
 			await fs.copy(sveltekitDir, dir);
 
 			switch (hostTarget) {

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -35,7 +35,7 @@ export const task: Task<TaskArgs, TaskEvents> = {
 		// Clean in the default case, but not if the caller passes a `false` `clean` arg,
 		// This is used by `gro publish` and `gro deploy` because they call `cleanFs` themselves.
 		if (clean) {
-			await cleanFs(fs, {buildProd: true}, log);
+			await cleanFs(fs, {buildProd: true, dist: true}, log);
 		}
 
 		// TODO delete prod builds (what about config/system tho?)

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -93,7 +93,7 @@ export const task: Task<TaskArgs> = {
 		log.info(magenta('↑↑↑↑↑↑↑'), green('ignore any errors in here'), magenta('↑↑↑↑↑↑↑'));
 
 		// Get ready to build from scratch.
-		await cleanFs(fs, {buildProd: true}, log);
+		await cleanFs(fs, {buildProd: true, dist: true}, log);
 
 		if (cleanAndExit) {
 			log.info(rainbow('all clean'));

--- a/src/publish.task.ts
+++ b/src/publish.task.ts
@@ -48,7 +48,7 @@ export const task: Task<TaskArgs> = {
 		await spawn('git', ['checkout', branch]);
 
 		// Clean before loading the config:
-		await cleanFs(fs, {buildProd: true}, log);
+		await cleanFs(fs, {buildProd: true, dist: true}, log);
 
 		const config = await loadConfig(fs, dev);
 		if (config.publish === null) {

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -48,6 +48,6 @@ export class TaskError extends Error {}
 // It's a beautiful mutable spaghetti mess. cant get enough
 // The raw CLI ares are handled by `mri` - https://github.com/lukeed/mri
 export interface Args {
-	_: string[];
+	_?: string[];
 	[key: string]: unknown; // can assign anything to `args` in tasks
 }

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -48,6 +48,6 @@ export class TaskError extends Error {}
 // It's a beautiful mutable spaghetti mess. cant get enough
 // The raw CLI ares are handled by `mri` - https://github.com/lukeed/mri
 export interface Args {
-	_?: string[];
+	_: string[];
 	[key: string]: unknown; // can assign anything to `args` in tasks
 }


### PR DESCRIPTION
Deletes `dist/` for tasks like build/deploy/publish -- we previously relied on adapters to clean up for themselves, but this change simplifies things for the normal case, avoiding surprising problems at the cost of disallowing partial builds.