### PR TITLE
attempt to fix deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^21.0.1",
-        "@rollup/plugin-node-resolve": "^13.0.6",
+        "@rollup/plugin-node-resolve": "^13.1.1",
         "@rollup/pluginutils": "^4.1.1",
         "@types/source-map-support": ">=0.5.4",
         "cheap-watch": "^1.0.4",
         "es-module-lexer": "^0.9.3",
-        "esbuild": "^0.14.2",
         "fs-extra": "^10.0.0",
         "mri": "^1.2.0",
         "path-browserify": "^1.0.1",
@@ -25,40 +24,43 @@
         "source-map-support": ">=0.5.20",
         "sourcemap-codec": "^1.4.8",
         "strict-event-emitter-types": "^2.0.0",
-        "svelte": "^3.44.2",
         "svelte-check": "^2.2.10",
-        "svelte-preprocess-esbuild": "^2.0.0",
         "terser": "^5.10.0",
         "tslib": "^2.3.1",
-        "typescript": "^4.5.3",
         "uvu": "^0.5.2"
       },
       "bin": {
         "gro": "dist/cli/gro.js"
       },
       "devDependencies": {
-        "@feltcoop/felt": "^0.14.1",
-        "@sveltejs/adapter-static": "^1.0.0-next.21",
-        "@sveltejs/kit": "^1.0.0-next.201",
+        "@feltcoop/felt": "^0.15.2",
+        "@sveltejs/adapter-static": "^1.0.0-next.23",
+        "@sveltejs/kit": "^1.0.0-next.203",
         "@types/fs-extra": "^9.0.13",
         "@types/node": "^16.11.12",
         "@types/path-browserify": "^1.0.0",
-        "@types/prettier": "^2.4.2"
+        "@types/prettier": "^2.4.2",
+        "esbuild": "^0.14.8",
+        "svelte": "^3.44.3",
+        "svelte-preprocess-esbuild": "^2.0.0",
+        "typescript": "^4.5.4"
       },
       "engines": {
         "node": ">=16.6.0"
       },
       "peerDependencies": {
-        "@feltcoop/felt": ">=0.14.0",
-        "@sveltejs/kit": "next",
-        "@types/source-map-support": ">=0.5.4",
-        "source-map-support": ">=0.5.20"
+        "@feltcoop/felt": ">=0.15.0",
+        "@sveltejs/kit": "*",
+        "esbuild": ">=0.9.0",
+        "svelte": ">=3.44.0",
+        "svelte-preprocess-esbuild": ">=2.0.0",
+        "typescript": ">=4.5.0"
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.14.1.tgz",
-      "integrity": "sha512-SEhSz/V4mtCUYvBqBDgtvqqwduHYongTEzvHHSK59OTpk9MwcL9Lmth9LNWIu3EHT6zbp8l0xX1HPpT+cy4J2w==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.15.2.tgz",
+      "integrity": "sha512-2ozSw9WfX9FTEeGjz7rewOOZXn4C3Nmc0OR+6lUl3rcAKCL8j1bC3FKq6MMI/zm9ort4T1RmeMdHioVrxe/Fqw==",
       "dev": true,
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
@@ -69,7 +71,7 @@
         "node": ">=16.6.0"
       },
       "peerDependencies": {
-        "@sveltejs/kit": "^1.0.0-next.165",
+        "@sveltejs/kit": "next",
         "svelte": "^3.0.0"
       }
     },
@@ -173,9 +175,9 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.6.tgz",
-      "integrity": "sha512-sFsPDMPd4gMqnh2gS0uIxELnoRUp5kBl5knxD2EO0778G1oOJv4G1vyT2cpWz75OU2jDVcXhjVUuTAczGyFNKA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.1.tgz",
+      "integrity": "sha512-6QKtRevXLrmEig9UiMYt2fSvee9TyltGRfw+qSs6xjUnxwjOzTOqy+/Lpxsgjb8mJn1EQNbCDAvt89O4uzL5kw==",
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
         "@types/resolve": "1.17.1",
@@ -230,21 +232,24 @@
       }
     },
     "node_modules/@sveltejs/adapter-static": {
-      "version": "1.0.0-next.21",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.21.tgz",
-      "integrity": "sha512-B4+QoUVAaANKx+mHntG8SqF45zbj3Ct4Akg/cGauo6COyfKZRhO5OsMa+wPuT2TKJBZC4eEDK0p+p9nyQBkxKQ==",
-      "dev": true
-    },
-    "node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.201",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.201.tgz",
-      "integrity": "sha512-WcYexOEPWgDWOk0oOteTU5QwWykdIcOFJig+akeHqwE/jVtPURLZFtTNx0ymUWXN4S+dUXf60KF6HEMv74FHpA==",
+      "version": "1.0.0-next.23",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.23.tgz",
+      "integrity": "sha512-7fp+tVjh/Fi5PQxTBQAdwbOgBqtJYtNNVaa6Gb7nf7ETClojrZWFZq9ZtRfIkrrNyRNGPOl81IMO5tIHNkVfxw==",
       "dev": true,
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",
+        "tiny-glob": "^0.2.9"
+      }
+    },
+    "node_modules/@sveltejs/kit": {
+      "version": "1.0.0-next.203",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.203.tgz",
+      "integrity": "sha512-+bhfmkzquWMSCCFIJoh36U9D6IKC0p/NrIr4CBHMAdRpqzL9lMP0AYQm1fUDH20F/6b2tWvGxmEg+gAmHikRfA==",
+      "dev": true,
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
         "cheap-watch": "^1.0.4",
         "sade": "^1.7.4",
-        "vite": "^2.6.12"
+        "vite": "^2.7.2"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
@@ -257,13 +262,13 @@
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.0-next.30",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.30.tgz",
-      "integrity": "sha512-YQqdMxjL1VgSFk4/+IY3yLwuRRapPafPiZTiaGEq1psbJYSNYUWx9F1zMm32GMsnogg3zn99mGJOqe3ld3HZSg==",
+      "version": "1.0.0-next.32",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.32.tgz",
+      "integrity": "sha512-Lhf5BxVylosHIW6U2s6WDQA39ycd+bXivC8gHsXCJeLzxoHj7Pv7XAOk25xRSXT4wHg9DWFMBQh2DFU0DxHZ2g==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.1.1",
-        "debug": "^4.3.2",
+        "debug": "^4.3.3",
         "kleur": "^4.1.4",
         "magic-string": "^0.25.7",
         "require-relative": "^0.8.7",
@@ -275,7 +280,7 @@
       "peerDependencies": {
         "diff-match-patch": "^1.0.5",
         "svelte": "^3.44.0",
-        "vite": "^2.6.0"
+        "vite": "^2.7.0"
       },
       "peerDependenciesMeta": {
         "diff-match-patch": {
@@ -509,9 +514,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -568,37 +573,39 @@
       "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
     },
     "node_modules/esbuild": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.2.tgz",
-      "integrity": "sha512-l076A6o/PIgcyM24s0dWmDI/b8RQf41uWoJu9I0M71CtW/YSw5T5NUeXxs5lo2tFQD+O4CW4nBHJXx3OY5NpXg==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.8.tgz",
+      "integrity": "sha512-stMsCBmxwaMpeK8GC/49L/cRGIwsHwoEN7Twk5zDTHlm/63c0KXFKzDC8iM2Mi3fyCKwS002TAH6IlAvqR6t3g==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "optionalDependencies": {
-        "esbuild-android-arm64": "0.14.2",
-        "esbuild-darwin-64": "0.14.2",
-        "esbuild-darwin-arm64": "0.14.2",
-        "esbuild-freebsd-64": "0.14.2",
-        "esbuild-freebsd-arm64": "0.14.2",
-        "esbuild-linux-32": "0.14.2",
-        "esbuild-linux-64": "0.14.2",
-        "esbuild-linux-arm": "0.14.2",
-        "esbuild-linux-arm64": "0.14.2",
-        "esbuild-linux-mips64le": "0.14.2",
-        "esbuild-linux-ppc64le": "0.14.2",
-        "esbuild-netbsd-64": "0.14.2",
-        "esbuild-openbsd-64": "0.14.2",
-        "esbuild-sunos-64": "0.14.2",
-        "esbuild-windows-32": "0.14.2",
-        "esbuild-windows-64": "0.14.2",
-        "esbuild-windows-arm64": "0.14.2"
+        "esbuild-android-arm64": "0.14.8",
+        "esbuild-darwin-64": "0.14.8",
+        "esbuild-darwin-arm64": "0.14.8",
+        "esbuild-freebsd-64": "0.14.8",
+        "esbuild-freebsd-arm64": "0.14.8",
+        "esbuild-linux-32": "0.14.8",
+        "esbuild-linux-64": "0.14.8",
+        "esbuild-linux-arm": "0.14.8",
+        "esbuild-linux-arm64": "0.14.8",
+        "esbuild-linux-mips64le": "0.14.8",
+        "esbuild-linux-ppc64le": "0.14.8",
+        "esbuild-linux-s390x": "0.14.8",
+        "esbuild-netbsd-64": "0.14.8",
+        "esbuild-openbsd-64": "0.14.8",
+        "esbuild-sunos-64": "0.14.8",
+        "esbuild-windows-32": "0.14.8",
+        "esbuild-windows-64": "0.14.8",
+        "esbuild-windows-arm64": "0.14.8"
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.12.tgz",
-      "integrity": "sha512-TSVZVrb4EIXz6KaYjXfTzPyyRpXV5zgYIADXtQsIenjZ78myvDGaPi11o4ZSaHIwFHsuwkB6ne5SZRBwAQ7maw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
+      "integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
       "cpu": [
         "arm64"
       ],
@@ -609,9 +616,9 @@
       ]
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.12.tgz",
-      "integrity": "sha512-c51C+N+UHySoV2lgfWSwwmlnLnL0JWj/LzuZt9Ltk9ub1s2Y8cr6SQV5W3mqVH1egUceew6KZ8GyI4nwu+fhsw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
+      "integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
       "cpu": [
         "x64"
       ],
@@ -622,9 +629,9 @@
       ]
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.12.tgz",
-      "integrity": "sha512-JvAMtshP45Hd8A8wOzjkY1xAnTKTYuP/QUaKp5eUQGX+76GIie3fCdUUr2ZEKdvpSImNqxiZSIMziEiGB5oUmQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
+      "integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
       "cpu": [
         "arm64"
       ],
