### PR TITLE
fix default config to build types only for production

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.50.3
+
+- fix default config to build types only for production
+  ([#300](https://github.com/feltcoop/gro/pull/300))
+
 ## 0.50.2
 
 - add `.schema.` files to system build

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -34,7 +34,7 @@ export const config: GroConfigCreator = async ({fs, dev}) => {
 			// note there's no build for SvelteKit frontends - should there be?
 		],
 		logLevel: ENV_LOG_LEVEL ?? LogLevel.Trace,
-		types: enableNodeLibrary,
+		types: !dev && enableNodeLibrary,
 		plugin: async () => [
 			// TODO dev server?
 			// enableDevServer ? (await import('../plugin/groPluginDevServer.js')).createPlugin() : null,


### PR DESCRIPTION
Sneaky bug wormed its way into breaking `gro gen` in unfortunate cases. This should send it to the compost pile of git history.