### PR TITLE
fix writing source meta concurrently

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - fix `svelte-check` to scope to `src/`
   ([#273](https://github.com/feltcoop/gro/pull/273))
+- fix writing source meta concurrently
+  ([#288](https://github.com/feltcoop/gro/pull/288))
 
 ## 0.47.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
   ([#273](https://github.com/feltcoop/gro/pull/273))
 - fix writing source meta concurrently
   ([#288](https://github.com/feltcoop/gro/pull/288))
+- add `utils/throttleAsync.ts`
+  ([#288](https://github.com/feltcoop/gro/pull/288))
 
 ## 0.47.0
 

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -615,6 +615,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 	private pendingBuilds: Map<BuildConfig, Set<string>> = new Map(); // value is sourceId
 	private enqueuedBuilds: Map<BuildConfig, Set<string>> = new Map(); // value is sourceId
 
+	// TODO probably use `throttleAsync` here
 	// This wrapper function protects against race conditions
 	// that could occur with concurrent builds.
 	// If a file is currently being build, it enqueues the file id,

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -91,7 +91,7 @@ export const updateSourceMeta = async (
 };
 
 const writeSourceMeta = throttleAsync(
-	async (fs: Filesystem, cacheId: string, data: SourceMetaData): Promise<void> =>
+	(fs: Filesystem, cacheId: string, data: SourceMetaData): Promise<void> =>
 		fs.writeFile(cacheId, JSON.stringify(serializeSourceMeta(data), null, 2)),
 	(_, cacheId) => cacheId,
 );

--- a/src/build/sourceMeta.ts
+++ b/src/build/sourceMeta.ts
@@ -99,6 +99,9 @@ const writeSourceMeta = async (
 	if (writingSourceMeta.has(cacheId)) {
 		await writingSourceMeta.get(cacheId);
 	}
+	// TODO when B finishes, if C came along, return its promise
+	// TODO last value wins, so we can throw away B
+	// TODO async debouncing
 	if (writingSourceMeta.has(cacheId)) throw Error('TODO bug here');
 	const promise = fs
 		.writeFile(cacheId, JSON.stringify(serializeSourceMeta(data), null, 2))

--- a/src/utils/throttleAsync.test.ts
+++ b/src/utils/throttleAsync.test.ts
@@ -1,0 +1,37 @@
+import {wait} from '@feltcoop/felt';
+import {suite} from 'uvu';
+import * as assert from 'uvu/assert';
+
+import {throttleAsync} from './throttleAsync.js';
+
+/* test__throttleAsync */
+const test__throttleAsync = suite('throttleAsync');
+
+test__throttleAsync('discards all but one concurrent call', async () => {
+	const results: string[] = [];
+	const fn = throttleAsync(
+		async (a: string, _b: number, c: string) => {
+			results.push(a + c + '_run');
+			await wait();
+			results.push(a + c + '_done');
+		},
+		(a, b) => a + b,
+	);
+	const promiseA1 = fn('a', 0, '1');
+	const promiseA2 = fn('a', 0, '2'); // discarded
+	const promiseA3 = fn('a', 0, '3'); // discarded
+	const promiseB1 = fn('b', 0, '1'); // not discarded because it has a different key
+	const promiseA4 = fn('a', 0, '4');
+	assert.equal(results, ['a1_run', 'b1_run']);
+	await promiseA1;
+	assert.equal(results, ['a1_run', 'b1_run', 'a1_done', 'a4_run']);
+	await promiseB1;
+	await promiseA2;
+	await promiseA3;
+	assert.equal(results, ['a1_run', 'b1_run', 'a1_done', 'a4_run', 'b1_done']);
+	await promiseA4;
+	assert.equal(results, ['a1_run', 'b1_run', 'a1_done', 'a4_run', 'b1_done', 'a4_done']);
+});
+
+test__throttleAsync.run();
+/* test__throttleAsync */

--- a/src/utils/throttleAsync.ts
+++ b/src/utils/throttleAsync.ts
@@ -1,0 +1,46 @@
+// TODO maybe support return values? gets tricky: what should it return for the skipped ones?
+// TODO delay? Is tricky because we'd want to return to the caller ASAP, but delay subsequent
+
+import {wait} from '@feltcoop/felt';
+
+/**
+ * Throttles calls to a promise-returning function.
+ * If the throttled function is called while the promise is pending,
+ * it's queued up to run after the promise completes,
+ * and only the last call is executed;
+ * calls except the most recent made during the pending promise are discarded.
+ * This is distinct from a queue where every call to the throttled function eventually runs.
+ * @param fn Any promise-returning function.
+ * @param toCacheKey Throttled calls are grouped by the `Map` key returned from this function.
+ * @param delay Throttled calls delay this many milliseconds after the previous call finishes.
+ * @returns Same as `fn`.
+ */
+export const throttleAsync = <TArgs extends any[]>(
+	fn: (...args: TArgs) => Promise<void>,
+	toCacheKey: (...args: TArgs) => any,
+	delay: number = 0,
+): ((...args: TArgs) => Promise<void>) => {
+	const cache: Map<string, {id: number; promise: Promise<void>}> = new Map();
+	let _id = 0;
+	return async (...args) => {
+		const id = _id++;
+		const cacheKey = toCacheKey(...args);
+		let cached = cache.get(cacheKey);
+		if (cached) {
+			cached.id = id; // queue this one up
+			await cached.promise;
+			if (cached.id !== id) return; // a later call supercedes this one
+			if (delay) await wait(delay);
+		}
+		const promise = fn(...args).then(() => {
+			if (id === cached!.id) {
+				cache.delete(cacheKey); // delete only when we're done with this `cacheKey`
+			}
+		});
+		if (!cached) {
+			cached = {promise, id};
+			cache.set(cacheKey, cached);
+		}
+		await promise;
+	};
+};

--- a/src/utils/throttleAsync.ts
+++ b/src/utils/throttleAsync.ts
@@ -1,7 +1,6 @@
-// TODO maybe support return values? gets tricky: what should it return for the skipped ones?
-// TODO delay? Is tricky because we'd want to return to the caller ASAP, but delay subsequent
-
 import {wait} from '@feltcoop/felt';
+
+// TODO maybe support return values? gets tricky: what should it return for the skipped ones?
 
 /**
  * Throttles calls to a promise-returning function.


### PR DESCRIPTION
There's a race condition with writing the source meta to disk. Hoping this fixes it; it's hard to replicate. Adds and tests the new utility `throttleAsync` to discard all but the first and last calls to a promise-returning function.