@@ -635,9 +642,9 @@
       ]
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.12.tgz",
-      "integrity": "sha512-r6On/Skv9f0ZjTu6PW5o7pdXr8aOgtFOEURJZYf1XAJs0IQ+gW+o1DzXjVkIoT+n1cm3N/t1KRJfX71MPg/ZUA==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
+      "integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
       "cpu": [
         "x64"
       ],
@@ -648,9 +655,9 @@
       ]
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.12.tgz",
-      "integrity": "sha512-F6LmI2Q1gii073kmBE3NOTt/6zLL5zvZsxNLF8PMAwdHc+iBhD1vzfI8uQZMJA1IgXa3ocr3L3DJH9fLGXy6Yw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
+      "integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
       "cpu": [
         "arm64"
       ],
@@ -661,9 +668,9 @@
       ]
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.12.tgz",
-      "integrity": "sha512-U1UZwG3UIwF7/V4tCVAo/nkBV9ag5KJiJTt+gaCmLVWH3bPLX7y+fNlhIWZy8raTMnXhMKfaTvWZ9TtmXzvkuQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
+      "integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
       "cpu": [
         "ia32"
       ],
@@ -674,9 +681,9 @@
       ]
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.12.tgz",
-      "integrity": "sha512-YpXSwtu2NxN3N4ifJxEdsgd6Q5d8LYqskrAwjmoCT6yQnEHJSF5uWcxv783HWN7lnGpJi9KUtDvYsnMdyGw71Q==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
+      "integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
       "cpu": [
         "x64"
       ],
@@ -687,9 +694,9 @@
       ]
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.12.tgz",
-      "integrity": "sha512-SyiT/JKxU6J+DY2qUiSLZJqCAftIt3uoGejZ0HDnUM2MGJqEGSGh7p1ecVL2gna3PxS4P+j6WAehCwgkBPXNIw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
+      "integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
       "cpu": [
         "arm"
       ],
@@ -700,9 +707,9 @@
       ]
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.12.tgz",
-      "integrity": "sha512-sgDNb8kb3BVodtAlcFGgwk+43KFCYjnFOaOfJibXnnIojNWuJHpL6aQJ4mumzNWw8Rt1xEtDQyuGK9f+Y24jGA==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
+      "integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
       "cpu": [
         "arm64"
       ],
@@ -713,9 +720,9 @@
       ]
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.12.tgz",
-      "integrity": "sha512-qQJHlZBG+QwVIA8AbTEtbvF084QgDi4DaUsUnA+EolY1bxrG+UyOuGflM2ZritGhfS/k7THFjJbjH2wIeoKA2g==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
+      "integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
       "cpu": [
         "mips64el"
       ],
@@ -726,9 +733,9 @@
       ]
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.12.tgz",
-      "integrity": "sha512-2dSnm1ldL7Lppwlo04CGQUpwNn5hGqXI38OzaoPOkRsBRWFBozyGxTFSee/zHFS+Pdh3b28JJbRK3owrrRgWNw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
+      "integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
       "cpu": [
         "ppc64"
       ],
@@ -738,10 +745,23 @@
         "linux"
       ]
     },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.8.tgz",
+      "integrity": "sha512-vURka7aCA5DrRoOqOn6pXYwFlDSoQ4qnqam8AC0Ikn6tibutuhgar6M3Ek2DCuz9yqd396mngdYr5A8x2TPkww==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.12.tgz",
-      "integrity": "sha512-D4raxr02dcRiQNbxOLzpqBzcJNFAdsDNxjUbKkDMZBkL54Z0vZh4LRndycdZAMcIdizC/l/Yp/ZsBdAFxc5nbA==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
+      "integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
       "cpu": [
         "x64"
       ],
@@ -752,9 +772,9 @@
       ]
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.12.tgz",
-      "integrity": "sha512-KuLCmYMb2kh05QuPJ+va60bKIH5wHL8ypDkmpy47lzwmdxNsuySeCMHuTv5o2Af1RUn5KLO5ZxaZeq4GEY7DaQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
+      "integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
       "cpu": [
         "x64"
       ],
@@ -765,9 +785,9 @@
       ]
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.12.tgz",
-      "integrity": "sha512-jBsF+e0woK3miKI8ufGWKG3o3rY9DpHvCVRn5eburMIIE+2c+y3IZ1srsthKyKI6kkXLvV4Cf/E7w56kLipMXw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
+      "integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
       "cpu": [
         "x64"
       ],
@@ -778,9 +798,9 @@
       ]
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.12.tgz",
-      "integrity": "sha512-L9m4lLFQrFeR7F+eLZXG82SbXZfUhyfu6CexZEil6vm+lc7GDCE0Q8DiNutkpzjv1+RAbIGVva9muItQ7HVTkQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
+      "integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
       "cpu": [
         "ia32"
       ],
