### PR TITLE
pass through args to eslint and fail check on warnings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,13 @@
 
 ## 0.50.4
 
+- make `gro check` fail on lint warnings
+  ([#302](https://github.com/feltcoop/gro/pull/302))
+- pass through args in `gro lint` to `eslint`
+  ([#302](https://github.com/feltcoop/gro/pull/302))
+
+## 0.50.4
+
 - run `eslint` in `gro check` if it's available
   ([#301](https://github.com/feltcoop/gro/pull/301))
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # changelog
 
-## 0.50.4
+## 0.50.5
 
 - make `gro check` fail on lint warnings
   ([#302](https://github.com/feltcoop/gro/pull/302))

--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -1,14 +1,13 @@
 import {type Task} from './task/task.js';
 import {TaskError} from './task/task.js';
 import {findGenModules} from './gen/genModule.js';
-import {SOURCE_DIRNAME} from './paths.js';
 
 export const task: Task = {
 	summary: 'check that everything is ready to commit',
 	run: async ({fs, log, args, invokeTask}) => {
 		await invokeTask('typecheck');
 
-		await invokeTask('lint', {_: [SOURCE_DIRNAME], 'max-warnings': 0});
+		await invokeTask('lint', {_: [], 'max-warnings': 0});
 
 		await invokeTask('test');
 

--- a/src/check.task.ts
+++ b/src/check.task.ts
@@ -1,12 +1,14 @@
 import {type Task} from './task/task.js';
 import {TaskError} from './task/task.js';
 import {findGenModules} from './gen/genModule.js';
+import {SOURCE_DIRNAME} from './paths.js';
 
 export const task: Task = {
 	summary: 'check that everything is ready to commit',
 	run: async ({fs, log, args, invokeTask}) => {
 		await invokeTask('typecheck');
-		await invokeTask('lint');
+
+		await invokeTask('lint', {_: [SOURCE_DIRNAME], 'max-warnings': 0});
 
 		await invokeTask('test');
 

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -56,10 +56,10 @@ export const serializeArgs = (args: Args): string[] => {
 	let _: string[] | null = null;
 	for (const [key, value] of Object.entries(args)) {
 		if (key === '_') {
-			_ = (value as any[]).map((v) => v.toString());
+			_ = (value as any[]).map((v) => (v === undefined ? '' : v + ''));
 		} else {
-			result.push(`--${key}`);
-			result.push((value as any).toString());
+			result.push(`${key.length === 1 ? '-' : '--'}${key}`);
+			if (value !== undefined) result.push((value as any) + '');
 		}
 	}
 	return _ ? [...result, ..._] : result;


### PR DESCRIPTION
Makes `gro check` fail on lint warnings, makes `gro lint` default to `src`, and passes through args to `gro lint` to `eslint`.