### PR TITLE
build minimal src

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.55.2
+
+- build only the included TypeScript files to `dist/src/`
+  ([#325](https://github.com/feltcoop/gro/pull/325))
+
 ## 0.55.1
 
 - add `format` option to gen files, defaults to `true`

--- a/src/adapt/groAdapterNodeLibrary.ts
+++ b/src/adapt/groAdapterNodeLibrary.ts
@@ -9,9 +9,7 @@ import type {Adapter} from './adapt.js';
 import {TaskError} from '../task/task.js';
 import {copyDist} from './utils.js';
 import {
-	paths,
 	sourceIdToBasePath,
-	SOURCE_DIRNAME,
 	toBuildExtension,
 	toImportId,
 	TS_TYPEMAP_EXTENSION,
@@ -132,9 +130,6 @@ export const createAdapter = ({
 						})
 						.filter(Boolean),
 				);
-
-				// copy src
-				await fs.copy(paths.source, `${outputDir}/${SOURCE_DIRNAME}`);
 
 				// update package.json with computed values
 				pkg.files = await toPkgFiles(fs, outputDir);

--- a/src/adapt/utils.ts
+++ b/src/adapt/utils.ts
@@ -49,14 +49,16 @@ export const copyDist = async (
 		typemapFiles.map(async (id) => {
 			const basePath = toBuildBasePath(id);
 			const sourceBasePath = `${stripEnd(basePath, TS_TYPEMAP_EXTENSION)}${TS_EXTENSION}`;
-			const distSourceId = pack
-				? `${distOutDir}/${SOURCE_DIRNAME}/${sourceBasePath}`
-				: `${paths.source}${sourceBasePath}`;
+			const sourceId = `${SOURCE_DIRNAME}/${sourceBasePath}`;
+			const distSourceId = pack ? `${distOutDir}/${sourceId}` : `${paths.source}${sourceBasePath}`;
 			const distOutPath = `${distOutDir}/${stripStart(basePath, rebasePath)}`;
 			const typemapSourcePath = relative(dirname(distOutPath), distSourceId);
 			const typemap = JSON.parse(await fs.readFile(id, 'utf8'));
 			typemap.sources[0] = typemapSourcePath; // haven't seen any exceptions that would break this
-			return fs.writeFile(distOutPath, JSON.stringify(typemap));
+			return Promise.all([
+				fs.copy(sourceId, `${distOutDir}/${sourceId}`), // copy source TypeScript files (but not other filetypes)
+				fs.writeFile(distOutPath, JSON.stringify(typemap)),
+			]);
 		}),
 	);
 };

--- a/src/adapt/utils.ts
+++ b/src/adapt/utils.ts
@@ -50,6 +50,7 @@ export const copyDist = async (
 			const basePath = toBuildBasePath(id);
 			const sourceBasePath = `${stripEnd(basePath, TS_TYPEMAP_EXTENSION)}${TS_EXTENSION}`;
 			const sourceId = `${SOURCE_DIRNAME}/${sourceBasePath}`;
+			// TODO when the `pack` hack is removed, use `distSourceId` below instead of reconstructing it
 			const distSourceId = pack ? `${distOutDir}/${sourceId}` : `${paths.source}${sourceBasePath}`;
 			const distOutPath = `${distOutDir}/${stripStart(basePath, rebasePath)}`;
 			const typemapSourcePath = relative(dirname(distOutPath), distSourceId);


### PR DESCRIPTION
Currently `gro build` copies the entire `src/` for typemap support (e.g. "Go to definition" goes to the TS source file, not the JS), and this changes it to only included the include TypeScript files.