@@ -791,9 +811,9 @@
       ]
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.12.tgz",
-      "integrity": "sha512-k4tX4uJlSbSkfs78W5d9+I9gpd+7N95W7H2bgOMFPsYREVJs31+Q2gLLHlsnlY95zBoPQMIzHooUIsixQIBjaQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
+      "integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
       "cpu": [
         "x64"
       ],
@@ -804,9 +824,9 @@
       ]
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.12.tgz",
-      "integrity": "sha512-2tTv/BpYRIvuwHpp2M960nG7uvL+d78LFW/ikPItO+2GfK51CswIKSetSpDii+cjz8e9iSPgs+BU4o8nWICBwQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
+      "integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
       "cpu": [
         "arm64"
       ],
@@ -817,204 +837,221 @@
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-android-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.2.tgz",
-      "integrity": "sha512-hEixaKMN3XXCkoe+0WcexO4CcBVU5DCSUT+7P8JZiWZCbAjSkc9b6Yz2X5DSfQmRCtI/cQRU6TfMYrMQ5NBfdw==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.8.tgz",
+      "integrity": "sha512-tAEoSHnPBSH0cCAFa/aYs3LPsoTY4SwsP6wDKi4PaelbQYNJjqNpAeweyJ8l98g1D6ZkLyqsHbkYj+209sezkA==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-darwin-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.2.tgz",
-      "integrity": "sha512-Uq8t0cbJQkxkQdbUfOl2wZqZ/AtLZjvJulR1HHnc96UgyzG9YlCLSDMiqjM+NANEy7/zzvwKJsy3iNC9wwqLJA==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.8.tgz",
+      "integrity": "sha512-t7p7WzTb+ybiD/irkMt5j/NzB+jY+8yPTsrXk5zCOH1O7DdthRnAUJ7pJPwImdL7jAGRbLtYRxUPgCHs/0qUPw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.2.tgz",
-      "integrity": "sha512-619MSa17sr7YCIrUj88KzQu2ESA4jKYtIYfLU/smX6qNgxQt3Y/gzM4s6sgJ4fPQzirvmXgcHv1ZNQAs/Xh48A==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.8.tgz",
+      "integrity": "sha512-5FeaT2zMUajKnBwUMSsjZev5iA38YHrDmXhkOCwZQIFUvhqojinqCrvv/X7dyxb1987bcY9KGwJ+EwDwd922HQ==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-freebsd-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.2.tgz",
-      "integrity": "sha512-aP6FE/ZsChZpUV6F3HE3x1Pz0paoYXycJ7oLt06g0G9dhJKknPawXCqQg/WMyD+ldCEZfo7F1kavenPdIT/SGQ==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.8.tgz",
+      "integrity": "sha512-pGHBLSf7ynfyDZXUtbq/GsA2VIwQlWXrUj1AMcE0id47mRdEUM8/1ZuqMGZx63hRnNgtK9zNJ8OIu2c7qq76Qw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.2.tgz",
-      "integrity": "sha512-LSm98WTb1QIhyS83+Po0KTpZNdd2XpVpI9ua5rLWqKWbKeNRFwOsjeiuwBaRNc+O32s9oC2ZMefETxHBV6VNkQ==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.8.tgz",
+      "integrity": "sha512-g4GgAnrx6Gh1BjKJjJWgPnOR4tW2FcAx9wFvyUjRsIjB35gT+aAFR+P/zStu5OG9LnbS8Pvjd4wS68QIXk+2dA==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-linux-32": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.2.tgz",
-      "integrity": "sha512-8VxnNEyeUbiGflTKcuVc5JEPTqXfsx2O6ABwUbfS1Hp26lYPRPC7pKQK5Dxa0MBejGc50jy7YZae3EGQUQ8EkQ==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.8.tgz",
+      "integrity": "sha512-wPfQJadF5vTzriw/B8Ide74PeAJlZW7czNx3NIUHkHlXb+En1SeIqNzl6jG9DuJUl57xD9Ucl9YJFEkFeX8eLg==",
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-linux-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.2.tgz",
-      "integrity": "sha512-4bzMS2dNxOJoFIiHId4w+tqQzdnsch71JJV1qZnbnErSFWcR9lRgpSqWnTTFtv6XM+MvltRzSXC5wQ7AEBY6Hg==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.8.tgz",
+      "integrity": "sha512-+RNuLk9RhRDL2kG+KTEYl5cIgF6AGLkRnKKWEu9DpCZaickONEqrKyQSVn410Hj105DLdW6qvIXQQHPycJhExg==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-linux-arm": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.2.tgz",
-      "integrity": "sha512-PaylahvMHhH8YMfJPMKEqi64qA0Su+d4FNfHKvlKes/2dUe4QxgbwXT9oLVgy8iJdcFMrO7By4R8fS8S0p8aVQ==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.8.tgz",
+      "integrity": "sha512-HIct38SvUAIJbiTwV/PVQroimQo96TGtzRDAEZxTorB4vsAj1r8bd0keXExPU4RH7G0zIqC4loQQpWYL+nH4Vg==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-linux-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.2.tgz",
-      "integrity": "sha512-RlIVp0RwJrdtasDF1vTFueLYZ8WuFzxoQ1OoRFZOTyJHCGCNgh7xJIC34gd7B7+RT0CzLBB4LcM5n0LS+hIoww==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.8.tgz",
+      "integrity": "sha512-BtWoKNYul9UoxUvQUSdSrvSmJyFL1sGnNPTSqWCg1wMe4kmc8UY2yVsXSSkKO8N2jtHxlgFyz/XhvNBzEwGVcw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.2.tgz",
-      "integrity": "sha512-Fdwrq2roFnO5oetIiUQQueZ3+5soCxBSJswg3MvYaXDomj47BN6oAWMZgLrFh1oVrtWrxSDLCJBenYdbm2s+qQ==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.8.tgz",
+      "integrity": "sha512-0DxnCl9XTvaQtsX6Qa+Phr5i9b04INwwSv2RbQ2UWRLoQ/037iaFzbmuhgrcmaGOcRwPkCa+4Qo5EgI01MUgsQ==",
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.2.tgz",
-      "integrity": "sha512-vxptskw8JfCDD9QqpRO0XnsM1osuWeRjPaXX1TwdveLogYsbdFtcuiuK/4FxGiNMUr1ojtnCS2rMPbY8puc5NA==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.8.tgz",
+      "integrity": "sha512-Uzr/OMj97Q0qoWLXCvXCKUY/z1SNI4iSZEuYylM5Nd71HGStL32XWq/MReJ0PYMvUMKKJicKSKw2jWM1uBQ84Q==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-netbsd-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.2.tgz",
-      "integrity": "sha512-I8+LzYK5iSNpspS9eCV9sW67Rj8FgMHimGri4mKiGAmN0pNfx+hFX146rYtzGtewuxKtTsPywWteHx+hPRLDsw==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.8.tgz",
+      "integrity": "sha512-tjyDak2/pp0VUAhBW6/ueuReMd5qLHNlisXl5pq0Xn0z+kH9urA/t1igm0JassWbdMz123td5ZEQWoD9KbtOAw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-openbsd-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.2.tgz",
-      "integrity": "sha512-120HgMe9elidWUvM2E6mMf0csrGwx8sYDqUIJugyMy1oHm+/nT08bTAVXuwYG/rkMIqsEO9AlMxuYnwR6En/3Q==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.8.tgz",
+      "integrity": "sha512-zAKKV15fIyAuDDga5rQv0lW2ufBWj/OCjqjDBb3dJf5SfoAi/DMIHuzmkKQeDQ+oxt9Rp1D7ZOlOBVflutFTqQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-sunos-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.2.tgz",
-      "integrity": "sha512-Q3xcf9Uyfra9UuCFxoLixVvdigo0daZaKJ97TL2KNA4bxRUPK18wwGUk3AxvgDQZpRmg82w9PnkaNYo7a+24ow==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.8.tgz",
+      "integrity": "sha512-xV41Wa8imziM/2dbWZjLKQbIETRgo5dE0oc/uPsgaecJhsrdA0VkGa/V432LJSUYv967xHDQdoRRl5tr80+NnQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-windows-32": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.2.tgz",
-      "integrity": "sha512-TW7O49tPsrq+N1sW8mb3m24j/iDGa4xzAZH4wHWwoIzgtZAYPKC0hpIhufRRG/LA30bdMChO9pjJZ5mtcybtBQ==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.8.tgz",
+      "integrity": "sha512-AxpdeLKQSyCZo7MzdOyV4OgEbEJcjnrS/2niAjbHESbjuS5P1DN/5vZoJ/JSWDVa/40OkBuHBhAXMx1HK3UDsg==",
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-windows-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.2.tgz",
-      "integrity": "sha512-Rym6ViMNmi1E2QuQMWy0AFAfdY0wGwZD73BnzlsQBX5hZBuy/L+Speh7ucUZ16gwsrMM9v86icZUDrSN/lNBKg==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.8.tgz",
+      "integrity": "sha512-/3pllNoy8mrz/E1rYalwiwwhzJBrYQhEapwAteHZbFVhGzYuB8F80e8x5eA8dhFHxDiZh1VzK+hREwwSt8UTQA==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/esbuild/node_modules/esbuild-windows-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.2.tgz",
-      "integrity": "sha512-ZrLbhr0vX5Em/P1faMnHucjVVWPS+m3tktAtz93WkMZLmbRJevhiW1y4CbulBd2z0MEdXZ6emDa1zFHq5O5bSA==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.8.tgz",
+      "integrity": "sha512-lTm5naoNgaUvzIiax3XYIEebqwr3bIIEEtqUhzQ2UQ+JMBmvhr02w3sJIJqF3axTX6TgWrC1OtM7DYNvFG+aXA==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1124,6 +1161,18 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "node_modules/graceful-fs": {
       "version": "4.2.6",
