### PR TITLE
add config option to copy src on build

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
   ([#348](https://github.com/feltcoop/gro/pull/348))
 - **break**: change `plugin/gro-plugin-api-server.ts` to a no-op outside of dev mode
   ([#347](https://github.com/feltcoop/gro/pull/347))
+- add `GroConfig` option `copyOnBuild`
+  ([#349](https://github.com/feltcoop/gro/pull/349))
 
 ## 0.62.4
 


### PR DESCRIPTION
**update**: closed, see https://github.com/feltcoop/felt-server/pull/540

Adds a config option to copy src on build to `dist/`. The motivating usecase is to let felt-server easily deploy its source code.

- how to implement?  
- name? update changelog

thinking something like `copy: [{from: 'src', to: 'static'}]`