### PR TITLE
register gen schemas

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.52.3
+
+- register schemas for schema gen
+  ([#316](https://github.com/feltcoop/gro/pull/316))
+
 ## 0.52.2
 
 - improve safety of `gro deploy` and update its docs

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.52.3
 
-- register schemas for schema gen
+- **break**: register schemas for gen and search for them before the file resolver
   ([#316](https://github.com/feltcoop/gro/pull/316))
 
 ## 0.52.2

--- a/src/gen/genSchemas.ts
+++ b/src/gen/genSchemas.ts
@@ -1,14 +1,18 @@
-import {compile} from '@ryanatkn/json-schema-to-typescript';
+import {compile, type Options} from '@ryanatkn/json-schema-to-typescript';
 import {stripEnd} from '@feltcoop/felt/util/string.js';
 
 import {type GenContext, type RawGenResult} from './gen.js';
-import {type SchemaGenModule} from './genModule.js';
+import {type GenModuleMeta, type SchemaGenModule} from './genModule.js';
 import {renderTsHeaderAndFooter} from './helpers/ts.js';
 import {normalizeTsImports} from './helpers/tsImport.js';
-import {isVocabSchema} from '../utils/schema.js';
+import {isVocabSchema, type VocabSchema} from '../utils/schema.js';
 
-export const genSchemas = async (mod: SchemaGenModule, ctx: GenContext): Promise<RawGenResult> => {
-	const {imports, types} = await runSchemaGen(ctx, mod);
+export const genSchemas = async (
+	mod: SchemaGenModule,
+	ctx: GenContext,
+	options: Partial<Options>,
+): Promise<RawGenResult> => {
+	const {imports, types} = await runSchemaGen(ctx, mod, options);
 	return renderTsHeaderAndFooter(
 		ctx,
 		`${imports.join('\n;\n')}
@@ -18,25 +22,28 @@ export const genSchemas = async (mod: SchemaGenModule, ctx: GenContext): Promise
 	);
 };
 
-export const runSchemaGen = async (
+const runSchemaGen = async (
 	ctx: GenContext,
 	mod: SchemaGenModule,
+	options: Partial<Options>,
 ): Promise<{imports: string[]; types: string[]}> => {
 	const rawImports: string[] = [];
 	const types: string[] = [];
 
-	for (const identifier in mod) {
-		const value = mod[identifier];
-		if (!isVocabSchema(value)) continue;
-
+	for (const {identifier, schema: originalSchema} of toSchemaInfoFromModule(mod)) {
 		// `json-schema-to-typescript` adds an `id` property,
 		// which causes `ajv` to fail to compile,
 		// so instead of adding `id` as an `ajv` keyword we shallow clone the schema.
-		const schema = {...value};
+		const schema = {...originalSchema};
 
 		// Compile the schema to TypeScript.
 		const finalIdentifier = stripEnd(identifier, 'Schema'); // convenient to avoid name collisions
-		const result = await compile(schema, finalIdentifier, {bannerComment: '', format: false}); // eslint-disable-line no-await-in-loop
+		// eslint-disable-next-line no-await-in-loop
+		const result = await compile(schema, finalIdentifier, {
+			bannerComment: '',
+			format: false,
+			...options,
+		});
 		types.push(result);
 
 		// Walk the entire schema and add any imports with `tsImport`.
@@ -71,4 +78,26 @@ const traverse = (obj: any, cb: (key: string, value: any, obj: any) => void): vo
 		cb(k, v, obj);
 		traverse(v, cb);
 	}
+};
+
+export const toSchemasFromModules = (genModules: GenModuleMeta[]): VocabSchema[] => {
+	const schemas: VocabSchema[] = [];
+	for (const genModule of genModules) {
+		if (genModule.type !== 'schema') continue;
+		for (const schemaInfo of toSchemaInfoFromModule(genModule.mod)) {
+			schemas.push(schemaInfo.schema);
+		}
+	}
+	return schemas;
+};
+
+export const toSchemaInfoFromModule = (
+	mod: SchemaGenModule,
+): Array<{identifier: string; schema: VocabSchema}> => {
+	const schemaInfo: Array<{identifier: string; schema: VocabSchema}> = [];
+	for (const identifier in mod) {
+		const value = mod[identifier];
+		if (isVocabSchema(value)) schemaInfo.push({identifier, schema: value});
+	}
+	return schemaInfo;
 };

--- a/src/gen/genSchemas.ts
+++ b/src/gen/genSchemas.ts
@@ -94,7 +94,7 @@ export const toSchemasFromModules = (genModules: GenModuleMeta[]): VocabSchema[]
 	return schemas;
 };
 
-export const toSchemaInfoFromModule = (
+const toSchemaInfoFromModule = (
 	mod: SchemaGenModule,
 ): Array<{identifier: string; schema: VocabSchema}> => {
 	const schemaInfo: Array<{identifier: string; schema: VocabSchema}> = [];

--- a/src/gen/genSchemas.ts
+++ b/src/gen/genSchemas.ts
@@ -3,6 +3,7 @@ import {
 	type Options as JsonSchemaToTypeScriptOptions,
 } from '@ryanatkn/json-schema-to-typescript';
 import {stripEnd} from '@feltcoop/felt/util/string.js';
+import {traverse} from '@feltcoop/felt/util/object.js';
 
 import {type GenContext, type RawGenResult} from './gen.js';
 import {type GenModuleMeta, type SchemaGenModule} from './genModule.js';
@@ -64,23 +65,6 @@ const runSchemaGen = async (
 	const imports = await normalizeTsImports(ctx.fs, rawImports, ctx.originId);
 
 	return {imports, types};
-};
-
-// TODO upstream to Felt?
-/**
- * Performs a depth-first traversal of an object's enumerable properties,
- * calling `cb` for every key and value.
- * @param obj Any object with enumerable properties.
- * @param cb Receives the key and value for every enumerable property on `obj` and its descendents.
- * @returns
- */
-const traverse = (obj: any, cb: (key: string, value: any, obj: any) => void): void => {
-	if (!obj || typeof obj !== 'object') return;
-	for (const k in obj) {
-		const v = obj[k];
-		cb(k, v, obj);
-		traverse(v, cb);
-	}
 };
 
 export const toSchemasFromModules = (genModules: GenModuleMeta[]): VocabSchema[] => {

--- a/src/gen/genSchemas.ts
+++ b/src/gen/genSchemas.ts
@@ -1,4 +1,7 @@
-import {compile, type Options} from '@ryanatkn/json-schema-to-typescript';
+import {
+	compile,
+	type Options as JsonSchemaToTypeScriptOptions,
+} from '@ryanatkn/json-schema-to-typescript';
 import {stripEnd} from '@feltcoop/felt/util/string.js';
 
 import {type GenContext, type RawGenResult} from './gen.js';
@@ -10,7 +13,7 @@ import {isVocabSchema, type VocabSchema} from '../utils/schema.js';
 export const genSchemas = async (
 	mod: SchemaGenModule,
 	ctx: GenContext,
-	options: Partial<Options>,
+	options: Partial<JsonSchemaToTypeScriptOptions>,
 ): Promise<RawGenResult> => {
 	const {imports, types} = await runSchemaGen(ctx, mod, options);
 	return renderTsHeaderAndFooter(
@@ -25,7 +28,7 @@ export const genSchemas = async (
 const runSchemaGen = async (
 	ctx: GenContext,
 	mod: SchemaGenModule,
-	options: Partial<Options>,
+	options: Partial<JsonSchemaToTypeScriptOptions>,
 ): Promise<{imports: string[]; types: string[]}> => {
 	const rawImports: string[] = [];
 	const types: string[] = [];

--- a/src/gen/runGen.ts
+++ b/src/gen/runGen.ts
@@ -18,6 +18,7 @@ import {
 import {type Filesystem} from '../fs/filesystem.js';
 import {printPath} from '../paths.js';
 import {genSchemas, toSchemasFromModules} from './genSchemas.js';
+import {toVocabSchemaResolver} from '../utils/schema.js';
 
 export const runGen = async (
 	fs: Filesystem,
@@ -102,7 +103,6 @@ export const runGen = async (
 	};
 };
 
-// TODO copy-pasted from felt-server, should it use this helper instead?
 const toGenSchemasOptions = (
 	genModules: GenModuleMeta[],
 ): Partial<JsonSchemaToTypeScriptOptions> => {
@@ -111,17 +111,7 @@ const toGenSchemasOptions = (
 		$refOptions: {
 			resolve: {
 				http: false, // disable web resolution
-				file: {
-					read: (file) => {
-						const schema = schemas.find((s) => s.$id === file.url);
-						if (!schema)
-							throw Error(
-								`Unable to find schema: "${file.url}".` +
-									' Is it unregistered in $lib/app/schemas.ts, or a typo, or outdated?',
-							);
-						return JSON.stringify(schema);
-					},
-				},
+				vocab: toVocabSchemaResolver(schemas),
 			},
 		},
 	};

--- a/src/gen/runGen.ts
+++ b/src/gen/runGen.ts
@@ -3,6 +3,7 @@ import {printError} from '@feltcoop/felt/util/print.js';
 import {Timings} from '@feltcoop/felt/util/timings.js';
 import {type Logger} from '@feltcoop/felt/util/log.js';
 import {UnreachableError} from '@feltcoop/felt/util/error.js';
+import {type Options as JsonSchemaToTypeScriptOptions} from '@ryanatkn/json-schema-to-typescript';
 
 import {type GenModuleMeta} from './genModule.js';
 import {
@@ -16,7 +17,7 @@ import {
 } from './gen.js';
 import {type Filesystem} from '../fs/filesystem.js';
 import {printPath} from '../paths.js';
-import {genSchemas} from './genSchemas.js';
+import {genSchemas, toSchemasFromModules} from './genSchemas.js';
 
 export const runGen = async (
 	fs: Filesystem,
@@ -28,6 +29,7 @@ export const runGen = async (
 	let outputCount = 0;
 	const timings = new Timings();
 	const timingForTotal = timings.start('total');
+	const genSchemasOptions = toGenSchemasOptions(genModules);
 	const results = await Promise.all(
 		genModules.map(async (moduleMeta): Promise<GenModuleResult> => {
 			inputCount++;
@@ -44,7 +46,7 @@ export const runGen = async (
 						break;
 					}
 					case 'schema': {
-						rawGenResult = await genSchemas(moduleMeta.mod, genCtx);
+						rawGenResult = await genSchemas(moduleMeta.mod, genCtx, genSchemasOptions);
 						break;
 					}
 					default: {
@@ -97,5 +99,30 @@ export const runGen = async (
 		inputCount,
 		outputCount,
 		elapsed: timingForTotal(),
+	};
+};
+
+// TODO copy-pasted from felt-server, should it use this helper instead?
+const toGenSchemasOptions = (
+	genModules: GenModuleMeta[],
+): Partial<JsonSchemaToTypeScriptOptions> => {
+	const schemas = toSchemasFromModules(genModules);
+	return {
+		$refOptions: {
+			resolve: {
+				http: false, // disable web resolution
+				file: {
+					read: (file) => {
+						const schema = schemas.find((s) => s.$id === file.url);
+						if (!schema)
+							throw Error(
+								`Unable to find schema: "${file.url}".` +
+									' Is it unregistered in $lib/app/schemas.ts, or a typo, or outdated?',
+							);
+						return JSON.stringify(schema);
+					},
+				},
+			},
+		},
 	};
 };

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,5 +1,5 @@
 import {type JSONSchema} from '@ryanatkn/json-schema-to-typescript';
-import {ResolverError, type ResolverOptions} from 'json-schema-ref-parser';
+import {type ResolverOptions} from 'json-schema-ref-parser';
 
 export interface VocabSchema extends JSONSchema {
 	$id: string;
@@ -19,7 +19,7 @@ export const toVocabSchemaResolver = (schemas: VocabSchema[]): ResolverOptions =
 	read: (file) => {
 		const schema = schemas.find((s) => s.$id === file.url);
 		if (!schema) {
-			throw new ResolverError(new Error(`Unable to find schema: "${file.url}".`), file.url);
+			throw new Error(`Unable to find schema: "${file.url}".`);
 		}
 		return JSON.stringify(schema);
 	},

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -18,9 +18,7 @@ export const toVocabSchemaResolver = (schemas: VocabSchema[]): ResolverOptions =
 	canRead: true,
 	read: (file) => {
 		const schema = schemas.find((s) => s.$id === file.url);
-		if (!schema) {
-			throw new Error(`Unable to find schema: "${file.url}".`);
-		}
+		if (!schema) throw new Error(`Unable to find schema: "${file.url}".`);
 		return JSON.stringify(schema);
 	},
 });

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,4 +1,5 @@
 import {type JSONSchema} from '@ryanatkn/json-schema-to-typescript';
+import {ResolverError, type ResolverOptions} from 'json-schema-ref-parser';
 
 export interface VocabSchema extends JSONSchema {
 	$id: string;
@@ -6,3 +7,20 @@ export interface VocabSchema extends JSONSchema {
 
 export const isVocabSchema = (value: unknown): value is VocabSchema =>
 	!!value && typeof value === 'object' && '$id' in value;
+
+/**
+ * Creates a custom resolver for `VocabSchema`s supporting paths like "/schemas/Something.json".
+ * @param schemas
+ * @returns
+ */
+export const toVocabSchemaResolver = (schemas: VocabSchema[]): ResolverOptions => ({
+	order: 1,
+	canRead: true,
+	read: (file) => {
+		const schema = schemas.find((s) => s.$id === file.url);
+		if (!schema) {
+			throw new ResolverError(new Error(`Unable to find schema: "${file.url}".`), file.url);
+		}
+		return JSON.stringify(schema);
+	},
+});


### PR DESCRIPTION
Currently, schema generation uses the default file resolution and tries to read from disk. We currently use schema refs with absolute paths like `/schemas/Thing.json` to ease composition as dependencies in other projects. This changes the default schema resolution to look through the schemas in memory, allowing schemas to reference each other with `$ref: '/schemas/Thing.json'`.
