### PR TITLE
use throttleAsync in filer build

### DIFF
--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -626,7 +626,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 				);
 			}
 		},
-		(sourceFile, buildConfig) => buildConfig.name + ':' + sourceFile.id,
+		(sourceFile, buildConfig) => buildConfig.name + '::' + sourceFile.id,
 	);
 
 	private async _buildSourceFile(

--- a/src/build/Filer.ts
+++ b/src/build/Filer.ts
@@ -573,7 +573,7 @@ export class Filer extends (EventEmitter as {new (): FilerEmitter}) implements B
 					if (newSourceFile.buildable && newSourceFile.buildFiles.size !== 0) {
 						return false;
 					}
-				} else if (areContentEqual(encoding, sourceFile.content, newSourceContent)) {
+				} else if (isContentEqual(encoding, sourceFile.content, newSourceContent)) {
 					// Memory cache is warm and source code hasn't changed, do nothing and exit early!
 					return false;
 				} else {
@@ -850,7 +850,7 @@ const syncBuildFilesToDisk = async (
 					shouldOutputNewFile = true;
 				} else {
 					const existingContent = await loadContent(fs, file.encoding, file.id);
-					if (!areContentEqual(file.encoding, file.content, existingContent)) {
+					if (!isContentEqual(file.encoding, file.content, existingContent)) {
 						log.trace(label, 'updating stale build file on disk', gray(file.id));
 						shouldOutputNewFile = true;
 					} // ...else the build file on disk already matches what's in memory.
@@ -859,7 +859,7 @@ const syncBuildFilesToDisk = async (
 					// but it avoids unnecessary writing to disk and misleadingly updated file stats.
 				}
 			} else if (change.type === 'updated') {
-				if (!areContentEqual(file.encoding, file.content, change.oldFile.content)) {
+				if (!isContentEqual(file.encoding, file.content, change.oldFile.content)) {
 					log.trace(label, 'updating build file on disk', gray(file.id));
 					shouldOutputNewFile = true;
 				}
@@ -938,7 +938,7 @@ const diffBuildFiles = (
 	return changes;
 };
 
-const areContentEqual = (encoding: Encoding, a: string | Buffer, b: string | Buffer): boolean => {
+const isContentEqual = (encoding: Encoding, a: string | Buffer, b: string | Buffer): boolean => {
 	switch (encoding) {
 		case 'utf8':
 			return a === b;

--- a/src/utils/throttleAsync.test.ts
+++ b/src/utils/throttleAsync.test.ts
@@ -24,7 +24,7 @@ test__throttleAsync('discards all but one concurrent call', async () => {
 	const promiseA4 = fn('a', 0, '4');
 	assert.equal(results, ['a1_run', 'b1_run']);
 	await promiseA1;
-	assert.equal(results, ['a1_run', 'b1_run', 'a1_done', 'a4_run']);
+	assert.equal(results, ['a1_run', 'b1_run', 'a1_done']);
 	await promiseB1;
 	await promiseA2;
 	await promiseA3;
@@ -36,6 +36,27 @@ test__throttleAsync('discards all but one concurrent call', async () => {
 	const promiseB1b = fn('b', 0, '1');
 	await promiseA1b;
 	await promiseB1b;
+});
+
+test__throttleAsync('throttles with a delay', async () => {
+	const results: string[] = [];
+	const fn = throttleAsync(
+		async (a: string, _b: number, c: string) => {
+			results.push(a + c + '_run');
+			await wait();
+			results.push(a + c + '_done');
+		},
+		(a, b) => a + b,
+		1,
+	);
+	const promise1 = fn('a', 0, '1');
+	assert.equal(results, ['a1_run']);
+	await promise1;
+	assert.equal(results, ['a1_run', 'a1_done']);
+	const promise2 = fn('a', 0, '2');
+	assert.equal(results, ['a1_run', 'a1_done']); // due to the delay, this does not have 'a2_run'
+	await promise2;
+	assert.equal(results, ['a1_run', 'a1_done', 'a2_run', 'a2_done']);
 });
 
 test__throttleAsync.run();

--- a/src/utils/throttleAsync.test.ts
+++ b/src/utils/throttleAsync.test.ts
@@ -32,10 +32,12 @@ test__throttleAsync('discards all but one concurrent call', async () => {
 	await promiseA4;
 	assert.equal(results, ['a1_run', 'b1_run', 'a1_done', 'a4_run', 'b1_done', 'a4_done']);
 	// run once more just to ensure nothing is off
+	results.length = 0;
 	const promiseA1b = fn('a', 0, '1');
-	const promiseB1b = fn('b', 0, '1');
 	await promiseA1b;
+	const promiseB1b = fn('b', 0, '1');
 	await promiseB1b;
+	assert.equal(results, ['a1_run', 'a1_done', 'b1_run', 'b1_done']);
 });
 
 test__throttleAsync('throttles with a delay', async () => {

--- a/src/utils/throttleAsync.test.ts
+++ b/src/utils/throttleAsync.test.ts
@@ -31,6 +31,11 @@ test__throttleAsync('discards all but one concurrent call', async () => {
 	assert.equal(results, ['a1_run', 'b1_run', 'a1_done', 'a4_run', 'b1_done']);
 	await promiseA4;
 	assert.equal(results, ['a1_run', 'b1_run', 'a1_done', 'a4_run', 'b1_done', 'a4_done']);
+	// run once more just to ensure nothing is off
+	const promiseA1b = fn('a', 0, '1');
+	const promiseB1b = fn('b', 0, '1');
+	await promiseA1b;
+	await promiseB1b;
 });
 
 test__throttleAsync.run();

--- a/src/utils/throttleAsync.ts
+++ b/src/utils/throttleAsync.ts
@@ -29,11 +29,10 @@ export const throttleAsync = <TArgs extends any[]>(
 			cached.id = id; // queue this one up
 			await cached.promise;
 			if (cached.id !== id) return; // a later call supercedes this one
-			// TODO subtle issue here where it doesn't actually enforce this delay between calls
-			// if the second call is made in the delay window after the first completes
-			if (delay) await wait(delay);
 		}
-		const promise = fn(...args).then(() => {
+		const result = fn(...args);
+		const promise = result.then(async () => {
+			if (delay) await wait(delay);
 			if (id === cached!.id) {
 				cache.delete(cacheKey); // delete only when we're done with this `cacheKey`
 			}
@@ -42,6 +41,6 @@ export const throttleAsync = <TArgs extends any[]>(
 			cached = {promise, id};
 			cache.set(cacheKey, cached);
 		}
-		return promise;
+		return result;
 	};
 };

--- a/src/utils/throttleAsync.ts
+++ b/src/utils/throttleAsync.ts
@@ -29,6 +29,8 @@ export const throttleAsync = <TArgs extends any[]>(
 			cached.id = id; // queue this one up
 			await cached.promise;
 			if (cached.id !== id) return; // a later call supercedes this one
+			// TODO subtle issue here where it doesn't actually enforce this delay between calls
+			// if the second call is made in the delay window after the first completes
 			if (delay) await wait(delay);
 		}
 		const promise = fn(...args).then(() => {
@@ -40,6 +42,6 @@ export const throttleAsync = <TArgs extends any[]>(
 			cached = {promise, id};
 			cache.set(cacheKey, cached);
 		}
-		await promise;
+		return promise;
 	};
 };


### PR DESCRIPTION
Uses the `throttleAsync` helper added in #288 to build files. It changes some behavior in subtle ways; the quirks I think I've identified can be fixed with a higher level redesign of the build process. Gro originally started with a haphazard single-file build process; with frontend build externals we hacked in some M:N building, which was since replaced with SvelteKit/Vite, and now I think we'll do M:N but better designed.

Also fixes `delay` in the `throttleAsync` implementation and adds some related tests.