### PR TITLE
improve typecheck reporting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # changelog
 
+## 0.61.2
+
+- change `gro typecheck` to always run both `tsc` and `svelte-check`
+  instead of stopping when `tsc` finds an error
+  ([#339](https://github.com/feltcoop/gro/pull/339))
+
 ## 0.61.1
 
 - upgrade SvelteKit import mocks

--- a/src/typecheck.task.ts
+++ b/src/typecheck.task.ts
@@ -38,7 +38,7 @@ export const task: Task<TypecheckTaskArgs> = {
 		}
 		if (svelteCheckResult && !svelteCheckResult.ok) {
 			if (errorMessage) errorMessage += ' ';
-			errorMessage = printSpawnResult(svelteCheckResult);
+			errorMessage += printSpawnResult(svelteCheckResult);
 		}
 		if (errorMessage) {
 			throw new TaskError(`Failed to typecheck. ${errorMessage}`);


### PR DESCRIPTION
Changes `gro typecheck` to always report both `tsc` and `svelte-check` errors instead of stopping when a `tsc` error is encountered.