@@ -1400,14 +1449,14 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.3.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-      "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
       "devOptional": true,
       "dependencies": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
-        "source-map-js": "^0.6.2"
+        "source-map-js": "^1.0.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -1605,9 +1654,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
+      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
       "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1655,9 +1704,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.44.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.2.tgz",
-      "integrity": "sha512-jrZhZtmH3ZMweXg1Q15onb8QlWD+a5T5Oca4C1jYvSURp2oD35h4A5TV6t6MEa93K4LlX6BkafZPdQoFjw/ylA==",
+      "version": "3.44.3",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.3.tgz",
+      "integrity": "sha512-aGgrNCip5PQFNfq9e9tmm7EYxWLVHoFsEsmKrtOeRD8dmoGDdyTQ+21xd7qgFd8MNdKGSYvg7F9dr+Tc0yDymg==",
       "engines": {
         "node": ">= 8"
       }
@@ -1758,9 +1807,9 @@
       }
     },
     "node_modules/svelte-hmr": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.7.tgz",
-      "integrity": "sha512-pDrzgcWSoMaK6AJkBWkmgIsecW0GChxYZSZieIYfCP0v2oPyx2CYU/zm7TBIcjLVUPP714WxmViE9Thht4etog==",
+      "version": "0.14.9",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.9.tgz",
+      "integrity": "sha512-bKE9+4qb4sAnA+TKHiYurUl970rjA0XmlP9TEP7K/ncyWz3m81kA4HOgmlZK/7irGK7gzZlaPDI3cmf8fp/+tg==",
       "dev": true,
       "peerDependencies": {
         "svelte": ">=3.19.0"
@@ -1770,6 +1819,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/svelte-preprocess-esbuild/-/svelte-preprocess-esbuild-2.0.0.tgz",
       "integrity": "sha512-kGJ14aXcQEcyteoIijDDPvMDIq/CpkMbkW/wAFISD//KGXu7Y5fi4T/6/whKgHZFY1vw52D1SrTwN34uvTjdjw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1810,6 +1860,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1835,9 +1895,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/typescript": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
-      "integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1873,15 +1933,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.13.tgz",
-      "integrity": "sha512-+tGZ1OxozRirTudl4M3N3UTNJOlxdVo/qBl2IlDEy/ZpTFcskp+k5ncNjayR3bRYTCbqSOFz2JWGN1UmuDMScA==",
+      "version": "2.7.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.7.7.tgz",
+      "integrity": "sha512-Nm4ingl//gMSj/p1aCBHuTc5Fd8W8Mwdci/HUvqCVq8xaJqF7z08S/LRq1M9kS0jRfJk1/f/CwUyQAr6YgsOLw==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.13.2",
-        "postcss": "^8.3.8",
+        "esbuild": "^0.13.12",
+        "postcss": "^8.4.5",
         "resolve": "^1.20.0",
-        "rollup": "^2.57.0"
+        "rollup": "^2.59.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1910,32 +1970,32 @@
       }
     },
     "node_modules/vite/node_modules/esbuild": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.12.tgz",
