### PR TITLE
add lint task

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.50.4
+
+- run `eslint` in `gro check` if it's available
+  ([#301](https://github.com/feltcoop/gro/pull/301))
+
 ## 0.50.3
 
 - fix default config to build types only for production

--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -6,6 +6,7 @@ export const task: Task = {
 	summary: 'check that everything is ready to commit',
 	run: async ({fs, log, args, invokeTask}) => {
 		await invokeTask('typecheck');
+		await invokeTask('lint');
 
 		await invokeTask('test');
 

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -14,6 +14,7 @@ What is a `Task`? See [`tasks.md`](./task.md).
 - [dev](../dev.task.ts) - start dev server
 - [format](../format.task.ts) - format source files
 - [gen](../gen.task.ts) - run code generation scripts
+- [lint](../lint.task.ts) - run eslint on the source files
 - [publish](../publish.task.ts) - bump version, publish to npm, and git push
 - [serve](../serve.task.ts) - start static file server
 - [test](../test.task.ts) - run tests

--- a/src/lint.task.ts
+++ b/src/lint.task.ts
@@ -1,0 +1,16 @@
+import {printSpawnResult, spawn} from '@feltcoop/felt/util/process.js';
+
+import {TaskError, type Task} from './task/task.js';
+import {SOURCE_DIRNAME} from './paths.js';
+
+export const task: Task = {
+	summary: 'run eslint on the source files',
+	run: async ({fs}): Promise<void> => {
+		if (await fs.exists('node_modules/.bin/eslint')) {
+			const eslintResult = await spawn('npx', ['eslint', SOURCE_DIRNAME]);
+			if (!eslintResult.ok) {
+				throw new TaskError(`ESLint found some problems. ${printSpawnResult(eslintResult)}`);
+			}
+		}
+	},
+};

--- a/src/lint.task.ts
+++ b/src/lint.task.ts
@@ -5,12 +5,14 @@ import {SOURCE_DIRNAME} from './paths.js';
 
 export const task: Task = {
 	summary: 'run eslint on the source files',
-	run: async ({fs}): Promise<void> => {
+	run: async ({fs, log}): Promise<void> => {
 		if (await fs.exists('node_modules/.bin/eslint')) {
 			const eslintResult = await spawn('npx', ['eslint', SOURCE_DIRNAME]);
 			if (!eslintResult.ok) {
 				throw new TaskError(`ESLint found some problems. ${printSpawnResult(eslintResult)}`);
 			}
+		} else {
+			log.info('ESLint is not installed; skipping linting');
 		}
 	},
 };


### PR DESCRIPTION
Adds the `gro lint` task using ESLint and calls it from `gro check`. Similarly to `svelte-check`, Gro does not specify ESLint as a peer dependency, and it'll detect if it's available in `node_modules/` before trying to run it.