### PR TITLE
fix task name printing for task directories

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.51.3
+
+- fix task name printing for task directories
+  ([#312](https://github.com/feltcoop/gro/pull/312))
+
 ## 0.51.2
 
 - support task dirs

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -37,7 +37,7 @@ export const toTaskName = (basePath: string): string => {
 	if (stripped === basePath) return basePath;
 	// Handle task directories, so `a/a.task` outputs `a` instead of `a/a`.
 	const s = stripped.split('/');
-	return s[s.length - 1] === s[s.length - 2] ? s.slice(-1).join('/') : stripped;
+	return s[s.length - 1] === s[s.length - 2] ? s.slice(0, -1).join('/') : stripped;
 };
 
 // This is used by tasks to signal a known failure.


### PR DESCRIPTION
Small bugfix from #311.