-      "integrity": "sha512-vTKKUt+yoz61U/BbrnmlG9XIjwpdIxmHB8DlPR0AAW6OdS+nBQBci6LUHU2q9WbBobMEIQxxDpKbkmOGYvxsow==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
+      "integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "optionalDependencies": {
-        "esbuild-android-arm64": "0.13.12",
-        "esbuild-darwin-64": "0.13.12",
-        "esbuild-darwin-arm64": "0.13.12",
-        "esbuild-freebsd-64": "0.13.12",
-        "esbuild-freebsd-arm64": "0.13.12",
-        "esbuild-linux-32": "0.13.12",
-        "esbuild-linux-64": "0.13.12",
-        "esbuild-linux-arm": "0.13.12",
-        "esbuild-linux-arm64": "0.13.12",
-        "esbuild-linux-mips64le": "0.13.12",
-        "esbuild-linux-ppc64le": "0.13.12",
-        "esbuild-netbsd-64": "0.13.12",
-        "esbuild-openbsd-64": "0.13.12",
-        "esbuild-sunos-64": "0.13.12",
-        "esbuild-windows-32": "0.13.12",
-        "esbuild-windows-64": "0.13.12",
-        "esbuild-windows-arm64": "0.13.12"
+        "esbuild-android-arm64": "0.13.15",
+        "esbuild-darwin-64": "0.13.15",
+        "esbuild-darwin-arm64": "0.13.15",
+        "esbuild-freebsd-64": "0.13.15",
+        "esbuild-freebsd-arm64": "0.13.15",
+        "esbuild-linux-32": "0.13.15",
+        "esbuild-linux-64": "0.13.15",
+        "esbuild-linux-arm": "0.13.15",
+        "esbuild-linux-arm64": "0.13.15",
+        "esbuild-linux-mips64le": "0.13.15",
+        "esbuild-linux-ppc64le": "0.13.15",
+        "esbuild-netbsd-64": "0.13.15",
+        "esbuild-openbsd-64": "0.13.15",
+        "esbuild-sunos-64": "0.13.15",
+        "esbuild-windows-32": "0.13.15",
+        "esbuild-windows-64": "0.13.15",
+        "esbuild-windows-arm64": "0.13.15"
       }
     },
     "node_modules/wrappy": {
@@ -1946,9 +2006,9 @@
   },
   "dependencies": {
     "@feltcoop/felt": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.14.1.tgz",
-      "integrity": "sha512-SEhSz/V4mtCUYvBqBDgtvqqwduHYongTEzvHHSK59OTpk9MwcL9Lmth9LNWIu3EHT6zbp8l0xX1HPpT+cy4J2w==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.15.2.tgz",
+      "integrity": "sha512-2ozSw9WfX9FTEeGjz7rewOOZXn4C3Nmc0OR+6lUl3rcAKCL8j1bC3FKq6MMI/zm9ort4T1RmeMdHioVrxe/Fqw==",
       "dev": true,
       "requires": {
         "@lukeed/uuid": "^2.0.0",
@@ -2033,9 +2093,9 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.6.tgz",
-      "integrity": "sha512-sFsPDMPd4gMqnh2gS0uIxELnoRUp5kBl5knxD2EO0778G1oOJv4G1vyT2cpWz75OU2jDVcXhjVUuTAczGyFNKA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.1.tgz",
+      "integrity": "sha512-6QKtRevXLrmEig9UiMYt2fSvee9TyltGRfw+qSs6xjUnxwjOzTOqy+/Lpxsgjb8mJn1EQNbCDAvt89O4uzL5kw==",
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
         "@types/resolve": "1.17.1",
@@ -2077,31 +2137,34 @@
       }
     },
     "@sveltejs/adapter-static": {
-      "version": "1.0.0-next.21",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.21.tgz",
-      "integrity": "sha512-B4+QoUVAaANKx+mHntG8SqF45zbj3Ct4Akg/cGauo6COyfKZRhO5OsMa+wPuT2TKJBZC4eEDK0p+p9nyQBkxKQ==",
-      "dev": true
-    },
-    "@sveltejs/kit": {
-      "version": "1.0.0-next.201",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.201.tgz",
-      "integrity": "sha512-WcYexOEPWgDWOk0oOteTU5QwWykdIcOFJig+akeHqwE/jVtPURLZFtTNx0ymUWXN4S+dUXf60KF6HEMv74FHpA==",
+      "version": "1.0.0-next.23",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.23.tgz",
+      "integrity": "sha512-7fp+tVjh/Fi5PQxTBQAdwbOgBqtJYtNNVaa6Gb7nf7ETClojrZWFZq9ZtRfIkrrNyRNGPOl81IMO5tIHNkVfxw==",
       "dev": true,
       "requires": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",
+        "tiny-glob": "^0.2.9"
+      }
+    },
+    "@sveltejs/kit": {
+      "version": "1.0.0-next.203",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.203.tgz",
+      "integrity": "sha512-+bhfmkzquWMSCCFIJoh36U9D6IKC0p/NrIr4CBHMAdRpqzL9lMP0AYQm1fUDH20F/6b2tWvGxmEg+gAmHikRfA==",
+      "dev": true,
+      "requires": {
+        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
         "cheap-watch": "^1.0.4",
         "sade": "^1.7.4",
-        "vite": "^2.6.12"
+        "vite": "^2.7.2"
       }
     },
     "@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.0-next.30",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.30.tgz",
-      "integrity": "sha512-YQqdMxjL1VgSFk4/+IY3yLwuRRapPafPiZTiaGEq1psbJYSNYUWx9F1zMm32GMsnogg3zn99mGJOqe3ld3HZSg==",
+      "version": "1.0.0-next.32",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.32.tgz",
+      "integrity": "sha512-Lhf5BxVylosHIW6U2s6WDQA39ycd+bXivC8gHsXCJeLzxoHj7Pv7XAOk25xRSXT4wHg9DWFMBQh2DFU0DxHZ2g==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.1.1",
-        "debug": "^4.3.2",
+        "debug": "^4.3.3",
         "kleur": "^4.1.4",
         "magic-string": "^0.25.7",
         "require-relative": "^0.8.7",
@@ -2290,9 +2353,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -2329,249 +2392,275 @@
       "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
     },
     "esbuild": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.2.tgz",
-      "integrity": "sha512-l076A6o/PIgcyM24s0dWmDI/b8RQf41uWoJu9I0M71CtW/YSw5T5NUeXxs5lo2tFQD+O4CW4nBHJXx3OY5NpXg==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.8.tgz",
+      "integrity": "sha512-stMsCBmxwaMpeK8GC/49L/cRGIwsHwoEN7Twk5zDTHlm/63c0KXFKzDC8iM2Mi3fyCKwS002TAH6IlAvqR6t3g==",
+      "dev": true,
       "requires": {
-        "esbuild-android-arm64": "0.14.2",
-        "esbuild-darwin-64": "0.14.2",
-        "esbuild-darwin-arm64": "0.14.2",
-        "esbuild-freebsd-64": "0.14.2",
-        "esbuild-freebsd-arm64": "0.14.2",
-        "esbuild-linux-32": "0.14.2",
-        "esbuild-linux-64": "0.14.2",
-        "esbuild-linux-arm": "0.14.2",
-        "esbuild-linux-arm64": "0.14.2",
-        "esbuild-linux-mips64le": "0.14.2",
-        "esbuild-linux-ppc64le": "0.14.2",
-        "esbuild-netbsd-64": "0.14.2",
-        "esbuild-openbsd-64": "0.14.2",
-        "esbuild-sunos-64": "0.14.2",
-        "esbuild-windows-32": "0.14.2",
-        "esbuild-windows-64": "0.14.2",
-        "esbuild-windows-arm64": "0.14.2"
+        "esbuild-android-arm64": "0.14.8",
+        "esbuild-darwin-64": "0.14.8",
+        "esbuild-darwin-arm64": "0.14.8",
+        "esbuild-freebsd-64": "0.14.8",
+        "esbuild-freebsd-arm64": "0.14.8",
+        "esbuild-linux-32": "0.14.8",
+        "esbuild-linux-64": "0.14.8",
+        "esbuild-linux-arm": "0.14.8",
+        "esbuild-linux-arm64": "0.14.8",
+        "esbuild-linux-mips64le": "0.14.8",
+        "esbuild-linux-ppc64le": "0.14.8",
+        "esbuild-linux-s390x": "0.14.8",
+        "esbuild-netbsd-64": "0.14.8",
+        "esbuild-openbsd-64": "0.14.8",
+        "esbuild-sunos-64": "0.14.8",
+        "esbuild-windows-32": "0.14.8",
+        "esbuild-windows-64": "0.14.8",
+        "esbuild-windows-arm64": "0.14.8"
       },
       "dependencies": {
         "esbuild-android-arm64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.2.tgz",
-          "integrity": "sha512-hEixaKMN3XXCkoe+0WcexO4CcBVU5DCSUT+7P8JZiWZCbAjSkc9b6Yz2X5DSfQmRCtI/cQRU6TfMYrMQ5NBfdw==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.8.tgz",
+          "integrity": "sha512-tAEoSHnPBSH0cCAFa/aYs3LPsoTY4SwsP6wDKi4PaelbQYNJjqNpAeweyJ8l98g1D6ZkLyqsHbkYj+209sezkA==",
+          "dev": true,
           "optional": true
         },
         "esbuild-darwin-64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.2.tgz",
-          "integrity": "sha512-Uq8t0cbJQkxkQdbUfOl2wZqZ/AtLZjvJulR1HHnc96UgyzG9YlCLSDMiqjM+NANEy7/zzvwKJsy3iNC9wwqLJA==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.8.tgz",
+          "integrity": "sha512-t7p7WzTb+ybiD/irkMt5j/NzB+jY+8yPTsrXk5zCOH1O7DdthRnAUJ7pJPwImdL7jAGRbLtYRxUPgCHs/0qUPw==",
+          "dev": true,
           "optional": true
         },
         "esbuild-darwin-arm64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.2.tgz",
