### PR TITLE
always run `svelte-kit sync` instead of checking for dir

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.63.1
 
+- pass `--skipLibCheck` to `tsc` on `gro build` so it can be disabled in dependents' tsconfigs
+  ([#352](https://github.com/feltcoop/gro/pull/352))
 - always run `svelte-kit sync` instead of checking for the directory first
   ([#352](https://github.com/feltcoop/gro/pull/352))
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.63.1
+
+- always run `svelte-kit sync` instead of checking for the directory first
+  ([#352](https://github.com/feltcoop/gro/pull/352))
+
 ## 0.63.0
 
 - **break**: change `src/gro.config.ts` to export a default value instead of a `config` property

--- a/src/build/buildSource.ts
+++ b/src/build/buildSource.ts
@@ -19,7 +19,7 @@ export const buildSource = async (
 ): Promise<void> => {
 	log.info('building source', gray(dev ? 'development' : 'production'));
 
-	await sveltekitSync(fs);
+	await sveltekitSync();
 
 	const totalTiming = createStopwatch();
 	const timings = new Timings();

--- a/src/build/typescriptUtils.ts
+++ b/src/build/typescriptUtils.ts
@@ -46,6 +46,7 @@ export const generateTypes = async (
 		declarationMap: typemap,
 		declaration: true,
 		emitDeclarationOnly: true,
+		skipLibCheck: true,
 	};
 	const serializedArgs = ['tsc', ...serializeArgs(forwardedArgs)];
 	log.info(printCommandArgs(serializedArgs));

--- a/src/typecheck.task.ts
+++ b/src/typecheck.task.ts
@@ -18,7 +18,7 @@ export const task: Task<Args> = {
 	run: async ({fs, args, log}): Promise<void> => {
 		const {tsconfig} = args;
 
-		await sveltekitSync(fs);
+		await sveltekitSync();
 
 		if (await fs.exists('node_modules/.bin/svelte-check')) {
 			// svelte-check

--- a/src/utils/sveltekit.ts
+++ b/src/utils/sveltekit.ts
@@ -1,14 +1,6 @@
+import {unwrap} from '@feltcoop/felt';
 import {spawn} from '@feltcoop/felt/util/process.js';
 
-import {SVELTEKIT_TSCONFIG} from '../paths.js';
-import type {Filesystem} from '../fs/filesystem';
-
-// TODO maybe always call sync without checking first?
-export const sveltekitSync = async (fs: Filesystem): Promise<void> => {
-	if (!(await fs.exists(SVELTEKIT_TSCONFIG))) {
-		const syncResult = await spawn('npx', ['svelte-kit', 'sync']);
-		if (!syncResult.ok) {
-			throw new Error(`Failed to call 'svelte-kit sync'.`);
-		}
-	}
+export const sveltekitSync = async (): Promise<void> => {
+	unwrap(await spawn('npx', ['svelte-kit', 'sync']), 'failed svelte-kit sync');
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
 		"sourceMap": true,
 		"importHelpers": true,
 		"checkJs": true,
-		"skipLibCheck": true,
 		"preserveValueImports": true
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
 		"sourceMap": true,
 		"importHelpers": true,
 		"checkJs": true,
+		"skipLibCheck": true,
 		"preserveValueImports": true
 	}
 }


### PR DESCRIPTION
Also fixes building so we can turn `skipLibCheck` off in user projects.