### PR TITLE
always build before running tasks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.54.1
+
+- always build before running tasks
+  ([#321](https://github.com/feltcoop/gro/pull/321))
+
 ## 0.54.0
 
 - **break**: upgrade deps including peer dep for `@feltcoop/felt@0.26.0`

--- a/src/gen.task.ts
+++ b/src/gen.task.ts
@@ -10,8 +10,6 @@ import {resolveRawInputPaths} from './fs/inputPath.js';
 import {loadModules} from './fs/modules.js';
 import {formatFile} from './format/formatFile.js';
 import {printPath} from './paths.js';
-import {loadConfig} from './config/config.js';
-import {buildSource} from './build/buildSource.js';
 import type {GenTaskArgs} from './genTask.js';
 import {GenTaskArgsSchema} from './genTask.schema.js';
 

--- a/src/gen.task.ts
+++ b/src/gen.task.ts
@@ -20,20 +20,11 @@ import {GenTaskArgsSchema} from './genTask.schema.js';
 export const task: Task<GenTaskArgs> = {
 	summary: 'run code generation scripts',
 	args: GenTaskArgsSchema,
-	run: async ({fs, log, args, dev}): Promise<void> => {
+	run: async ({fs, log, args}): Promise<void> => {
 		const {_: rawInputPaths, check} = args;
 
 		const totalTiming = createStopwatch();
 		const timings = new Timings();
-
-		// TODO won't need to build if `gen` becomes a builder
-		// first build everything
-		const timingToLoadConfig = timings.start('load config');
-		const config = await loadConfig(fs, dev);
-		timingToLoadConfig();
-		const timingToBuildSource = timings.start('buildSource');
-		await buildSource(fs, config, dev, log);
-		timingToBuildSource();
 
 		// resolve the input paths relative to src/
 		const inputPaths = resolveRawInputPaths(rawInputPaths);

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -89,8 +89,6 @@ export const invokeTask = async (
 			// Over time we'll remove much of Gro's functionality and use something like `tsm`:
 			// https://github.com/feltcoop/gro/issues/319
 
-			// TODO BLOCK should this run in a separate process?
-
 			// Import these lazily to avoid importing their comparatively heavy transitive dependencies
 			// every time a task is invoked.
 			log.info('building project to run task');

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -6,8 +6,6 @@ import {yellow} from 'kleur/colors';
 import {TaskError, type Task} from './task/task.js';
 import {toBuildOutPath, toRootPath} from './paths.js';
 import {SYSTEM_BUILD_NAME} from './build/buildConfigDefaults.js';
-import {loadConfig} from './config/config.js';
-import {buildSource} from './build/buildSource.js';
 import type {TestTaskArgs} from './testTask.js';
 import {TestTaskArgsSchema} from './testTask.schema.js';
 import {addArg, printCommandArgs, serializeArgs, toForwardedArgs} from './utils/args.js';

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -26,15 +26,6 @@ export const task: Task<TestTaskArgs> = {
 
 		const timings = new Timings();
 
-		const timingToLoadConfig = timings.start('load config');
-		const config = await loadConfig(fs, dev);
-		timingToLoadConfig();
-
-		// TODO cleaner way to detect & rebuild?
-		const timingToPrebuild = timings.start('prebuild');
-		await buildSource(fs, config, dev, log);
-		timingToPrebuild();
-
 		// Projects may not define any artifacts for the Node build,
 		// and we don't force anything out in that case,
 		// so just exit early if that happens.


### PR DESCRIPTION
This is a step towards removing Gro's build system. Gro was designed before fast TypeScript transpilers like `esbuild` and `swc` (we now use the former because of SvelteKit), but now that it's ~20-100x faster (in my tests, using 1 to 8 cores, respectively) there's little reason not to compile on the fly, because it makes the UX much better. Gro users shouldn't have to run `gro dev` all the time, and this is one step towards removing its build system altogether in favor of something like [`tsm`](https://github.com/lukeed/tsm).