-          "integrity": "sha512-619MSa17sr7YCIrUj88KzQu2ESA4jKYtIYfLU/smX6qNgxQt3Y/gzM4s6sgJ4fPQzirvmXgcHv1ZNQAs/Xh48A==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.8.tgz",
+          "integrity": "sha512-5FeaT2zMUajKnBwUMSsjZev5iA38YHrDmXhkOCwZQIFUvhqojinqCrvv/X7dyxb1987bcY9KGwJ+EwDwd922HQ==",
+          "dev": true,
           "optional": true
         },
         "esbuild-freebsd-64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.2.tgz",
-          "integrity": "sha512-aP6FE/ZsChZpUV6F3HE3x1Pz0paoYXycJ7oLt06g0G9dhJKknPawXCqQg/WMyD+ldCEZfo7F1kavenPdIT/SGQ==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.8.tgz",
+          "integrity": "sha512-pGHBLSf7ynfyDZXUtbq/GsA2VIwQlWXrUj1AMcE0id47mRdEUM8/1ZuqMGZx63hRnNgtK9zNJ8OIu2c7qq76Qw==",
+          "dev": true,
           "optional": true
         },
         "esbuild-freebsd-arm64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.2.tgz",
-          "integrity": "sha512-LSm98WTb1QIhyS83+Po0KTpZNdd2XpVpI9ua5rLWqKWbKeNRFwOsjeiuwBaRNc+O32s9oC2ZMefETxHBV6VNkQ==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.8.tgz",
+          "integrity": "sha512-g4GgAnrx6Gh1BjKJjJWgPnOR4tW2FcAx9wFvyUjRsIjB35gT+aAFR+P/zStu5OG9LnbS8Pvjd4wS68QIXk+2dA==",
+          "dev": true,
           "optional": true
         },
         "esbuild-linux-32": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.2.tgz",
-          "integrity": "sha512-8VxnNEyeUbiGflTKcuVc5JEPTqXfsx2O6ABwUbfS1Hp26lYPRPC7pKQK5Dxa0MBejGc50jy7YZae3EGQUQ8EkQ==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.8.tgz",
+          "integrity": "sha512-wPfQJadF5vTzriw/B8Ide74PeAJlZW7czNx3NIUHkHlXb+En1SeIqNzl6jG9DuJUl57xD9Ucl9YJFEkFeX8eLg==",
+          "dev": true,
           "optional": true
         },
         "esbuild-linux-64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.2.tgz",
-          "integrity": "sha512-4bzMS2dNxOJoFIiHId4w+tqQzdnsch71JJV1qZnbnErSFWcR9lRgpSqWnTTFtv6XM+MvltRzSXC5wQ7AEBY6Hg==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.8.tgz",
+          "integrity": "sha512-+RNuLk9RhRDL2kG+KTEYl5cIgF6AGLkRnKKWEu9DpCZaickONEqrKyQSVn410Hj105DLdW6qvIXQQHPycJhExg==",
+          "dev": true,
           "optional": true
         },
         "esbuild-linux-arm": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.2.tgz",
-          "integrity": "sha512-PaylahvMHhH8YMfJPMKEqi64qA0Su+d4FNfHKvlKes/2dUe4QxgbwXT9oLVgy8iJdcFMrO7By4R8fS8S0p8aVQ==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.8.tgz",
+          "integrity": "sha512-HIct38SvUAIJbiTwV/PVQroimQo96TGtzRDAEZxTorB4vsAj1r8bd0keXExPU4RH7G0zIqC4loQQpWYL+nH4Vg==",
+          "dev": true,
           "optional": true
         },
         "esbuild-linux-arm64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.2.tgz",
-          "integrity": "sha512-RlIVp0RwJrdtasDF1vTFueLYZ8WuFzxoQ1OoRFZOTyJHCGCNgh7xJIC34gd7B7+RT0CzLBB4LcM5n0LS+hIoww==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.8.tgz",
+          "integrity": "sha512-BtWoKNYul9UoxUvQUSdSrvSmJyFL1sGnNPTSqWCg1wMe4kmc8UY2yVsXSSkKO8N2jtHxlgFyz/XhvNBzEwGVcw==",
+          "dev": true,
           "optional": true
         },
         "esbuild-linux-mips64le": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.2.tgz",
-          "integrity": "sha512-Fdwrq2roFnO5oetIiUQQueZ3+5soCxBSJswg3MvYaXDomj47BN6oAWMZgLrFh1oVrtWrxSDLCJBenYdbm2s+qQ==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.8.tgz",
+          "integrity": "sha512-0DxnCl9XTvaQtsX6Qa+Phr5i9b04INwwSv2RbQ2UWRLoQ/037iaFzbmuhgrcmaGOcRwPkCa+4Qo5EgI01MUgsQ==",
+          "dev": true,
           "optional": true
         },
         "esbuild-linux-ppc64le": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.2.tgz",
-          "integrity": "sha512-vxptskw8JfCDD9QqpRO0XnsM1osuWeRjPaXX1TwdveLogYsbdFtcuiuK/4FxGiNMUr1ojtnCS2rMPbY8puc5NA==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.8.tgz",
+          "integrity": "sha512-Uzr/OMj97Q0qoWLXCvXCKUY/z1SNI4iSZEuYylM5Nd71HGStL32XWq/MReJ0PYMvUMKKJicKSKw2jWM1uBQ84Q==",
+          "dev": true,
           "optional": true
         },
         "esbuild-netbsd-64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.2.tgz",
-          "integrity": "sha512-I8+LzYK5iSNpspS9eCV9sW67Rj8FgMHimGri4mKiGAmN0pNfx+hFX146rYtzGtewuxKtTsPywWteHx+hPRLDsw==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.8.tgz",
+          "integrity": "sha512-tjyDak2/pp0VUAhBW6/ueuReMd5qLHNlisXl5pq0Xn0z+kH9urA/t1igm0JassWbdMz123td5ZEQWoD9KbtOAw==",
+          "dev": true,
           "optional": true
         },
         "esbuild-openbsd-64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.2.tgz",
-          "integrity": "sha512-120HgMe9elidWUvM2E6mMf0csrGwx8sYDqUIJugyMy1oHm+/nT08bTAVXuwYG/rkMIqsEO9AlMxuYnwR6En/3Q==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.8.tgz",
+          "integrity": "sha512-zAKKV15fIyAuDDga5rQv0lW2ufBWj/OCjqjDBb3dJf5SfoAi/DMIHuzmkKQeDQ+oxt9Rp1D7ZOlOBVflutFTqQ==",
+          "dev": true,
           "optional": true
         },
         "esbuild-sunos-64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.2.tgz",
-          "integrity": "sha512-Q3xcf9Uyfra9UuCFxoLixVvdigo0daZaKJ97TL2KNA4bxRUPK18wwGUk3AxvgDQZpRmg82w9PnkaNYo7a+24ow==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.8.tgz",
+          "integrity": "sha512-xV41Wa8imziM/2dbWZjLKQbIETRgo5dE0oc/uPsgaecJhsrdA0VkGa/V432LJSUYv967xHDQdoRRl5tr80+NnQ==",
+          "dev": true,
           "optional": true
         },
         "esbuild-windows-32": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.2.tgz",
-          "integrity": "sha512-TW7O49tPsrq+N1sW8mb3m24j/iDGa4xzAZH4wHWwoIzgtZAYPKC0hpIhufRRG/LA30bdMChO9pjJZ5mtcybtBQ==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.8.tgz",
+          "integrity": "sha512-AxpdeLKQSyCZo7MzdOyV4OgEbEJcjnrS/2niAjbHESbjuS5P1DN/5vZoJ/JSWDVa/40OkBuHBhAXMx1HK3UDsg==",
+          "dev": true,
           "optional": true
         },
         "esbuild-windows-64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.2.tgz",
