### PR TITLE
change config to a default export instead of a `config` property

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.63.0
 
+- **break**: change `src/gro.config.ts` to export a default value instead of a `config` property
+  ([#348](https://github.com/feltcoop/gro/pull/348))
 - **break**: change `plugin/gro-plugin-api-server.ts` to a no-op outside of dev mode
   ([#347](https://github.com/feltcoop/gro/pull/347))
 

--- a/src/config/gro.config.default.ts
+++ b/src/config/gro.config.default.ts
@@ -21,7 +21,7 @@ It looks at the project and tries to do the right thing:
 
 */
 
-export const config: GroConfigCreator = async ({fs, dev}) => {
+const config: GroConfigCreator = async ({fs, dev}) => {
 	const [enableNodeLibrary, enableApiServer, enableSveltekitFrontend] = await Promise.all([
 		hasNodeLibrary(fs),
 		hasApiServer(fs),
@@ -59,3 +59,5 @@ export const config: GroConfigCreator = async ({fs, dev}) => {
 	};
 	return partial;
 };
+
+export default config;

--- a/src/docs/adapt.md
+++ b/src/docs/adapt.md
@@ -76,7 +76,7 @@ a function that returns `Adapter` instances:
 ```ts
 import type {GroConfigCreator} from '@feltcoop/gro';
 
-export const config: GroConfigCreator = async () => {
+const config: GroConfigCreator = async () => {
 	return {
 		adapt: async () => [
 			(await import('@feltcoop/gro/gro-adapter-sveltekit-frontend.js')).createAdapter(),
@@ -109,6 +109,8 @@ export const config: GroConfigCreator = async () => {
 		adapt: () => [null],
 	};
 };
+
+export default config;
 ```
 
 Why must `adapt` be a function, and not just one or more `Adapter` instances?

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -32,11 +32,13 @@ Here's a config for a simple Node project:
 ```ts
 import type {GroConfigCreator} from '@feltcoop/gro';
 
-export const config: GroConfigCreator = async () => {
+const config: GroConfigCreator = async () => {
 	return {
 		builds: [{name: 'server', platform: 'node', input: 'index.ts'}],
 	};
 };
+
+export default config;
 ```
 
 Here's [Gro's own internal config](/src/gro.config.ts) and

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -7,7 +7,7 @@ import {NODE_LIBRARY_BUILD_CONFIG, SYSTEM_BUILD_CONFIG} from './build/buildConfi
 // This is the config for the Gro project itself.
 // The default config for dependent projects is located at `./config/gro.config.default.ts`.
 
-export const config: GroConfigCreator = async ({dev}) => {
+const config: GroConfigCreator = async ({dev}) => {
 	const partial: GroConfigPartial = {
 		builds: [
 			{
@@ -56,3 +56,5 @@ export const config: GroConfigCreator = async ({dev}) => {
 	};
 	return partial;
 };
+
+export default config;


### PR DESCRIPTION
Changes the Gro config to be inline with SvelteKit and Vite, exporting a default instead of a `config` property.