-          "integrity": "sha512-Rym6ViMNmi1E2QuQMWy0AFAfdY0wGwZD73BnzlsQBX5hZBuy/L+Speh7ucUZ16gwsrMM9v86icZUDrSN/lNBKg==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.8.tgz",
+          "integrity": "sha512-/3pllNoy8mrz/E1rYalwiwwhzJBrYQhEapwAteHZbFVhGzYuB8F80e8x5eA8dhFHxDiZh1VzK+hREwwSt8UTQA==",
+          "dev": true,
           "optional": true
         },
         "esbuild-windows-arm64": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.2.tgz",
-          "integrity": "sha512-ZrLbhr0vX5Em/P1faMnHucjVVWPS+m3tktAtz93WkMZLmbRJevhiW1y4CbulBd2z0MEdXZ6emDa1zFHq5O5bSA==",
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.8.tgz",
+          "integrity": "sha512-lTm5naoNgaUvzIiax3XYIEebqwr3bIIEEtqUhzQ2UQ+JMBmvhr02w3sJIJqF3axTX6TgWrC1OtM7DYNvFG+aXA==",
+          "dev": true,
           "optional": true
         }
       }
     },
     "esbuild-android-arm64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.12.tgz",
-      "integrity": "sha512-TSVZVrb4EIXz6KaYjXfTzPyyRpXV5zgYIADXtQsIenjZ78myvDGaPi11o4ZSaHIwFHsuwkB6ne5SZRBwAQ7maw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
+      "integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.12.tgz",
-      "integrity": "sha512-c51C+N+UHySoV2lgfWSwwmlnLnL0JWj/LzuZt9Ltk9ub1s2Y8cr6SQV5W3mqVH1egUceew6KZ8GyI4nwu+fhsw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
+      "integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.12.tgz",
-      "integrity": "sha512-JvAMtshP45Hd8A8wOzjkY1xAnTKTYuP/QUaKp5eUQGX+76GIie3fCdUUr2ZEKdvpSImNqxiZSIMziEiGB5oUmQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
+      "integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.12.tgz",
-      "integrity": "sha512-r6On/Skv9f0ZjTu6PW5o7pdXr8aOgtFOEURJZYf1XAJs0IQ+gW+o1DzXjVkIoT+n1cm3N/t1KRJfX71MPg/ZUA==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
+      "integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.12.tgz",
-      "integrity": "sha512-F6LmI2Q1gii073kmBE3NOTt/6zLL5zvZsxNLF8PMAwdHc+iBhD1vzfI8uQZMJA1IgXa3ocr3L3DJH9fLGXy6Yw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
+      "integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.12.tgz",
-      "integrity": "sha512-U1UZwG3UIwF7/V4tCVAo/nkBV9ag5KJiJTt+gaCmLVWH3bPLX7y+fNlhIWZy8raTMnXhMKfaTvWZ9TtmXzvkuQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
+      "integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.12.tgz",
-      "integrity": "sha512-YpXSwtu2NxN3N4ifJxEdsgd6Q5d8LYqskrAwjmoCT6yQnEHJSF5uWcxv783HWN7lnGpJi9KUtDvYsnMdyGw71Q==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
+      "integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.12.tgz",
-      "integrity": "sha512-SyiT/JKxU6J+DY2qUiSLZJqCAftIt3uoGejZ0HDnUM2MGJqEGSGh7p1ecVL2gna3PxS4P+j6WAehCwgkBPXNIw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
+      "integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.12.tgz",
-      "integrity": "sha512-sgDNb8kb3BVodtAlcFGgwk+43KFCYjnFOaOfJibXnnIojNWuJHpL6aQJ4mumzNWw8Rt1xEtDQyuGK9f+Y24jGA==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
+      "integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.12.tgz",
-      "integrity": "sha512-qQJHlZBG+QwVIA8AbTEtbvF084QgDi4DaUsUnA+EolY1bxrG+UyOuGflM2ZritGhfS/k7THFjJbjH2wIeoKA2g==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
+      "integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.12.tgz",
-      "integrity": "sha512-2dSnm1ldL7Lppwlo04CGQUpwNn5hGqXI38OzaoPOkRsBRWFBozyGxTFSee/zHFS+Pdh3b28JJbRK3owrrRgWNw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
+      "integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-s390x": {
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.8.tgz",
+      "integrity": "sha512-vURka7aCA5DrRoOqOn6pXYwFlDSoQ4qnqam8AC0Ikn6tibutuhgar6M3Ek2DCuz9yqd396mngdYr5A8x2TPkww==",
       "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.12.tgz",
-      "integrity": "sha512-D4raxr02dcRiQNbxOLzpqBzcJNFAdsDNxjUbKkDMZBkL54Z0vZh4LRndycdZAMcIdizC/l/Yp/ZsBdAFxc5nbA==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
+      "integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
       "dev": true,
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.12.tgz",
-      "integrity": "sha512-KuLCmYMb2kh05QuPJ+va60bKIH5wHL8ypDkmpy47lzwmdxNsuySeCMHuTv5o2Af1RUn5KLO5ZxaZeq4GEY7DaQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
+      "integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
       "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.12.tgz",
-      "integrity": "sha512-jBsF+e0woK3miKI8ufGWKG3o3rY9DpHvCVRn5eburMIIE+2c+y3IZ1srsthKyKI6kkXLvV4Cf/E7w56kLipMXw==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
+      "integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.12.tgz",
-      "integrity": "sha512-L9m4lLFQrFeR7F+eLZXG82SbXZfUhyfu6CexZEil6vm+lc7GDCE0Q8DiNutkpzjv1+RAbIGVva9muItQ7HVTkQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
+      "integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.12.tgz",
-      "integrity": "sha512-k4tX4uJlSbSkfs78W5d9+I9gpd+7N95W7H2bgOMFPsYREVJs31+Q2gLLHlsnlY95zBoPQMIzHooUIsixQIBjaQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
+      "integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.12.tgz",
-      "integrity": "sha512-2tTv/BpYRIvuwHpp2M960nG7uvL+d78LFW/ikPItO+2GfK51CswIKSetSpDii+cjz8e9iSPgs+BU4o8nWICBwQ==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
+      "integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
       "dev": true,
       "optional": true
     },
@@ -2654,6 +2743,18 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.6",
@@ -2862,14 +2963,14 @@
       "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
     },
     "postcss": {
-      "version": "8.3.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-      "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
       "devOptional": true,
       "requires": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
-        "source-map-js": "^0.6.2"
+        "source-map-js": "^1.0.1"
       }
     },
     "prettier": {
@@ -2991,9 +3092,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
+      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
       "devOptional": true
     },
     "source-map-support": {
@@ -3032,9 +3133,9 @@
       }
     },
     "svelte": {
-      "version": "3.44.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.2.tgz",
-      "integrity": "sha512-jrZhZtmH3ZMweXg1Q15onb8QlWD+a5T5Oca4C1jYvSURp2oD35h4A5TV6t6MEa93K4LlX6BkafZPdQoFjw/ylA=="
+      "version": "3.44.3",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.3.tgz",
+      "integrity": "sha512-aGgrNCip5PQFNfq9e9tmm7EYxWLVHoFsEsmKrtOeRD8dmoGDdyTQ+21xd7qgFd8MNdKGSYvg7F9dr+Tc0yDymg=="
     },
     "svelte-check": {
       "version": "2.2.10",
@@ -3073,9 +3174,9 @@
       }
     },
     "svelte-hmr": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.7.tgz",
-      "integrity": "sha512-pDrzgcWSoMaK6AJkBWkmgIsecW0GChxYZSZieIYfCP0v2oPyx2CYU/zm7TBIcjLVUPP714WxmViE9Thht4etog==",
+      "version": "0.14.9",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.9.tgz",
+      "integrity": "sha512-bKE9+4qb4sAnA+TKHiYurUl970rjA0XmlP9TEP7K/ncyWz3m81kA4HOgmlZK/7irGK7gzZlaPDI3cmf8fp/+tg==",
       "dev": true,
       "requires": {}
     },
@@ -3083,6 +3184,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/svelte-preprocess-esbuild/-/svelte-preprocess-esbuild-2.0.0.tgz",
       "integrity": "sha512-kGJ14aXcQEcyteoIijDDPvMDIq/CpkMbkW/wAFISD//KGXu7Y5fi4T/6/whKgHZFY1vw52D1SrTwN34uvTjdjw==",
+      "dev": true,
       "requires": {}
     },
     "terser": {
@@ -3100,6 +3202,16 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
+      }
+    },
+    "tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
       }
     },
     "to-regex-range": {
@@ -3121,9 +3233,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "typescript": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
-      "integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ=="
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
     },
     "universalify": {
       "version": "2.0.0",
@@ -3143,41 +3255,41 @@
       }
     },
     "vite": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.13.tgz",
-      "integrity": "sha512-+tGZ1OxozRirTudl4M3N3UTNJOlxdVo/qBl2IlDEy/ZpTFcskp+k5ncNjayR3bRYTCbqSOFz2JWGN1UmuDMScA==",
+      "version": "2.7.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.7.7.tgz",
+      "integrity": "sha512-Nm4ingl//gMSj/p1aCBHuTc5Fd8W8Mwdci/HUvqCVq8xaJqF7z08S/LRq1M9kS0jRfJk1/f/CwUyQAr6YgsOLw==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.13.2",
+        "esbuild": "^0.13.12",
         "fsevents": "~2.3.2",
-        "postcss": "^8.3.8",
+        "postcss": "^8.4.5",
         "resolve": "^1.20.0",
-        "rollup": "^2.57.0"
+        "rollup": "^2.59.0"
       },
       "dependencies": {
         "esbuild": {
-          "version": "0.13.12",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.12.tgz",
-          "integrity": "sha512-vTKKUt+yoz61U/BbrnmlG9XIjwpdIxmHB8DlPR0AAW6OdS+nBQBci6LUHU2q9WbBobMEIQxxDpKbkmOGYvxsow==",
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
+          "integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
           "dev": true,
           "requires": {
-            "esbuild-android-arm64": "0.13.12",
-            "esbuild-darwin-64": "0.13.12",
-            "esbuild-darwin-arm64": "0.13.12",
-            "esbuild-freebsd-64": "0.13.12",
-            "esbuild-freebsd-arm64": "0.13.12",
-            "esbuild-linux-32": "0.13.12",
-            "esbuild-linux-64": "0.13.12",
-            "esbuild-linux-arm": "0.13.12",
-            "esbuild-linux-arm64": "0.13.12",
-            "esbuild-linux-mips64le": "0.13.12",
-            "esbuild-linux-ppc64le": "0.13.12",
-            "esbuild-netbsd-64": "0.13.12",
-            "esbuild-openbsd-64": "0.13.12",
-            "esbuild-sunos-64": "0.13.12",
-            "esbuild-windows-32": "0.13.12",
-            "esbuild-windows-64": "0.13.12",
-            "esbuild-windows-arm64": "0.13.12"
+            "esbuild-android-arm64": "0.13.15",
+            "esbuild-darwin-64": "0.13.15",
+            "esbuild-darwin-arm64": "0.13.15",
+            "esbuild-freebsd-64": "0.13.15",
+            "esbuild-freebsd-arm64": "0.13.15",
+            "esbuild-linux-32": "0.13.15",
+            "esbuild-linux-64": "0.13.15",
+            "esbuild-linux-arm": "0.13.15",
+            "esbuild-linux-arm64": "0.13.15",
+            "esbuild-linux-mips64le": "0.13.15",
+            "esbuild-linux-ppc64le": "0.13.15",
+            "esbuild-netbsd-64": "0.13.15",
+            "esbuild-openbsd-64": "0.13.15",
+            "esbuild-sunos-64": "0.13.15",
+            "esbuild-windows-32": "0.13.15",
+            "esbuild-windows-64": "0.13.15",
+            "esbuild-windows-arm64": "0.13.15"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -50,12 +50,11 @@
   },
   "dependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",
-    "@rollup/plugin-node-resolve": "^13.0.6",
+    "@rollup/plugin-node-resolve": "^13.1.1",
     "@rollup/pluginutils": "^4.1.1",
     "@types/source-map-support": ">=0.5.4",
     "cheap-watch": "^1.0.4",
     "es-module-lexer": "^0.9.3",
-    "esbuild": "^0.14.2",
     "fs-extra": "^10.0.0",
     "mri": "^1.2.0",
     "path-browserify": "^1.0.1",
@@ -65,28 +64,31 @@
     "source-map-support": ">=0.5.20",
     "sourcemap-codec": "^1.4.8",
     "strict-event-emitter-types": "^2.0.0",
-    "svelte": "^3.44.2",
     "svelte-check": "^2.2.10",
-    "svelte-preprocess-esbuild": "^2.0.0",
     "terser": "^5.10.0",
     "tslib": "^2.3.1",
-    "typescript": "^4.5.3",
     "uvu": "^0.5.2"
   },
   "peerDependencies": {
-    "@feltcoop/felt": ">=0.14.0",
-    "@sveltejs/kit": "next",
-    "@types/source-map-support": ">=0.5.4",
-    "source-map-support": ">=0.5.20"
+    "@feltcoop/felt": ">=0.15.0",
+    "@sveltejs/kit": "*",
+    "esbuild": ">=0.9.0",
+    "svelte": ">=3.44.0",
+    "svelte-preprocess-esbuild": ">=2.0.0",
+    "typescript": ">=4.5.0"
   },
   "devDependencies": {
-    "@feltcoop/felt": "^0.14.1",
-    "@sveltejs/adapter-static": "^1.0.0-next.21",
-    "@sveltejs/kit": "^1.0.0-next.201",
+    "@feltcoop/felt": "^0.15.2",
+    "@sveltejs/adapter-static": "^1.0.0-next.23",
+    "@sveltejs/kit": "^1.0.0-next.203",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^16.11.12",
     "@types/path-browserify": "^1.0.0",
-    "@types/prettier": "^2.4.2"
+    "@types/prettier": "^2.4.2",
+    "esbuild": "^0.14.8",
+    "svelte": "^3.44.3",
+    "svelte-preprocess-esbuild": "^2.0.0",
+    "typescript": "^4.5.4"
   },
   "prettier": {
     "useTabs": true,

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "@feltcoop/felt": ">=0.15.0",
-    "@sveltejs/kit": "*",
+    "@sveltejs/kit": ">=1.0.0-next.203",
     "esbuild": ">=0.9.0",
     "svelte": ">=3.44.0",
     "svelte-preprocess-esbuild": ">=2.0.0",


### PR DESCRIPTION
Apparently #286 broke some things for dependent projects like felt-template. Npm seems to not correctly handle peer deps when linking -- or I'm doing something wrong (very possible) -- so I can't seem to test this before publishing. I may just have to cycle through some patch versions before fixing this. I may revert #286 if I can't figure it out quickly. It seems like it's related to esbuild.